### PR TITLE
Format all files with clang-format

### DIFF
--- a/src/include/xml_reader_functions.hpp
+++ b/src/include/xml_reader_functions.hpp
@@ -7,35 +7,37 @@ namespace duckdb {
 class XMLReaderFunctions {
 public:
 	static void Register(ExtensionLoader &loader);
-	
+
 	// Replacement scan function for direct file querying
 	static unique_ptr<TableRef> ReadXMLReplacement(ClientContext &context, ReplacementScanInput &input,
-	                                                optional_ptr<ReplacementScanData> data);
-	
+	                                               optional_ptr<ReplacementScanData> data);
+
 private:
 	// Table functions for reading XML files
 	static void ReadXMLObjectsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static unique_ptr<FunctionData> ReadXMLObjectsBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                     vector<LogicalType> &return_types, vector<string> &names);
-	static unique_ptr<GlobalTableFunctionState> ReadXMLObjectsInit(ClientContext &context, TableFunctionInitInput &input);
-	
+	                                                   vector<LogicalType> &return_types, vector<string> &names);
+	static unique_ptr<GlobalTableFunctionState> ReadXMLObjectsInit(ClientContext &context,
+	                                                               TableFunctionInitInput &input);
+
 	// Simplified read_xml function (without schema inference for now)
 	static void ReadXMLFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static unique_ptr<FunctionData> ReadXMLBind(ClientContext &context, TableFunctionBindInput &input,
-	                                             vector<LogicalType> &return_types, vector<string> &names);
+	                                            vector<LogicalType> &return_types, vector<string> &names);
 	static unique_ptr<GlobalTableFunctionState> ReadXMLInit(ClientContext &context, TableFunctionInitInput &input);
-	
+
 	// HTML reading functions
 	static void ReadHTMLFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static unique_ptr<FunctionData> ReadHTMLBind(ClientContext &context, TableFunctionBindInput &input,
-	                                              vector<LogicalType> &return_types, vector<string> &names);
+	                                             vector<LogicalType> &return_types, vector<string> &names);
 	static unique_ptr<GlobalTableFunctionState> ReadHTMLInit(ClientContext &context, TableFunctionInitInput &input);
-	
+
 	// HTML table extraction functions
 	static void HTMLExtractTablesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static unique_ptr<FunctionData> HTMLExtractTablesBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                        vector<LogicalType> &return_types, vector<string> &names);
-	static unique_ptr<GlobalTableFunctionState> HTMLExtractTablesInit(ClientContext &context, TableFunctionInitInput &input);
+	                                                      vector<LogicalType> &return_types, vector<string> &names);
+	static unique_ptr<GlobalTableFunctionState> HTMLExtractTablesInit(ClientContext &context,
+	                                                                  TableFunctionInitInput &input);
 };
 
 // Function data structures
@@ -43,7 +45,7 @@ struct XMLReadFunctionData : public TableFunctionData {
 	vector<string> files;
 	bool ignore_errors = false;
 	idx_t max_file_size = 16777216; // 16MB default
-	
+
 	// Explicit schema information (when columns parameter is provided)
 	bool has_explicit_schema = false;
 	vector<string> column_names;
@@ -53,7 +55,7 @@ struct XMLReadFunctionData : public TableFunctionData {
 struct XMLReadGlobalState : public GlobalTableFunctionState {
 	idx_t file_index = 0;
 	vector<string> files;
-	
+
 	idx_t MaxThreads() const override {
 		return 1; // Single-threaded for now
 	}
@@ -68,7 +70,7 @@ struct HTMLTableExtractionGlobalState : public GlobalTableFunctionState {
 	vector<vector<vector<string>>> all_tables; // [table][row][column]
 	idx_t current_table = 0;
 	idx_t current_row = 0;
-	
+
 	idx_t MaxThreads() const override {
 		return 1; // Single-threaded for now
 	}

--- a/src/include/xml_scalar_functions.hpp
+++ b/src/include/xml_scalar_functions.hpp
@@ -7,17 +7,17 @@ namespace duckdb {
 class XMLScalarFunctions {
 public:
 	static void Register(ExtensionLoader &loader);
-	
+
 private:
 	// Validation functions
 	static void XMLValidFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void XMLWellFormedFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void XMLValidateSchemaFunction(DataChunk &args, ExpressionState &state, Vector &result);
-	
+
 	// Text extraction functions
 	static void XMLExtractTextFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void XMLExtractAllTextFunction(DataChunk &args, ExpressionState &state, Vector &result);
-	
+
 	// Element extraction functions
 	static void XMLExtractElementsFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void XMLExtractElementsStringFunction(DataChunk &args, ExpressionState &state, Vector &result);
@@ -25,22 +25,23 @@ private:
 	static void XMLExtractAttributesFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void XMLExtractCommentsFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void XMLExtractCDataFunction(DataChunk &args, ExpressionState &state, Vector &result);
-	
+
 	// Content manipulation functions
 	static void XMLPrettyPrintFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void XMLMinifyFunction(DataChunk &args, ExpressionState &state, Vector &result);
-	
+
 	// Conversion functions
 	static void XMLToJSONFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void XMLToJSONWithSchemaFunction(DataChunk &args, ExpressionState &state, Vector &result);
-	static unique_ptr<FunctionData> XMLToJSONWithSchemaBind(ClientContext &context, ScalarFunction &bound_function, vector<unique_ptr<Expression>> &arguments);
+	static unique_ptr<FunctionData> XMLToJSONWithSchemaBind(ClientContext &context, ScalarFunction &bound_function,
+	                                                        vector<unique_ptr<Expression>> &arguments);
 	static void JSONToXMLFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void ValueToXMLFunction(DataChunk &args, ExpressionState &state, Vector &result);
-	
+
 	// Analysis functions
 	static void XMLStatsFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void XMLNamespacesFunction(DataChunk &args, ExpressionState &state, Vector &result);
-	
+
 	// HTML-specific extraction functions
 	static void HTMLExtractTextFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void HTMLExtractTextWithXPathFunction(DataChunk &args, ExpressionState &state, Vector &result);
@@ -48,7 +49,7 @@ private:
 	static void HTMLExtractImagesFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void HTMLExtractTableRowsFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void HTMLExtractTablesJSONFunction(DataChunk &args, ExpressionState &state, Vector &result);
-	
+
 	// HTML parsing functions
 	static void ParseHTMLFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void ReadHTMLFunction(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/include/xml_schema_inference.hpp
+++ b/src/include/xml_schema_inference.hpp
@@ -10,39 +10,39 @@ namespace duckdb {
 
 // 4-tier priority system for XML element classification
 enum class XMLTier {
-	HOMOGENEOUS_CONFORMING = 1,    // Can be mapped to clean DuckDB types (SCALAR, LIST, STRUCT with consistent structure)
-	HETEROGENEOUS_CONFORMING = 2,  // Inconsistent but extractable structure (STRUCT with mixed types, mixed arrays)
-	EXTRACTABLE_AS_FRAGMENT = 3,   // Can be unwrapped as XMLFragment (no parent attributes, content-focused)
-	FALLBACK_TO_XML = 4            // Must preserve full XML context (has parent attributes or complex nesting)
+	HOMOGENEOUS_CONFORMING = 1, // Can be mapped to clean DuckDB types (SCALAR, LIST, STRUCT with consistent structure)
+	HETEROGENEOUS_CONFORMING = 2, // Inconsistent but extractable structure (STRUCT with mixed types, mixed arrays)
+	EXTRACTABLE_AS_FRAGMENT = 3,  // Can be unwrapped as XMLFragment (no parent attributes, content-focused)
+	FALLBACK_TO_XML = 4           // Must preserve full XML context (has parent attributes or complex nesting)
 };
 
 // Configuration options for schema inference
 struct XMLSchemaOptions {
 	// Schema inference controls
-	std::string root_element;           // Extract only children of specified root (empty = auto-detect)
-	bool auto_detect = true;            // Automatic type detection
-	int32_t max_depth = -1;             // Maximum analysis depth (-1 = unlimited)
-	int32_t sample_size = 50;           // Number of elements to sample for inference
-	
+	std::string root_element; // Extract only children of specified root (empty = auto-detect)
+	bool auto_detect = true;  // Automatic type detection
+	int32_t max_depth = -1;   // Maximum analysis depth (-1 = unlimited)
+	int32_t sample_size = 50; // Number of elements to sample for inference
+
 	// Attribute handling
-	bool include_attributes = true;     // Include attributes as columns
-	std::string attribute_prefix = "";  // Prefix for attribute columns (e.g., 'attr_')
+	bool include_attributes = true;         // Include attributes as columns
+	std::string attribute_prefix = "";      // Prefix for attribute columns (e.g., 'attr_')
 	std::string attribute_mode = "columns"; // 'columns' | 'map' | 'discard'
-	
+
 	// Content handling
 	std::string text_content_column = "text_content"; // Column name for mixed text content
-	bool preserve_mixed_content = false; // Handle elements with both text and children
-	bool unnest_as_columns = true;      // True: flatten nested elements as columns, False: preserve as structs (future)
-	
+	bool preserve_mixed_content = false;              // Handle elements with both text and children
+	bool unnest_as_columns = true; // True: flatten nested elements as columns, False: preserve as structs (future)
+
 	// Type detection
-	bool temporal_detection = true;     // Detect DATE/TIME/TIMESTAMP
-	bool numeric_detection = true;      // Detect optimal numeric types
-	bool boolean_detection = true;      // Detect boolean values
-	
+	bool temporal_detection = true; // Detect DATE/TIME/TIMESTAMP
+	bool numeric_detection = true;  // Detect optimal numeric types
+	bool boolean_detection = true;  // Detect boolean values
+
 	// Collection handling
-	double array_threshold = 0.8;       // Minimum homogeneity for arrays (80%)
-	int32_t max_array_depth = 3;        // Maximum nested array depth
-	
+	double array_threshold = 0.8; // Minimum homogeneity for arrays (80%)
+	int32_t max_array_depth = 3;  // Maximum nested array depth
+
 	// Error handling
 	bool ignore_errors = false;         // Continue on parsing errors
 	idx_t maximum_file_size = 16777216; // 16MB default
@@ -50,53 +50,54 @@ struct XMLSchemaOptions {
 
 // Information about an inferred column
 struct XMLColumnInfo {
-	std::string name;                   // Column name
-	LogicalType type;                   // DuckDB type
-	bool is_attribute;                  // True if this comes from an XML attribute
-	std::string xpath;                  // XPath to extract this column
-	double confidence;                  // Schema inference confidence (0.0-1.0)
+	std::string name;                       // Column name
+	LogicalType type;                       // DuckDB type
+	bool is_attribute;                      // True if this comes from an XML attribute
+	std::string xpath;                      // XPath to extract this column
+	double confidence;                      // Schema inference confidence (0.0-1.0)
 	std::vector<std::string> sample_values; // Sample values used for type detection
-	
-	XMLColumnInfo(const std::string& name, LogicalType type, bool is_attribute = false, 
-	              const std::string& xpath = "", double confidence = 1.0)
-		: name(name), type(type), is_attribute(is_attribute), xpath(xpath), confidence(confidence) {}
+
+	XMLColumnInfo(const std::string &name, LogicalType type, bool is_attribute = false, const std::string &xpath = "",
+	              double confidence = 1.0)
+	    : name(name), type(type), is_attribute(is_attribute), xpath(xpath), confidence(confidence) {
+	}
 };
 
 // Statistics about element patterns
 struct ElementPattern {
-	std::string name;                   // Element name
-	int32_t occurrence_count = 0;       // How many times this element appears
-	std::vector<std::string> sample_values; // Sample text values
+	std::string name;                                          // Element name
+	int32_t occurrence_count = 0;                              // How many times this element appears
+	std::vector<std::string> sample_values;                    // Sample text values
 	std::unordered_map<std::string, int32_t> attribute_counts; // Attribute frequency
-	bool has_children = false;          // Has child elements
-	bool has_text = false;              // Has text content
-	
+	bool has_children = false;                                 // Has child elements
+	bool has_text = false;                                     // Has text content
+
 	// Enhanced nested structure tracking
-	std::unordered_map<std::string, int32_t> child_element_counts; // Child element frequency
+	std::unordered_map<std::string, int32_t> child_element_counts;              // Child element frequency
 	std::vector<std::unordered_map<std::string, std::string>> child_structures; // Sample child structures
-	bool appears_in_array = false;      // This element appears multiple times with same parent
+	bool appears_in_array = false;         // This element appears multiple times with same parent
 	bool has_homogeneous_structure = true; // All instances have same structure
-	
+
 	// Computed flags for 6-tier priority system
-	bool is_scalar = false;             // Only text content, no children
-	bool all_children_same_name = false; // All children have identical names
+	bool is_scalar = false;                   // Only text content, no children
+	bool all_children_same_name = false;      // All children have identical names
 	bool all_children_different_name = false; // All children have unique names (no repeats)
-	bool has_attributes = false;        // This node has attributes
-	bool children_have_attributes = false; // Any child has attributes
-	bool all_children_conforming = false; // All children can be consistently typed
-	
+	bool has_attributes = false;              // This node has attributes
+	bool children_have_attributes = false;    // Any child has attributes
+	bool all_children_conforming = false;     // All children can be consistently typed
+
 	double GetFrequency(int32_t total_samples) const {
 		return total_samples > 0 ? static_cast<double>(occurrence_count) / total_samples : 0.0;
 	}
-	
+
 	bool IsListCandidate() const {
 		return appears_in_array && has_homogeneous_structure;
 	}
-	
+
 	bool IsStructCandidate() const {
 		return has_children && !has_text && child_element_counts.size() > 0;
 	}
-	
+
 	// 4-tier priority system detection
 	XMLTier GetTier() const {
 		// Tier 1: Homogeneous conforming - can map to clean DuckDB types
@@ -112,19 +113,19 @@ struct ElementPattern {
 			// Consistent struct with predictable schema (STRUCT)
 			return XMLTier::HOMOGENEOUS_CONFORMING;
 		}
-		
+
 		// Tier 2: Heterogeneous conforming - extractable but inconsistent
 		if (has_children && all_children_conforming) {
 			// Mixed structure but children are individually conforming
 			return XMLTier::HETEROGENEOUS_CONFORMING;
 		}
-		
+
 		// Tier 3: Extractable as fragment - can unwrap without parent context
 		if (!has_attributes) {
 			// No parent attributes means we can safely unwrap content
 			return XMLTier::EXTRACTABLE_AS_FRAGMENT;
 		}
-		
+
 		// Tier 4: Fall back to XML - must preserve full context
 		return XMLTier::FALLBACK_TO_XML;
 	}
@@ -134,58 +135,57 @@ struct ElementPattern {
 class XMLSchemaInference {
 public:
 	// Main inference function
-	static std::vector<XMLColumnInfo> InferSchema(const std::string& xml_content, 
-	                                               const XMLSchemaOptions& options = XMLSchemaOptions{});
-	
+	static std::vector<XMLColumnInfo> InferSchema(const std::string &xml_content,
+	                                              const XMLSchemaOptions &options = XMLSchemaOptions {});
+
 	// Extract structured data according to inferred schema
-	static std::vector<std::vector<Value>> ExtractData(const std::string& xml_content,
-	                                                     const XMLSchemaOptions& options = XMLSchemaOptions{});
-	
+	static std::vector<std::vector<Value>> ExtractData(const std::string &xml_content,
+	                                                   const XMLSchemaOptions &options = XMLSchemaOptions {});
+
 	// Extract structured data according to explicit schema
-	static std::vector<std::vector<Value>> ExtractDataWithSchema(const std::string& xml_content,
-	                                                              const std::vector<std::string>& column_names,
-	                                                              const std::vector<LogicalType>& column_types,
-	                                                              const XMLSchemaOptions& options = XMLSchemaOptions{});
-	
+	static std::vector<std::vector<Value>> ExtractDataWithSchema(const std::string &xml_content,
+	                                                             const std::vector<std::string> &column_names,
+	                                                             const std::vector<LogicalType> &column_types,
+	                                                             const XMLSchemaOptions &options = XMLSchemaOptions {});
+
 	// Analyze document structure and detect patterns
-	static std::vector<ElementPattern> AnalyzeDocumentStructure(const std::string& xml_content,
-	                                                             const XMLSchemaOptions& options);
-	
+	static std::vector<ElementPattern> AnalyzeDocumentStructure(const std::string &xml_content,
+	                                                            const XMLSchemaOptions &options);
+
 	// Infer type from sample values
-	static LogicalType InferTypeFromSamples(const std::vector<std::string>& samples,
-	                                         const XMLSchemaOptions& options);
-	
+	static LogicalType InferTypeFromSamples(const std::vector<std::string> &samples, const XMLSchemaOptions &options);
+
 	// Detect nested structures (LIST and STRUCT types)
-	static LogicalType InferNestedType(const ElementPattern& pattern,
-	                                    const std::unordered_map<std::string, ElementPattern>& all_patterns,
-	                                    const XMLSchemaOptions& options);
-	
+	static LogicalType InferNestedType(const ElementPattern &pattern,
+	                                   const std::unordered_map<std::string, ElementPattern> &all_patterns,
+	                                   const XMLSchemaOptions &options);
+
 	// Type detection helpers
-	static bool IsBoolean(const std::string& value);
-	static bool IsInteger(const std::string& value);
-	static bool IsDouble(const std::string& value);
-	static bool IsDate(const std::string& value);
-	static bool IsTime(const std::string& value);
-	static bool IsTimestamp(const std::string& value);
-	
+	static bool IsBoolean(const std::string &value);
+	static bool IsInteger(const std::string &value);
+	static bool IsDouble(const std::string &value);
+	static bool IsDate(const std::string &value);
+	static bool IsTime(const std::string &value);
+	static bool IsTimestamp(const std::string &value);
+
 private:
 	// Internal helper functions
-	static void AnalyzeElement(xmlNodePtr node, std::unordered_map<std::string, ElementPattern>& patterns,
-	                           const XMLSchemaOptions& options, int32_t current_depth = 0);
-	
-	static std::string GetElementXPath(const std::string& element_name, bool is_attribute = false,
-	                                   const std::string& attribute_name = "");
-	
-	static LogicalType GetMostSpecificType(const std::vector<LogicalType>& types);
-	
-	static std::string CleanTextContent(const std::string& text);
-	
-	static Value ConvertToValue(const std::string& text, const LogicalType& target_type);
-	
+	static void AnalyzeElement(xmlNodePtr node, std::unordered_map<std::string, ElementPattern> &patterns,
+	                           const XMLSchemaOptions &options, int32_t current_depth = 0);
+
+	static std::string GetElementXPath(const std::string &element_name, bool is_attribute = false,
+	                                   const std::string &attribute_name = "");
+
+	static LogicalType GetMostSpecificType(const std::vector<LogicalType> &types);
+
+	static std::string CleanTextContent(const std::string &text);
+
+	static Value ConvertToValue(const std::string &text, const LogicalType &target_type);
+
 	// Recursive extraction helpers for complex types
-	static Value ExtractValueFromNode(xmlNodePtr node, const LogicalType& target_type);
-	static Value ExtractStructFromNode(xmlNodePtr node, const LogicalType& struct_type);
-	static Value ExtractListFromNode(xmlNodePtr node, const LogicalType& list_type);
+	static Value ExtractValueFromNode(xmlNodePtr node, const LogicalType &target_type);
+	static Value ExtractStructFromNode(xmlNodePtr node, const LogicalType &struct_type);
+	static Value ExtractListFromNode(xmlNodePtr node, const LogicalType &list_type);
 	static Value ExtractXMLArrayFromNode(xmlNodePtr node);
 };
 

--- a/src/include/xml_types.hpp
+++ b/src/include/xml_types.hpp
@@ -10,12 +10,12 @@ public:
 	static LogicalType XMLFragmentType();
 	static LogicalType XMLArrayType();
 	static LogicalType HTMLType();
-	static bool IsXMLType(const LogicalType& type);
-	static bool IsXMLFragmentType(const LogicalType& type);
-	static bool IsXMLArrayType(const LogicalType& type);
-	static bool IsHTMLType(const LogicalType& type);
+	static bool IsXMLType(const LogicalType &type);
+	static bool IsXMLFragmentType(const LogicalType &type);
+	static bool IsXMLArrayType(const LogicalType &type);
+	static bool IsHTMLType(const LogicalType &type);
 	static void Register(ExtensionLoader &loader);
-	
+
 private:
 	static bool XMLToVarcharCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters);
 	static bool VarcharToXMLCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters);

--- a/src/include/xml_utils.hpp
+++ b/src/include/xml_utils.hpp
@@ -11,30 +11,29 @@ namespace duckdb {
 
 // Schema options for XML to JSON conversion
 struct XMLToJSONOptions {
-	std::vector<std::string> force_list;    // Element names to always convert to arrays
-	std::string attr_prefix = "@";          // Prefix for attributes (default "@")
-	std::string text_key = "#text";         // Key for text content (default "#text")
-	std::string namespaces = "strip";       // Namespace handling: "strip", "expand", "keep" (default "strip")
-	std::string xmlns_key = "";             // Key for namespace declarations (default "", empty means disabled)
-	std::string empty_elements = "object";  // How to handle empty elements: "object", "null", "string"
+	std::vector<std::string> force_list;   // Element names to always convert to arrays
+	std::string attr_prefix = "@";         // Prefix for attributes (default "@")
+	std::string text_key = "#text";        // Key for text content (default "#text")
+	std::string namespaces = "strip";      // Namespace handling: "strip", "expand", "keep" (default "strip")
+	std::string xmlns_key = "";            // Key for namespace declarations (default "", empty means disabled)
+	std::string empty_elements = "object"; // How to handle empty elements: "object", "null", "string"
 };
 
 // Function bind data for XML to JSON with schema
 struct XMLToJSONBindData : public FunctionData {
 	XMLToJSONOptions options;
-	
-	explicit XMLToJSONBindData(XMLToJSONOptions opts) : options(std::move(opts)) {}
-	
+
+	explicit XMLToJSONBindData(XMLToJSONOptions opts) : options(std::move(opts)) {
+	}
+
 	unique_ptr<FunctionData> Copy() const override {
 		return make_uniq<XMLToJSONBindData>(options);
 	}
-	
+
 	bool Equals(const FunctionData &other_p) const override {
 		auto &other = other_p.Cast<XMLToJSONBindData>();
-		return options.force_list == other.options.force_list &&
-		       options.attr_prefix == other.options.attr_prefix &&
-		       options.text_key == other.options.text_key &&
-		       options.namespaces == other.options.namespaces &&
+		return options.force_list == other.options.force_list && options.attr_prefix == other.options.attr_prefix &&
+		       options.text_key == other.options.text_key && options.namespaces == other.options.namespaces &&
 		       options.empty_elements == other.options.empty_elements;
 	}
 };
@@ -43,50 +42,57 @@ struct XMLToJSONBindData : public FunctionData {
 struct XMLDocRAII {
 	xmlDocPtr doc = nullptr;
 	xmlXPathContextPtr xpath_ctx = nullptr;
-	
-	XMLDocRAII(const std::string& xml_str);
-	XMLDocRAII(const std::string& content, bool is_html);
+
+	XMLDocRAII(const std::string &xml_str);
+	XMLDocRAII(const std::string &content, bool is_html);
 	~XMLDocRAII();
-	
+
 	// Delete copy operations for safety
-	XMLDocRAII(const XMLDocRAII&) = delete;
-	XMLDocRAII& operator=(const XMLDocRAII&) = delete;
-	
+	XMLDocRAII(const XMLDocRAII &) = delete;
+	XMLDocRAII &operator=(const XMLDocRAII &) = delete;
+
 	// Move operations
-	XMLDocRAII(XMLDocRAII&& other) noexcept;
-	XMLDocRAII& operator=(XMLDocRAII&& other) noexcept;
-	
-	bool IsValid() const { return doc != nullptr; }
+	XMLDocRAII(XMLDocRAII &&other) noexcept;
+	XMLDocRAII &operator=(XMLDocRAII &&other) noexcept;
+
+	bool IsValid() const {
+		return doc != nullptr;
+	}
 };
 
 // Custom deleters for libxml2 resources to use with DuckDB's smart pointers
 struct XMLSchemaParserDeleter {
 	void operator()(xmlSchemaParserCtxtPtr ptr) const {
-		if (ptr) xmlSchemaFreeParserCtxt(ptr);
+		if (ptr)
+			xmlSchemaFreeParserCtxt(ptr);
 	}
 };
 
 struct XMLSchemaDeleter {
 	void operator()(xmlSchemaPtr ptr) const {
-		if (ptr) xmlSchemaFree(ptr);
+		if (ptr)
+			xmlSchemaFree(ptr);
 	}
 };
 
 struct XMLSchemaValidDeleter {
 	void operator()(xmlSchemaValidCtxtPtr ptr) const {
-		if (ptr) xmlSchemaFreeValidCtxt(ptr);
+		if (ptr)
+			xmlSchemaFreeValidCtxt(ptr);
 	}
 };
 
 struct XMLCharDeleter {
-	void operator()(xmlChar* ptr) const {
-		if (ptr) xmlFree(ptr);
+	void operator()(xmlChar *ptr) const {
+		if (ptr)
+			xmlFree(ptr);
 	}
 };
 
 struct XMLDocDeleter {
 	void operator()(xmlDocPtr ptr) const {
-		if (ptr) xmlFreeDoc(ptr);
+		if (ptr)
+			xmlFreeDoc(ptr);
 	}
 };
 
@@ -157,48 +163,49 @@ struct HTMLTable {
 class XMLUtils {
 public:
 	// Validation functions
-	static bool IsValidXML(const std::string& xml_str);
-	static bool IsWellFormedXML(const std::string& xml_str);
-	static bool ValidateXMLSchema(const std::string& xml_str, const std::string& xsd_schema);
-	
+	static bool IsValidXML(const std::string &xml_str);
+	static bool IsWellFormedXML(const std::string &xml_str);
+	static bool ValidateXMLSchema(const std::string &xml_str, const std::string &xsd_schema);
+
 	// Extraction functions
-	static std::vector<XMLElement> ExtractByXPath(const std::string& xml_str, const std::string& xpath);
-	static std::string ExtractTextByXPath(const std::string& xml_str, const std::string& xpath);
-	static std::vector<XMLComment> ExtractComments(const std::string& xml_str);
-	static std::vector<XMLComment> ExtractCData(const std::string& xml_str);
-	static std::vector<XMLNamespace> ExtractNamespaces(const std::string& xml_str);
-	
+	static std::vector<XMLElement> ExtractByXPath(const std::string &xml_str, const std::string &xpath);
+	static std::string ExtractTextByXPath(const std::string &xml_str, const std::string &xpath);
+	static std::vector<XMLComment> ExtractComments(const std::string &xml_str);
+	static std::vector<XMLComment> ExtractCData(const std::string &xml_str);
+	static std::vector<XMLNamespace> ExtractNamespaces(const std::string &xml_str);
+
 	// Content manipulation
-	static std::string PrettyPrintXML(const std::string& xml_str);
-	static std::string MinifyXML(const std::string& xml_str);
-	
+	static std::string PrettyPrintXML(const std::string &xml_str);
+	static std::string MinifyXML(const std::string &xml_str);
+
 	// Analysis functions
-	static XMLStats GetXMLStats(const std::string& xml_str);
-	
+	static XMLStats GetXMLStats(const std::string &xml_str);
+
 	// Conversion functions
-	static std::string XMLToJSON(const std::string& xml_str);
-	static std::string XMLToJSON(const std::string& xml_str, const XMLToJSONOptions& options);
-	static std::string JSONToXML(const std::string& json_str);
-	static std::string ScalarToXML(const std::string& value, const std::string& node_name);
-	
+	static std::string XMLToJSON(const std::string &xml_str);
+	static std::string XMLToJSON(const std::string &xml_str, const XMLToJSONOptions &options);
+	static std::string JSONToXML(const std::string &json_str);
+	static std::string ScalarToXML(const std::string &value, const std::string &node_name);
+
 	// XMLFragment extraction
-	static std::string ExtractXMLFragment(const std::string& xml_str, const std::string& xpath);
-	static std::string ExtractXMLFragmentAll(const std::string& xml_str, const std::string& xpath);
-	
+	static std::string ExtractXMLFragment(const std::string &xml_str, const std::string &xpath);
+	static std::string ExtractXMLFragmentAll(const std::string &xml_str, const std::string &xpath);
+
 	// Complex type conversion functions for to_xml()
-	static void ConvertListToXML(Vector &input_vector, Vector &result, idx_t count, const std::string& node_name);
-	static void ConvertStructToXML(Vector &input_vector, Vector &result, idx_t count, const std::string& node_name);
-	
+	static void ConvertListToXML(Vector &input_vector, Vector &result, idx_t count, const std::string &node_name);
+	static void ConvertStructToXML(Vector &input_vector, Vector &result, idx_t count, const std::string &node_name);
+
 	// Recursive value conversion for nested types - returns xmlNodePtr for direct attachment
-	static xmlNodePtr ConvertValueToXMLNode(const Value& value, const LogicalType& type, const std::string& node_name, xmlDocPtr doc);
-	
+	static xmlNodePtr ConvertValueToXMLNode(const Value &value, const LogicalType &type, const std::string &node_name,
+	                                        xmlDocPtr doc);
+
 	// HTML-specific extraction functions
-	static std::vector<HTMLLink> ExtractHTMLLinks(const std::string& html_str);
-	static std::vector<HTMLImage> ExtractHTMLImages(const std::string& html_str);
-	static std::vector<HTMLTable> ExtractHTMLTables(const std::string& html_str);
-	static std::string ExtractHTMLText(const std::string& html_str, const std::string& selector = "");
-	static std::string ExtractHTMLTextByXPath(const std::string& html_str, const std::string& xpath);
-	
+	static std::vector<HTMLLink> ExtractHTMLLinks(const std::string &html_str);
+	static std::vector<HTMLImage> ExtractHTMLImages(const std::string &html_str);
+	static std::vector<HTMLTable> ExtractHTMLTables(const std::string &html_str);
+	static std::string ExtractHTMLText(const std::string &html_str, const std::string &selector = "");
+	static std::string ExtractHTMLTextByXPath(const std::string &html_str, const std::string &xpath);
+
 	// Internal helper functions
 	static XMLElement ProcessXMLNode(xmlNodePtr node);
 	static std::string GetNodePath(xmlNodePtr node);

--- a/src/webbed_extension.cpp
+++ b/src/webbed_extension.cpp
@@ -12,27 +12,27 @@
 namespace duckdb {
 
 static void LoadInternal(ExtensionLoader &loader) {
-    // JSON extension is automatically available as a dependency
-    
-    // Initialize libxml2
-    XMLUtils::InitializeLibXML();
-    
-    // Register XML types (includes JSON to XML casting)
-    XMLTypes::Register(loader);
-    
-    // Register scalar functions
-    XMLScalarFunctions::Register(loader);
-    
-    // Register table functions
-    XMLReaderFunctions::Register(loader);
-    
-    // Register replacement scan for direct file querying (FROM 'file.xml')
-    auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
-    config.replacement_scans.emplace_back(XMLReaderFunctions::ReadXMLReplacement);
+	// JSON extension is automatically available as a dependency
+
+	// Initialize libxml2
+	XMLUtils::InitializeLibXML();
+
+	// Register XML types (includes JSON to XML casting)
+	XMLTypes::Register(loader);
+
+	// Register scalar functions
+	XMLScalarFunctions::Register(loader);
+
+	// Register table functions
+	XMLReaderFunctions::Register(loader);
+
+	// Register replacement scan for direct file querying (FROM 'file.xml')
+	auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
+	config.replacement_scans.emplace_back(XMLReaderFunctions::ReadXMLReplacement);
 }
 
 void WebbedExtension::Load(ExtensionLoader &loader) {
-    LoadInternal(loader);
+	LoadInternal(loader);
 }
 
 // Add cleanup when extension is unloaded
@@ -57,7 +57,7 @@ std::string WebbedExtension::Version() const {
 extern "C" {
 
 DUCKDB_CPP_EXTENSION_ENTRY(webbed, loader) {
-    duckdb::LoadInternal(loader);
+	duckdb::LoadInternal(loader);
 }
 
 DUCKDB_EXTENSION_API const char *webbed_version() {

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -9,7 +9,7 @@ namespace duckdb {
 
 void XMLScalarFunctions::XMLValidFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
-	
+
 	UnaryExecutor::Execute<string_t, bool>(xml_vector, result, args.size(), [&](string_t xml_str) {
 		std::string xml_string = xml_str.GetString();
 		return XMLUtils::IsValidXML(xml_string);
@@ -18,7 +18,7 @@ void XMLScalarFunctions::XMLValidFunction(DataChunk &args, ExpressionState &stat
 
 void XMLScalarFunctions::XMLWellFormedFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
-	
+
 	UnaryExecutor::Execute<string_t, bool>(xml_vector, result, args.size(), [&](string_t xml_str) {
 		std::string xml_string = xml_str.GetString();
 		return XMLUtils::IsWellFormedXML(xml_string);
@@ -28,20 +28,19 @@ void XMLScalarFunctions::XMLWellFormedFunction(DataChunk &args, ExpressionState 
 void XMLScalarFunctions::XMLExtractTextFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
 	auto &xpath_vector = args.data[1];
-	
+
 	BinaryExecutor::Execute<string_t, string_t, string_t>(
-		xml_vector, xpath_vector, result, args.size(),
-		[&](string_t xml_str, string_t xpath_str) {
-			std::string xml_string = xml_str.GetString();
-			std::string xpath_string = xpath_str.GetString();
-			std::string extracted_text = XMLUtils::ExtractTextByXPath(xml_string, xpath_string);
-			return StringVector::AddString(result, extracted_text);
-		});
+	    xml_vector, xpath_vector, result, args.size(), [&](string_t xml_str, string_t xpath_str) {
+		    std::string xml_string = xml_str.GetString();
+		    std::string xpath_string = xpath_str.GetString();
+		    std::string extracted_text = XMLUtils::ExtractTextByXPath(xml_string, xpath_string);
+		    return StringVector::AddString(result, extracted_text);
+	    });
 }
 
 void XMLScalarFunctions::XMLExtractAllTextFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
-	
+
 	UnaryExecutor::Execute<string_t, string_t>(xml_vector, result, args.size(), [&](string_t xml_str) {
 		std::string xml_string = xml_str.GetString();
 		// Extract all text content by getting all text nodes and concatenating them
@@ -57,74 +56,71 @@ void XMLScalarFunctions::XMLExtractAllTextFunction(DataChunk &args, ExpressionSt
 void XMLScalarFunctions::XMLExtractElementsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
 	auto &xpath_vector = args.data[1];
-	
+
 	BinaryExecutor::Execute<string_t, string_t, string_t>(
-		xml_vector, xpath_vector, result, args.size(),
-		[&](string_t xml_str, string_t xpath_str) {
-			std::string xml_string = xml_str.GetString();
-			std::string xpath_string = xpath_str.GetString();
-			
-			// Extract XML fragment using our new utility function
-			std::string fragment_xml = XMLUtils::ExtractXMLFragment(xml_string, xpath_string);
-			
-			return StringVector::AddString(result, fragment_xml);
-		});
+	    xml_vector, xpath_vector, result, args.size(), [&](string_t xml_str, string_t xpath_str) {
+		    std::string xml_string = xml_str.GetString();
+		    std::string xpath_string = xpath_str.GetString();
+
+		    // Extract XML fragment using our new utility function
+		    std::string fragment_xml = XMLUtils::ExtractXMLFragment(xml_string, xpath_string);
+
+		    return StringVector::AddString(result, fragment_xml);
+	    });
 }
 
 void XMLScalarFunctions::XMLExtractElementsStringFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
 	auto &xpath_vector = args.data[1];
-	
+
 	BinaryExecutor::Execute<string_t, string_t, string_t>(
-		xml_vector, xpath_vector, result, args.size(),
-		[&](string_t xml_str, string_t xpath_str) {
-			std::string xml_string = xml_str.GetString();
-			std::string xpath_string = xpath_str.GetString();
-			
-			// Extract ALL XML fragments separated by newlines
-			std::string fragment_xml = XMLUtils::ExtractXMLFragmentAll(xml_string, xpath_string);
-			
-			return StringVector::AddString(result, fragment_xml);
-		});
+	    xml_vector, xpath_vector, result, args.size(), [&](string_t xml_str, string_t xpath_str) {
+		    std::string xml_string = xml_str.GetString();
+		    std::string xpath_string = xpath_str.GetString();
+
+		    // Extract ALL XML fragments separated by newlines
+		    std::string fragment_xml = XMLUtils::ExtractXMLFragmentAll(xml_string, xpath_string);
+
+		    return StringVector::AddString(result, fragment_xml);
+	    });
 }
 
 void XMLScalarFunctions::XMLWrapFragmentFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &fragment_vector = args.data[0];
 	auto &wrapper_vector = args.data[1];
-	
+
 	BinaryExecutor::Execute<string_t, string_t, string_t>(
-		fragment_vector, wrapper_vector, result, args.size(),
-		[&](string_t fragment_str, string_t wrapper_str) {
-			std::string fragment = fragment_str.GetString();
-			std::string wrapper = wrapper_str.GetString();
-			
-			// Create wrapped XML: <wrapper>fragment</wrapper>
-			std::string wrapped_xml = "<" + wrapper + ">" + fragment + "</" + wrapper + ">";
-			
-			return StringVector::AddString(result, wrapped_xml);
-		});
+	    fragment_vector, wrapper_vector, result, args.size(), [&](string_t fragment_str, string_t wrapper_str) {
+		    std::string fragment = fragment_str.GetString();
+		    std::string wrapper = wrapper_str.GetString();
+
+		    // Create wrapped XML: <wrapper>fragment</wrapper>
+		    std::string wrapped_xml = "<" + wrapper + ">" + fragment + "</" + wrapper + ">";
+
+		    return StringVector::AddString(result, wrapped_xml);
+	    });
 }
 
 void XMLScalarFunctions::XMLExtractAttributesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
 	auto &xpath_vector = args.data[1];
 	auto count = args.size();
-	
+
 	// Extract attributes from elements matching XPath expression
 	for (idx_t i = 0; i < count; i++) {
 		// Get input values
 		auto xml_str = FlatVector::GetData<string_t>(xml_vector)[i];
 		auto xpath_str = FlatVector::GetData<string_t>(xpath_vector)[i];
-		
+
 		std::string xml_string = xml_str.GetString();
 		std::string xpath_string = xpath_str.GetString();
-		
+
 		// Extract elements and their attributes using XPath
 		auto elements = XMLUtils::ExtractByXPath(xml_string, xpath_string);
-		
+
 		// Create list of attribute structs
 		vector<Value> attr_values;
-		
+
 		for (const auto &elem : elements) {
 			// For each element, extract its attributes
 			for (const auto &attr_pair : elem.attributes) {
@@ -134,22 +130,19 @@ void XMLScalarFunctions::XMLExtractAttributesFunction(DataChunk &args, Expressio
 				attr_children.emplace_back("attribute_name", Value(attr_pair.first));
 				attr_children.emplace_back("attribute_value", Value(attr_pair.second));
 				attr_children.emplace_back("line_number", Value::BIGINT(elem.line_number));
-				
+
 				attr_values.emplace_back(Value::STRUCT(attr_children));
 			}
 		}
-		
+
 		// Create list value
-		auto attr_struct_type = LogicalType::STRUCT({
-			make_pair("element_name", LogicalType::VARCHAR),
-			make_pair("element_path", LogicalType::VARCHAR),
-			make_pair("attribute_name", LogicalType::VARCHAR),
-			make_pair("attribute_value", LogicalType::VARCHAR),
-			make_pair("line_number", LogicalType::BIGINT)
-		});
-		
+		auto attr_struct_type = LogicalType::STRUCT(
+		    {make_pair("element_name", LogicalType::VARCHAR), make_pair("element_path", LogicalType::VARCHAR),
+		     make_pair("attribute_name", LogicalType::VARCHAR), make_pair("attribute_value", LogicalType::VARCHAR),
+		     make_pair("line_number", LogicalType::BIGINT)});
+
 		Value list_value = Value::LIST(attr_struct_type, attr_values);
-		
+
 		// Set result
 		result.SetValue(i, list_value);
 	}
@@ -157,7 +150,7 @@ void XMLScalarFunctions::XMLExtractAttributesFunction(DataChunk &args, Expressio
 
 void XMLScalarFunctions::XMLPrettyPrintFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
-	
+
 	UnaryExecutor::Execute<string_t, string_t>(xml_vector, result, args.size(), [&](string_t xml_str) {
 		std::string xml_string = xml_str.GetString();
 		std::string formatted = XMLUtils::PrettyPrintXML(xml_string);
@@ -167,7 +160,7 @@ void XMLScalarFunctions::XMLPrettyPrintFunction(DataChunk &args, ExpressionState
 
 void XMLScalarFunctions::XMLMinifyFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
-	
+
 	UnaryExecutor::Execute<string_t, string_t>(xml_vector, result, args.size(), [&](string_t xml_str) {
 		std::string xml_string = xml_str.GetString();
 		std::string minified = XMLUtils::MinifyXML(xml_string);
@@ -178,43 +171,40 @@ void XMLScalarFunctions::XMLMinifyFunction(DataChunk &args, ExpressionState &sta
 void XMLScalarFunctions::XMLValidateSchemaFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
 	auto &schema_vector = args.data[1];
-	
-	BinaryExecutor::Execute<string_t, string_t, bool>(
-		xml_vector, schema_vector, result, args.size(),
-		[&](string_t xml_str, string_t schema_str) {
-			std::string xml_string = xml_str.GetString();
-			std::string schema_string = schema_str.GetString();
-			return XMLUtils::ValidateXMLSchema(xml_string, schema_string);
-		});
+
+	BinaryExecutor::Execute<string_t, string_t, bool>(xml_vector, schema_vector, result, args.size(),
+	                                                  [&](string_t xml_str, string_t schema_str) {
+		                                                  std::string xml_string = xml_str.GetString();
+		                                                  std::string schema_string = schema_str.GetString();
+		                                                  return XMLUtils::ValidateXMLSchema(xml_string, schema_string);
+	                                                  });
 }
 
 void XMLScalarFunctions::XMLExtractCommentsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
 	auto count = args.size();
-	
+
 	for (idx_t i = 0; i < count; i++) {
 		auto xml_str = FlatVector::GetData<string_t>(xml_vector)[i];
 		std::string xml_string = xml_str.GetString();
-		
+
 		auto comments = XMLUtils::ExtractComments(xml_string);
-		
+
 		// Create list of comment structs
 		vector<Value> comment_values;
-		
+
 		for (const auto &comment : comments) {
 			child_list_t<Value> comment_children;
 			comment_children.emplace_back("content", Value(comment.content));
 			comment_children.emplace_back("line_number", Value::BIGINT(comment.line_number));
-			
+
 			comment_values.emplace_back(Value::STRUCT(comment_children));
 		}
-		
+
 		// Create list value
-		auto comment_struct_type = LogicalType::STRUCT({
-			make_pair("content", LogicalType::VARCHAR),
-			make_pair("line_number", LogicalType::BIGINT)
-		});
-		
+		auto comment_struct_type = LogicalType::STRUCT(
+		    {make_pair("content", LogicalType::VARCHAR), make_pair("line_number", LogicalType::BIGINT)});
+
 		Value list_value = Value::LIST(comment_struct_type, comment_values);
 		result.SetValue(i, list_value);
 	}
@@ -223,30 +213,28 @@ void XMLScalarFunctions::XMLExtractCommentsFunction(DataChunk &args, ExpressionS
 void XMLScalarFunctions::XMLExtractCDataFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
 	auto count = args.size();
-	
+
 	for (idx_t i = 0; i < count; i++) {
 		auto xml_str = FlatVector::GetData<string_t>(xml_vector)[i];
 		std::string xml_string = xml_str.GetString();
-		
+
 		auto cdata_sections = XMLUtils::ExtractCData(xml_string);
-		
+
 		// Create list of CDATA structs
 		vector<Value> cdata_values;
-		
+
 		for (const auto &cdata : cdata_sections) {
 			child_list_t<Value> cdata_children;
 			cdata_children.emplace_back("content", Value(cdata.content));
 			cdata_children.emplace_back("line_number", Value::BIGINT(cdata.line_number));
-			
+
 			cdata_values.emplace_back(Value::STRUCT(cdata_children));
 		}
-		
+
 		// Create list value
-		auto cdata_struct_type = LogicalType::STRUCT({
-			make_pair("content", LogicalType::VARCHAR),
-			make_pair("line_number", LogicalType::BIGINT)
-		});
-		
+		auto cdata_struct_type = LogicalType::STRUCT(
+		    {make_pair("content", LogicalType::VARCHAR), make_pair("line_number", LogicalType::BIGINT)});
+
 		Value list_value = Value::LIST(cdata_struct_type, cdata_values);
 		result.SetValue(i, list_value);
 	}
@@ -255,13 +243,13 @@ void XMLScalarFunctions::XMLExtractCDataFunction(DataChunk &args, ExpressionStat
 void XMLScalarFunctions::XMLStatsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
 	auto count = args.size();
-	
+
 	for (idx_t i = 0; i < count; i++) {
 		auto xml_str = FlatVector::GetData<string_t>(xml_vector)[i];
 		std::string xml_string = xml_str.GetString();
-		
+
 		auto stats = XMLUtils::GetXMLStats(xml_string);
-		
+
 		// Create stats struct
 		child_list_t<Value> stats_children;
 		stats_children.emplace_back("element_count", Value::BIGINT(stats.element_count));
@@ -269,7 +257,7 @@ void XMLScalarFunctions::XMLStatsFunction(DataChunk &args, ExpressionState &stat
 		stats_children.emplace_back("max_depth", Value::BIGINT(stats.max_depth));
 		stats_children.emplace_back("size_bytes", Value::BIGINT(stats.size_bytes));
 		stats_children.emplace_back("namespace_count", Value::BIGINT(stats.namespace_count));
-		
+
 		Value stats_value = Value::STRUCT(stats_children);
 		result.SetValue(i, stats_value);
 	}
@@ -278,30 +266,28 @@ void XMLScalarFunctions::XMLStatsFunction(DataChunk &args, ExpressionState &stat
 void XMLScalarFunctions::XMLNamespacesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
 	auto count = args.size();
-	
+
 	for (idx_t i = 0; i < count; i++) {
 		auto xml_str = FlatVector::GetData<string_t>(xml_vector)[i];
 		std::string xml_string = xml_str.GetString();
-		
+
 		auto namespaces = XMLUtils::ExtractNamespaces(xml_string);
-		
+
 		// Create list of namespace structs
 		vector<Value> ns_values;
-		
+
 		for (const auto &ns : namespaces) {
 			child_list_t<Value> ns_children;
 			ns_children.emplace_back("prefix", Value(ns.prefix));
 			ns_children.emplace_back("uri", Value(ns.uri));
-			
+
 			ns_values.emplace_back(Value::STRUCT(ns_children));
 		}
-		
+
 		// Create list value
-		auto ns_struct_type = LogicalType::STRUCT({
-			make_pair("prefix", LogicalType::VARCHAR),
-			make_pair("uri", LogicalType::VARCHAR)
-		});
-		
+		auto ns_struct_type =
+		    LogicalType::STRUCT({make_pair("prefix", LogicalType::VARCHAR), make_pair("uri", LogicalType::VARCHAR)});
+
 		Value list_value = Value::LIST(ns_struct_type, ns_values);
 		result.SetValue(i, list_value);
 	}
@@ -309,7 +295,7 @@ void XMLScalarFunctions::XMLNamespacesFunction(DataChunk &args, ExpressionState 
 
 void XMLScalarFunctions::XMLToJSONFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
-	
+
 	UnaryExecutor::Execute<string_t, string_t>(xml_vector, result, args.size(), [&](string_t xml_str) {
 		std::string xml_string = xml_str.GetString();
 		std::string json_string = XMLUtils::XMLToJSON(xml_string);
@@ -317,11 +303,13 @@ void XMLScalarFunctions::XMLToJSONFunction(DataChunk &args, ExpressionState &sta
 	});
 }
 
-unique_ptr<FunctionData> XMLScalarFunctions::XMLToJSONWithSchemaBind(ClientContext &context, ScalarFunction &bound_function, vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> XMLScalarFunctions::XMLToJSONWithSchemaBind(ClientContext &context,
+                                                                     ScalarFunction &bound_function,
+                                                                     vector<unique_ptr<Expression>> &arguments) {
 	if (arguments.empty()) {
 		throw BinderException("xml_to_json requires at least one argument (the XML string)");
 	}
-	
+
 	XMLToJSONOptions options; // Start with defaults
 
 	// First argument is the XML string (positional)
@@ -331,11 +319,12 @@ unique_ptr<FunctionData> XMLScalarFunctions::XMLToJSONWithSchemaBind(ClientConte
 	for (idx_t i = 1; i < arguments.size(); i++) {
 		auto &arg = arguments[i];
 		std::string param_name = arg->GetAlias();
-		
+
 		if (param_name.empty()) {
-			throw BinderException("All arguments after the first must be named parameters (e.g., force_list := ['name'])");
+			throw BinderException(
+			    "All arguments after the first must be named parameters (e.g., force_list := ['name'])");
 		}
-		
+
 		// Check if the argument is foldable (constant)
 		if (arg->HasParameter()) {
 			throw ParameterNotResolvedException();
@@ -343,10 +332,10 @@ unique_ptr<FunctionData> XMLScalarFunctions::XMLToJSONWithSchemaBind(ClientConte
 		if (!arg->IsFoldable()) {
 			throw BinderException("Parameter '%s' must be a constant value", param_name);
 		}
-		
+
 		// Extract the constant value
 		Value param_value = ExpressionExecutor::EvaluateScalar(context, *arg);
-		
+
 		if (param_name == "force_list") {
 			if (param_value.IsNull()) {
 				options.force_list.clear(); // NULL means empty list
@@ -355,7 +344,8 @@ unique_ptr<FunctionData> XMLScalarFunctions::XMLToJSONWithSchemaBind(ClientConte
 			} else {
 				// Check child type only if list is not empty
 				auto &list_children = ListValue::GetChildren(param_value);
-				if (!list_children.empty() && ListType::GetChildType(param_value.type()).id() != LogicalTypeId::VARCHAR) {
+				if (!list_children.empty() &&
+				    ListType::GetChildType(param_value.type()).id() != LogicalTypeId::VARCHAR) {
 					throw BinderException("force_list parameter must be a list of strings, e.g., ['name', 'item']");
 				}
 				options.force_list.clear();
@@ -390,7 +380,9 @@ unique_ptr<FunctionData> XMLScalarFunctions::XMLToJSONWithSchemaBind(ClientConte
 			} else {
 				auto ns_val = StringValue::Get(param_value);
 				if (ns_val != "strip" && ns_val != "expand" && ns_val != "keep") {
-					throw BinderException("Invalid value for namespaces parameter: Must be one of: 'strip', 'expand', or 'keep', got '%s'", ns_val);
+					throw BinderException("Invalid value for namespaces parameter: Must be one of: 'strip', 'expand', "
+					                      "or 'keep', got '%s'",
+					                      ns_val);
 				}
 				options.namespaces = ns_val;
 			}
@@ -406,11 +398,14 @@ unique_ptr<FunctionData> XMLScalarFunctions::XMLToJSONWithSchemaBind(ClientConte
 			if (param_value.IsNull()) {
 				options.empty_elements = "object"; // Default
 			} else if (param_value.type().id() != LogicalTypeId::VARCHAR) {
-				throw BinderException("Invalid value for empty_elements: VARCHAR required, got '%s'", param_value.type().ToString());
+				throw BinderException("Invalid value for empty_elements: VARCHAR required, got '%s'",
+				                      param_value.type().ToString());
 			} else {
 				auto empty_val = StringValue::Get(param_value);
 				if (empty_val != "object" && empty_val != "null" && empty_val != "string") {
-					throw BinderException("Invalid value for empty_elements parameter: Must be one of: 'object', 'null', or 'string', got '%s'", empty_val);
+					throw BinderException("Invalid value for empty_elements parameter: Must be one of: 'object', "
+					                      "'null', or 'string', got '%s'",
+					                      empty_val);
 				}
 				options.empty_elements = empty_val;
 			}
@@ -418,7 +413,7 @@ unique_ptr<FunctionData> XMLScalarFunctions::XMLToJSONWithSchemaBind(ClientConte
 			throw BinderException("Unknown parameter '%s' for xml_to_json", param_name);
 		}
 	}
-	
+
 	return make_uniq<XMLToJSONBindData>(options);
 }
 
@@ -443,7 +438,7 @@ void XMLScalarFunctions::XMLToJSONWithSchemaFunction(DataChunk &args, Expression
 
 void XMLScalarFunctions::JSONToXMLFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &json_vector = args.data[0];
-	
+
 	UnaryExecutor::Execute<string_t, string_t>(json_vector, result, args.size(), [&](string_t json_str) {
 		std::string json_string = json_str.GetString();
 		std::string xml_string = XMLUtils::JSONToXML(json_string);
@@ -454,14 +449,14 @@ void XMLScalarFunctions::JSONToXMLFunction(DataChunk &args, ExpressionState &sta
 void XMLScalarFunctions::ValueToXMLFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &input_vector = args.data[0];
 	auto &input_type = input_vector.GetType();
-	
+
 	// Type debugging (can be removed in production)
-	// printf("DEBUG to_xml: input_type=%s, id=%d, has_alias=%s, alias=%s\n", 
-	//	input_type.ToString().c_str(), 
+	// printf("DEBUG to_xml: input_type=%s, id=%d, has_alias=%s, alias=%s\n",
+	//	input_type.ToString().c_str(),
 	//	(int)input_type.id(),
 	//	input_type.HasAlias() ? "true" : "false",
 	//	input_type.HasAlias() ? input_type.GetAlias().c_str() : "none");
-	
+
 	// Get node name (default "xml" if not provided)
 	std::string default_node_name = "xml";
 	if (args.ColumnCount() == 2) {
@@ -475,7 +470,7 @@ void XMLScalarFunctions::ValueToXMLFunction(DataChunk &args, ExpressionState &st
 			}
 		}
 	}
-	
+
 	// Apply our type hierarchy
 	if (XMLTypes::IsXMLFragmentType(input_type)) {
 		// XMLFragment → Insert verbatim
@@ -483,7 +478,7 @@ void XMLScalarFunctions::ValueToXMLFunction(DataChunk &args, ExpressionState &st
 			return StringVector::AddString(result, input.GetString());
 		});
 	} else if (XMLTypes::IsXMLType(input_type)) {
-		// XML → Insert verbatim  
+		// XML → Insert verbatim
 		UnaryExecutor::Execute<string_t, string_t>(input_vector, result, args.size(), [&](string_t input) {
 			return StringVector::AddString(result, input.GetString());
 		});
@@ -491,22 +486,21 @@ void XMLScalarFunctions::ValueToXMLFunction(DataChunk &args, ExpressionState &st
 		// LIST → Recursive conversion
 		XMLUtils::ConvertListToXML(input_vector, result, args.size(), default_node_name);
 	} else if (input_type.id() == LogicalTypeId::STRUCT) {
-		// STRUCT → Recursive conversion  
+		// STRUCT → Recursive conversion
 		XMLUtils::ConvertStructToXML(input_vector, result, args.size(), default_node_name);
 	} else {
 		// Check if this is an explicit JSON type (has JSON alias)
 		bool is_json_type = false;
-		
+
 		try {
 			// Only check for explicit JSON type (has JSON alias)
-			is_json_type = (input_type.id() == LogicalTypeId::VARCHAR && 
-							input_type.HasAlias() && 
-							input_type.GetAlias() == "JSON");
+			is_json_type =
+			    (input_type.id() == LogicalTypeId::VARCHAR && input_type.HasAlias() && input_type.GetAlias() == "JSON");
 		} catch (...) {
 			// Error in detection, treat as non-JSON
 			is_json_type = false;
 		}
-		
+
 		if (is_json_type) {
 			// JSON → Structural conversion (same as JSON::XML casting)
 			UnaryExecutor::Execute<string_t, string_t>(input_vector, result, args.size(), [&](string_t json_input) {
@@ -519,7 +513,7 @@ void XMLScalarFunctions::ValueToXMLFunction(DataChunk &args, ExpressionState &st
 			for (idx_t i = 0; i < args.size(); i++) {
 				Value input_value = input_vector.GetValue(i);
 				std::string input_str;
-				
+
 				if (input_value.IsNull()) {
 					input_str = "";
 				} else if (input_type.id() == LogicalTypeId::VARCHAR) {
@@ -528,7 +522,7 @@ void XMLScalarFunctions::ValueToXMLFunction(DataChunk &args, ExpressionState &st
 					// Convert any other type to string representation
 					input_str = input_value.ToString();
 				}
-				
+
 				// Check if input is already valid XML (only for string types)
 				if (input_type.id() == LogicalTypeId::VARCHAR && XMLUtils::IsValidXML(input_str)) {
 					result.SetValue(i, Value(input_str));
@@ -546,255 +540,287 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	// Register xml function (same as to_xml for now) - using VARCHAR for now, will enhance type system later
 	auto xml_function = ScalarFunction("xml", {LogicalType::VARCHAR}, LogicalType::VARCHAR, ValueToXMLFunction);
 	loader.RegisterFunction(xml_function);
-	
+
 	// Register to_xml function (single argument) - ANY type variant (unified path)
 	auto to_xml_any_function = ScalarFunction("to_xml", {LogicalType::ANY}, XMLTypes::XMLType(), ValueToXMLFunction);
 	loader.RegisterFunction(to_xml_any_function);
-	
+
 	// Register to_xml function (two arguments: value, node_name) - ANY type variant (unified path)
-	auto to_xml_any_with_name_function = ScalarFunction("to_xml", 
-		{LogicalType::ANY, LogicalType::VARCHAR}, XMLTypes::XMLType(), ValueToXMLFunction);
+	auto to_xml_any_with_name_function =
+	    ScalarFunction("to_xml", {LogicalType::ANY, LogicalType::VARCHAR}, XMLTypes::XMLType(), ValueToXMLFunction);
 	loader.RegisterFunction(to_xml_any_with_name_function);
-	
-	// Register xml_libxml2_version function 
-	auto xml_libxml2_version_function = ScalarFunction("xml_libxml2_version", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
-		[](DataChunk &args, ExpressionState &state, Vector &result) {
-			auto &name_vector = args.data[0];
-			UnaryExecutor::Execute<string_t, string_t>(name_vector, result, args.size(), [&](string_t name) {
-				return StringVector::AddString(result, "Xml " + name.GetString() + ", my linked libxml2 version is 2.13.8");
-			});
-		});
+
+	// Register xml_libxml2_version function
+	auto xml_libxml2_version_function = ScalarFunction(
+	    "xml_libxml2_version", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	    [](DataChunk &args, ExpressionState &state, Vector &result) {
+		    auto &name_vector = args.data[0];
+		    UnaryExecutor::Execute<string_t, string_t>(name_vector, result, args.size(), [&](string_t name) {
+			    return StringVector::AddString(result,
+			                                   "Xml " + name.GetString() + ", my linked libxml2 version is 2.13.8");
+		    });
+	    });
 	loader.RegisterFunction(xml_libxml2_version_function);
-	
+
 	// Register xml_valid function - both XML and VARCHAR overloads
-	auto xml_valid_function = ScalarFunction("xml_valid", {XMLTypes::XMLType()}, LogicalType::BOOLEAN, XMLValidFunction);
+	auto xml_valid_function =
+	    ScalarFunction("xml_valid", {XMLTypes::XMLType()}, LogicalType::BOOLEAN, XMLValidFunction);
 	loader.RegisterFunction(xml_valid_function);
-	auto xml_valid_varchar_function = ScalarFunction("xml_valid", {LogicalType::VARCHAR}, LogicalType::BOOLEAN, XMLValidFunction);
+	auto xml_valid_varchar_function =
+	    ScalarFunction("xml_valid", {LogicalType::VARCHAR}, LogicalType::BOOLEAN, XMLValidFunction);
 	loader.RegisterFunction(xml_valid_varchar_function);
-	
+
 	// Register xml_well_formed function - both XML and VARCHAR overloads
-	auto xml_well_formed_function = ScalarFunction("xml_well_formed", {XMLTypes::XMLType()}, LogicalType::BOOLEAN, XMLWellFormedFunction);
+	auto xml_well_formed_function =
+	    ScalarFunction("xml_well_formed", {XMLTypes::XMLType()}, LogicalType::BOOLEAN, XMLWellFormedFunction);
 	loader.RegisterFunction(xml_well_formed_function);
-	auto xml_well_formed_varchar_function = ScalarFunction("xml_well_formed", {LogicalType::VARCHAR}, LogicalType::BOOLEAN, XMLWellFormedFunction);
+	auto xml_well_formed_varchar_function =
+	    ScalarFunction("xml_well_formed", {LogicalType::VARCHAR}, LogicalType::BOOLEAN, XMLWellFormedFunction);
 	loader.RegisterFunction(xml_well_formed_varchar_function);
-	
+
 	// Register xml_extract_text function with multiple overloads to handle string literals
 	ScalarFunctionSet xml_extract_text_functions("xml_extract_text");
-	
+
 	// XML + VARCHAR
-	xml_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractTextFunction));
+	xml_extract_text_functions.AddFunction(
+	    ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractTextFunction));
 	// XML + STRING_LITERAL (for direct string literals)
-	xml_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)}, LogicalType::VARCHAR, XMLExtractTextFunction));
+	xml_extract_text_functions.AddFunction(
+	    ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)}, LogicalType::VARCHAR,
+	                   XMLExtractTextFunction));
 	// HTMLType + VARCHAR (use HTML-specific function)
-	xml_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR}, LogicalType::VARCHAR, HTMLExtractTextWithXPathFunction));
+	xml_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
+	                                                      LogicalType::VARCHAR, HTMLExtractTextWithXPathFunction));
 	// HTMLType + STRING_LITERAL (use HTML-specific function)
-	xml_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)}, LogicalType::VARCHAR, HTMLExtractTextWithXPathFunction));
+	xml_extract_text_functions.AddFunction(
+	    ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)}, LogicalType::VARCHAR,
+	                   HTMLExtractTextWithXPathFunction));
 	// XMLFragment + VARCHAR (for results from xml_extract_elements)
-	xml_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractTextFunction));
+	xml_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR},
+	                                                      LogicalType::VARCHAR, XMLExtractTextFunction));
 	// XMLFragment + STRING_LITERAL
-	xml_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)}, LogicalType::VARCHAR, XMLExtractTextFunction));
+	xml_extract_text_functions.AddFunction(
+	    ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)}, LogicalType::VARCHAR,
+	                   XMLExtractTextFunction));
 	// VARCHAR + VARCHAR (compatibility)
-	xml_extract_text_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractTextFunction));
+	xml_extract_text_functions.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractTextFunction));
 	// VARCHAR + STRING_LITERAL (compatibility)
-	xml_extract_text_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)}, LogicalType::VARCHAR, XMLExtractTextFunction));
-	
+	xml_extract_text_functions.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)}, LogicalType::VARCHAR,
+	                   XMLExtractTextFunction));
+
 	loader.RegisterFunction(xml_extract_text_functions);
-	
+
 	// Register xml_extract_all_text function - both XML and VARCHAR overloads
-	auto xml_extract_all_text_function = ScalarFunction("xml_extract_all_text", 
-		{XMLTypes::XMLType()}, LogicalType::VARCHAR, XMLExtractAllTextFunction);
+	auto xml_extract_all_text_function =
+	    ScalarFunction("xml_extract_all_text", {XMLTypes::XMLType()}, LogicalType::VARCHAR, XMLExtractAllTextFunction);
 	loader.RegisterFunction(xml_extract_all_text_function);
-	auto xml_extract_all_text_varchar_function = ScalarFunction("xml_extract_all_text", 
-		{LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractAllTextFunction);
+	auto xml_extract_all_text_varchar_function =
+	    ScalarFunction("xml_extract_all_text", {LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractAllTextFunction);
 	loader.RegisterFunction(xml_extract_all_text_varchar_function);
-	
+
 	// Register xml_extract_elements function as a function set
 	ScalarFunctionSet xml_extract_elements_functions("xml_extract_elements");
-	
+
 	// XML + VARCHAR
-	xml_extract_elements_functions.AddFunction(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR}, XMLTypes::XMLFragmentType(), XMLExtractElementsFunction));
+	xml_extract_elements_functions.AddFunction(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR},
+	                                                          XMLTypes::XMLFragmentType(), XMLExtractElementsFunction));
 	// XML + STRING_LITERAL
-	xml_extract_elements_functions.AddFunction(ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)}, XMLTypes::XMLFragmentType(), XMLExtractElementsFunction));
+	xml_extract_elements_functions.AddFunction(
+	    ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)}, XMLTypes::XMLFragmentType(),
+	                   XMLExtractElementsFunction));
 	// HTML + VARCHAR
-	xml_extract_elements_functions.AddFunction(ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR}, XMLTypes::XMLFragmentType(), XMLExtractElementsFunction));
+	xml_extract_elements_functions.AddFunction(ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
+	                                                          XMLTypes::XMLFragmentType(), XMLExtractElementsFunction));
 	// HTML + STRING_LITERAL
-	xml_extract_elements_functions.AddFunction(ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)}, XMLTypes::XMLFragmentType(), XMLExtractElementsFunction));
+	xml_extract_elements_functions.AddFunction(
+	    ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)}, XMLTypes::XMLFragmentType(),
+	                   XMLExtractElementsFunction));
 	// XMLFragment + VARCHAR (for nested extraction)
-	xml_extract_elements_functions.AddFunction(ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR}, XMLTypes::XMLFragmentType(), XMLExtractElementsFunction));
+	xml_extract_elements_functions.AddFunction(ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR},
+	                                                          XMLTypes::XMLFragmentType(), XMLExtractElementsFunction));
 	// XMLFragment + STRING_LITERAL
-	xml_extract_elements_functions.AddFunction(ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)}, XMLTypes::XMLFragmentType(), XMLExtractElementsFunction));
+	xml_extract_elements_functions.AddFunction(
+	    ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   XMLTypes::XMLFragmentType(), XMLExtractElementsFunction));
 	// VARCHAR + VARCHAR (compatibility)
-	xml_extract_elements_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, XMLTypes::XMLFragmentType(), XMLExtractElementsFunction));
+	xml_extract_elements_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                                          XMLTypes::XMLFragmentType(), XMLExtractElementsFunction));
 	// VARCHAR + STRING_LITERAL (compatibility)
-	xml_extract_elements_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)}, XMLTypes::XMLFragmentType(), XMLExtractElementsFunction));
-	
+	xml_extract_elements_functions.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)}, XMLTypes::XMLFragmentType(),
+	                   XMLExtractElementsFunction));
+
 	loader.RegisterFunction(xml_extract_elements_functions);
-	
+
 	// Register xml_extract_elements_string function as a function set
 	ScalarFunctionSet xml_extract_elements_string_functions("xml_extract_elements_string");
-	xml_extract_elements_string_functions.AddFunction(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractElementsStringFunction));
-	xml_extract_elements_string_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractElementsStringFunction));
+	xml_extract_elements_string_functions.AddFunction(ScalarFunction(
+	    {XMLTypes::XMLType(), LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractElementsStringFunction));
+	xml_extract_elements_string_functions.AddFunction(ScalarFunction(
+	    {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractElementsStringFunction));
 	loader.RegisterFunction(xml_extract_elements_string_functions);
-	
+
 	// Register xml_wrap_fragment function (returns XML)
-	auto xml_wrap_fragment_function = ScalarFunction("xml_wrap_fragment", 
-		{LogicalType::VARCHAR, LogicalType::VARCHAR}, XMLTypes::XMLType(), XMLWrapFragmentFunction);
+	auto xml_wrap_fragment_function = ScalarFunction("xml_wrap_fragment", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                                 XMLTypes::XMLType(), XMLWrapFragmentFunction);
 	loader.RegisterFunction(xml_wrap_fragment_function);
-	
+
 	// Register xml_extract_attributes function (returns LIST<STRUCT>)
-	auto attr_struct_type = LogicalType::STRUCT({
-		make_pair("element_name", LogicalType::VARCHAR),
-		make_pair("element_path", LogicalType::VARCHAR),
-		make_pair("attribute_name", LogicalType::VARCHAR),
-		make_pair("attribute_value", LogicalType::VARCHAR),
-		make_pair("line_number", LogicalType::BIGINT)
-	});
+	auto attr_struct_type = LogicalType::STRUCT(
+	    {make_pair("element_name", LogicalType::VARCHAR), make_pair("element_path", LogicalType::VARCHAR),
+	     make_pair("attribute_name", LogicalType::VARCHAR), make_pair("attribute_value", LogicalType::VARCHAR),
+	     make_pair("line_number", LogicalType::BIGINT)});
 	// Register xml_extract_attributes function as a function set
 	ScalarFunctionSet xml_extract_attributes_functions("xml_extract_attributes");
-	xml_extract_attributes_functions.AddFunction(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR}, LogicalType::LIST(attr_struct_type), XMLExtractAttributesFunction));
-	xml_extract_attributes_functions.AddFunction(ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR}, LogicalType::LIST(attr_struct_type), XMLExtractAttributesFunction));
-	xml_extract_attributes_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::LIST(attr_struct_type), XMLExtractAttributesFunction));
+	xml_extract_attributes_functions.AddFunction(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR},
+	                                                            LogicalType::LIST(attr_struct_type),
+	                                                            XMLExtractAttributesFunction));
+	xml_extract_attributes_functions.AddFunction(ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
+	                                                            LogicalType::LIST(attr_struct_type),
+	                                                            XMLExtractAttributesFunction));
+	xml_extract_attributes_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                                            LogicalType::LIST(attr_struct_type),
+	                                                            XMLExtractAttributesFunction));
 	loader.RegisterFunction(xml_extract_attributes_functions);
-	
+
 	// Register xml_pretty_print function
-	auto xml_pretty_print_function = ScalarFunction("xml_pretty_print", 
-		{LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLPrettyPrintFunction);
+	auto xml_pretty_print_function =
+	    ScalarFunction("xml_pretty_print", {LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLPrettyPrintFunction);
 	loader.RegisterFunction(xml_pretty_print_function);
-	
+
 	// Register xml_minify function
-	auto xml_minify_function = ScalarFunction("xml_minify", 
-		{LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLMinifyFunction);
+	auto xml_minify_function =
+	    ScalarFunction("xml_minify", {LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLMinifyFunction);
 	loader.RegisterFunction(xml_minify_function);
-	
+
 	// Register xml_validate_schema function
-	auto xml_validate_schema_function = ScalarFunction("xml_validate_schema", 
-		{LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN, XMLValidateSchemaFunction);
+	auto xml_validate_schema_function =
+	    ScalarFunction("xml_validate_schema", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                   XMLValidateSchemaFunction);
 	loader.RegisterFunction(xml_validate_schema_function);
-	
+
 	// Register xml_extract_comments function (returns LIST<STRUCT>)
-	auto comment_struct_type = LogicalType::STRUCT({
-		make_pair("content", LogicalType::VARCHAR),
-		make_pair("line_number", LogicalType::BIGINT)
-	});
-	auto xml_extract_comments_function = ScalarFunction("xml_extract_comments", 
-		{XMLTypes::XMLType()}, LogicalType::LIST(comment_struct_type), XMLExtractCommentsFunction);
+	auto comment_struct_type = LogicalType::STRUCT(
+	    {make_pair("content", LogicalType::VARCHAR), make_pair("line_number", LogicalType::BIGINT)});
+	auto xml_extract_comments_function =
+	    ScalarFunction("xml_extract_comments", {XMLTypes::XMLType()}, LogicalType::LIST(comment_struct_type),
+	                   XMLExtractCommentsFunction);
 	loader.RegisterFunction(xml_extract_comments_function);
-	
+
 	// Register xml_extract_cdata function (returns LIST<STRUCT>)
-	auto xml_extract_cdata_function = ScalarFunction("xml_extract_cdata", 
-		{XMLTypes::XMLType()}, LogicalType::LIST(comment_struct_type), XMLExtractCDataFunction);
+	auto xml_extract_cdata_function = ScalarFunction("xml_extract_cdata", {XMLTypes::XMLType()},
+	                                                 LogicalType::LIST(comment_struct_type), XMLExtractCDataFunction);
 	loader.RegisterFunction(xml_extract_cdata_function);
-	
+
 	// Register xml_stats function (returns STRUCT)
-	auto stats_struct_type = LogicalType::STRUCT({
-		make_pair("element_count", LogicalType::BIGINT),
-		make_pair("attribute_count", LogicalType::BIGINT),
-		make_pair("max_depth", LogicalType::BIGINT),
-		make_pair("size_bytes", LogicalType::BIGINT),
-		make_pair("namespace_count", LogicalType::BIGINT)
-	});
-	auto xml_stats_function = ScalarFunction("xml_stats", 
-		{LogicalType::VARCHAR}, stats_struct_type, XMLStatsFunction);
+	auto stats_struct_type = LogicalType::STRUCT(
+	    {make_pair("element_count", LogicalType::BIGINT), make_pair("attribute_count", LogicalType::BIGINT),
+	     make_pair("max_depth", LogicalType::BIGINT), make_pair("size_bytes", LogicalType::BIGINT),
+	     make_pair("namespace_count", LogicalType::BIGINT)});
+	auto xml_stats_function = ScalarFunction("xml_stats", {LogicalType::VARCHAR}, stats_struct_type, XMLStatsFunction);
 	loader.RegisterFunction(xml_stats_function);
-	
+
 	// Register xml_namespaces function (returns LIST<STRUCT>)
-	auto namespace_struct_type = LogicalType::STRUCT({
-		make_pair("prefix", LogicalType::VARCHAR),
-		make_pair("uri", LogicalType::VARCHAR)
-	});
-	auto xml_namespaces_function = ScalarFunction("xml_namespaces", 
-		{LogicalType::VARCHAR}, LogicalType::LIST(namespace_struct_type), XMLNamespacesFunction);
+	auto namespace_struct_type =
+	    LogicalType::STRUCT({make_pair("prefix", LogicalType::VARCHAR), make_pair("uri", LogicalType::VARCHAR)});
+	auto xml_namespaces_function = ScalarFunction("xml_namespaces", {LogicalType::VARCHAR},
+	                                              LogicalType::LIST(namespace_struct_type), XMLNamespacesFunction);
 	loader.RegisterFunction(xml_namespaces_function);
-	
+
 	// Register xml_to_json function with optional named parameters
-	ScalarFunction xml_to_json_function("xml_to_json", {LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLToJSONWithSchemaFunction, XMLToJSONWithSchemaBind);
+	ScalarFunction xml_to_json_function("xml_to_json", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                    XMLToJSONWithSchemaFunction, XMLToJSONWithSchemaBind);
 	xml_to_json_function.varargs = LogicalType::ANY;
 	xml_to_json_function.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
 	loader.RegisterFunction(xml_to_json_function);
-	
+
 	// Register json_to_xml function
-	auto json_to_xml_function = ScalarFunction("json_to_xml", 
-		{LogicalType::VARCHAR}, LogicalType::VARCHAR, JSONToXMLFunction);
+	auto json_to_xml_function =
+	    ScalarFunction("json_to_xml", {LogicalType::VARCHAR}, LogicalType::VARCHAR, JSONToXMLFunction);
 	loader.RegisterFunction(json_to_xml_function);
-	
+
 	// Register HTML extraction functions following markdown extension patterns
-	
+
 	// Define return types for HTML functions
-	auto html_link_struct_type = LogicalType::STRUCT({
-		{"text", LogicalType(LogicalTypeId::VARCHAR)},
-		{"href", LogicalType(LogicalTypeId::VARCHAR)},
-		{"title", LogicalType(LogicalTypeId::VARCHAR)},
-		{"line_number", LogicalType(LogicalTypeId::BIGINT)}
-	});
-	
-	auto html_image_struct_type = LogicalType::STRUCT({
-		{"alt", LogicalType(LogicalTypeId::VARCHAR)},
-		{"src", LogicalType(LogicalTypeId::VARCHAR)},
-		{"title", LogicalType(LogicalTypeId::VARCHAR)},
-		{"width", LogicalType(LogicalTypeId::BIGINT)},
-		{"height", LogicalType(LogicalTypeId::BIGINT)},
-		{"line_number", LogicalType(LogicalTypeId::BIGINT)}
-	});
-	
-	auto html_table_row_struct_type = LogicalType::STRUCT({
-		{"table_index", LogicalType(LogicalTypeId::BIGINT)},
-		{"row_type", LogicalType(LogicalTypeId::VARCHAR)},
-		{"row_index", LogicalType(LogicalTypeId::BIGINT)},
-		{"column_index", LogicalType(LogicalTypeId::BIGINT)},
-		{"cell_value", LogicalType(LogicalTypeId::VARCHAR)},
-		{"line_number", LogicalType(LogicalTypeId::BIGINT)},
-		{"num_columns", LogicalType(LogicalTypeId::BIGINT)},
-		{"num_rows", LogicalType(LogicalTypeId::BIGINT)}
-	});
-	
+	auto html_link_struct_type = LogicalType::STRUCT({{"text", LogicalType(LogicalTypeId::VARCHAR)},
+	                                                  {"href", LogicalType(LogicalTypeId::VARCHAR)},
+	                                                  {"title", LogicalType(LogicalTypeId::VARCHAR)},
+	                                                  {"line_number", LogicalType(LogicalTypeId::BIGINT)}});
+
+	auto html_image_struct_type = LogicalType::STRUCT({{"alt", LogicalType(LogicalTypeId::VARCHAR)},
+	                                                   {"src", LogicalType(LogicalTypeId::VARCHAR)},
+	                                                   {"title", LogicalType(LogicalTypeId::VARCHAR)},
+	                                                   {"width", LogicalType(LogicalTypeId::BIGINT)},
+	                                                   {"height", LogicalType(LogicalTypeId::BIGINT)},
+	                                                   {"line_number", LogicalType(LogicalTypeId::BIGINT)}});
+
+	auto html_table_row_struct_type = LogicalType::STRUCT({{"table_index", LogicalType(LogicalTypeId::BIGINT)},
+	                                                       {"row_type", LogicalType(LogicalTypeId::VARCHAR)},
+	                                                       {"row_index", LogicalType(LogicalTypeId::BIGINT)},
+	                                                       {"column_index", LogicalType(LogicalTypeId::BIGINT)},
+	                                                       {"cell_value", LogicalType(LogicalTypeId::VARCHAR)},
+	                                                       {"line_number", LogicalType(LogicalTypeId::BIGINT)},
+	                                                       {"num_columns", LogicalType(LogicalTypeId::BIGINT)},
+	                                                       {"num_rows", LogicalType(LogicalTypeId::BIGINT)}});
+
 	auto html_table_json_struct_type = LogicalType::STRUCT({
-		{"table_index", LogicalType(LogicalTypeId::BIGINT)},
-		{"line_number", LogicalType(LogicalTypeId::BIGINT)},
-		{"num_columns", LogicalType(LogicalTypeId::BIGINT)},
-		{"num_rows", LogicalType(LogicalTypeId::BIGINT)},
-		{"headers", LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR))},
-		{"table_data", LogicalType::LIST(LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR)))},
-		{"table_json", LogicalType::STRUCT({})}, // Complex nested struct
-		{"json_structure", LogicalType::STRUCT({})} // Complex nested struct
+	    {"table_index", LogicalType(LogicalTypeId::BIGINT)},
+	    {"line_number", LogicalType(LogicalTypeId::BIGINT)},
+	    {"num_columns", LogicalType(LogicalTypeId::BIGINT)},
+	    {"num_rows", LogicalType(LogicalTypeId::BIGINT)},
+	    {"headers", LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR))},
+	    {"table_data", LogicalType::LIST(LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR)))},
+	    {"table_json", LogicalType::STRUCT({})},    // Complex nested struct
+	    {"json_structure", LogicalType::STRUCT({})} // Complex nested struct
 	});
-	
+
 	// Register html_extract_text function with XPath support
 	ScalarFunctionSet html_extract_text_functions("html_extract_text");
-	html_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::HTMLType()}, LogicalType::VARCHAR, HTMLExtractTextFunction));
-	html_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR}, LogicalType::VARCHAR, HTMLExtractTextWithXPathFunction));
-	html_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)}, LogicalType::VARCHAR, HTMLExtractTextWithXPathFunction));
+	html_extract_text_functions.AddFunction(
+	    ScalarFunction({XMLTypes::HTMLType()}, LogicalType::VARCHAR, HTMLExtractTextFunction));
+	html_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
+	                                                       LogicalType::VARCHAR, HTMLExtractTextWithXPathFunction));
+	html_extract_text_functions.AddFunction(
+	    ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)}, LogicalType::VARCHAR,
+	                   HTMLExtractTextWithXPathFunction));
 	loader.RegisterFunction(html_extract_text_functions);
-	
+
 	// Register html_extract_links function
-	auto html_extract_links_function = ScalarFunction("html_extract_links", 
-		{XMLTypes::HTMLType()}, LogicalType::LIST(html_link_struct_type), HTMLExtractLinksFunction);
+	auto html_extract_links_function =
+	    ScalarFunction("html_extract_links", {XMLTypes::HTMLType()}, LogicalType::LIST(html_link_struct_type),
+	                   HTMLExtractLinksFunction);
 	loader.RegisterFunction(html_extract_links_function);
-	
+
 	// Register html_extract_images function
-	auto html_extract_images_function = ScalarFunction("html_extract_images", 
-		{XMLTypes::HTMLType()}, LogicalType::LIST(html_image_struct_type), HTMLExtractImagesFunction);
+	auto html_extract_images_function =
+	    ScalarFunction("html_extract_images", {XMLTypes::HTMLType()}, LogicalType::LIST(html_image_struct_type),
+	                   HTMLExtractImagesFunction);
 	loader.RegisterFunction(html_extract_images_function);
-	
+
 	// Register html_extract_table_rows function
-	auto html_extract_table_rows_function = ScalarFunction("html_extract_table_rows", 
-		{XMLTypes::HTMLType()}, LogicalType::LIST(html_table_row_struct_type), HTMLExtractTableRowsFunction);
+	auto html_extract_table_rows_function =
+	    ScalarFunction("html_extract_table_rows", {XMLTypes::HTMLType()}, LogicalType::LIST(html_table_row_struct_type),
+	                   HTMLExtractTableRowsFunction);
 	loader.RegisterFunction(html_extract_table_rows_function);
-	
+
 	// Register html_extract_tables_json function
-	auto html_extract_tables_json_function = ScalarFunction("html_extract_tables_json", 
-		{XMLTypes::HTMLType()}, LogicalType::LIST(html_table_json_struct_type), HTMLExtractTablesJSONFunction);
+	auto html_extract_tables_json_function =
+	    ScalarFunction("html_extract_tables_json", {XMLTypes::HTMLType()},
+	                   LogicalType::LIST(html_table_json_struct_type), HTMLExtractTablesJSONFunction);
 	loader.RegisterFunction(html_extract_tables_json_function);
-	
+
 	// Register parse_html scalar function for parsing HTML content directly
-	auto parse_html_function = ScalarFunction("parse_html", 
-		{LogicalType::VARCHAR}, XMLTypes::HTMLType(), ReadHTMLFunction);
+	auto parse_html_function =
+	    ScalarFunction("parse_html", {LogicalType::VARCHAR}, XMLTypes::HTMLType(), ReadHTMLFunction);
 	loader.RegisterFunction(parse_html_function);
 }
 
 // HTML-specific extraction function implementations
 void XMLScalarFunctions::HTMLExtractTextFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &html_vector = args.data[0];
-	
+
 	UnaryExecutor::Execute<string_t, string_t>(html_vector, result, args.size(), [&](string_t html_str) {
 		std::string html_string = html_str.GetString();
 		std::string extracted_text = XMLUtils::ExtractHTMLText(html_string);
@@ -805,27 +831,26 @@ void XMLScalarFunctions::HTMLExtractTextFunction(DataChunk &args, ExpressionStat
 void XMLScalarFunctions::HTMLExtractTextWithXPathFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &html_vector = args.data[0];
 	auto &xpath_vector = args.data[1];
-	
+
 	BinaryExecutor::Execute<string_t, string_t, string_t>(
-		html_vector, xpath_vector, result, args.size(),
-		[&](string_t html_str, string_t xpath_str) {
-			std::string html_string = html_str.GetString();
-			std::string xpath_string = xpath_str.GetString();
-			std::string extracted_text = XMLUtils::ExtractHTMLTextByXPath(html_string, xpath_string);
-			return StringVector::AddString(result, extracted_text);
-		});
+	    html_vector, xpath_vector, result, args.size(), [&](string_t html_str, string_t xpath_str) {
+		    std::string html_string = html_str.GetString();
+		    std::string xpath_string = xpath_str.GetString();
+		    std::string extracted_text = XMLUtils::ExtractHTMLTextByXPath(html_string, xpath_string);
+		    return StringVector::AddString(result, extracted_text);
+	    });
 }
 
 void XMLScalarFunctions::HTMLExtractLinksFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &html_vector = args.data[0];
 	auto count = args.size();
-	
+
 	for (idx_t i = 0; i < count; i++) {
 		auto html_str = FlatVector::GetData<string_t>(html_vector)[i];
 		std::string html_string = html_str.GetString();
-		
+
 		auto links = XMLUtils::ExtractHTMLLinks(html_string);
-		
+
 		vector<Value> link_values;
 		for (const auto &link : links) {
 			child_list_t<Value> link_children;
@@ -833,17 +858,14 @@ void XMLScalarFunctions::HTMLExtractLinksFunction(DataChunk &args, ExpressionSta
 			link_children.emplace_back("href", Value(link.url));
 			link_children.emplace_back("title", link.title.empty() ? Value() : Value(link.title));
 			link_children.emplace_back("line_number", Value::BIGINT(link.line_number));
-			
+
 			link_values.emplace_back(Value::STRUCT(link_children));
 		}
-		
-		auto link_struct_type = LogicalType::STRUCT({
-			make_pair("text", LogicalType::VARCHAR),
-			make_pair("href", LogicalType::VARCHAR),
-			make_pair("title", LogicalType::VARCHAR),
-			make_pair("line_number", LogicalType::BIGINT)
-		});
-		
+
+		auto link_struct_type = LogicalType::STRUCT(
+		    {make_pair("text", LogicalType::VARCHAR), make_pair("href", LogicalType::VARCHAR),
+		     make_pair("title", LogicalType::VARCHAR), make_pair("line_number", LogicalType::BIGINT)});
+
 		Value list_value = Value::LIST(link_struct_type, link_values);
 		result.SetValue(i, list_value);
 	}
@@ -852,13 +874,13 @@ void XMLScalarFunctions::HTMLExtractLinksFunction(DataChunk &args, ExpressionSta
 void XMLScalarFunctions::HTMLExtractImagesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &html_vector = args.data[0];
 	auto count = args.size();
-	
+
 	for (idx_t i = 0; i < count; i++) {
 		auto html_str = FlatVector::GetData<string_t>(html_vector)[i];
 		std::string html_string = html_str.GetString();
-		
+
 		auto images = XMLUtils::ExtractHTMLImages(html_string);
-		
+
 		vector<Value> image_values;
 		for (const auto &image : images) {
 			child_list_t<Value> image_children;
@@ -868,19 +890,15 @@ void XMLScalarFunctions::HTMLExtractImagesFunction(DataChunk &args, ExpressionSt
 			image_children.emplace_back("width", Value::BIGINT(image.width));
 			image_children.emplace_back("height", Value::BIGINT(image.height));
 			image_children.emplace_back("line_number", Value::BIGINT(image.line_number));
-			
+
 			image_values.emplace_back(Value::STRUCT(image_children));
 		}
-		
-		auto image_struct_type = LogicalType::STRUCT({
-			make_pair("alt", LogicalType::VARCHAR),
-			make_pair("src", LogicalType::VARCHAR),
-			make_pair("title", LogicalType::VARCHAR),
-			make_pair("width", LogicalType::BIGINT),
-			make_pair("height", LogicalType::BIGINT),
-			make_pair("line_number", LogicalType::BIGINT)
-		});
-		
+
+		auto image_struct_type = LogicalType::STRUCT(
+		    {make_pair("alt", LogicalType::VARCHAR), make_pair("src", LogicalType::VARCHAR),
+		     make_pair("title", LogicalType::VARCHAR), make_pair("width", LogicalType::BIGINT),
+		     make_pair("height", LogicalType::BIGINT), make_pair("line_number", LogicalType::BIGINT)});
+
 		Value list_value = Value::LIST(image_struct_type, image_values);
 		result.SetValue(i, list_value);
 	}
@@ -889,19 +907,19 @@ void XMLScalarFunctions::HTMLExtractImagesFunction(DataChunk &args, ExpressionSt
 void XMLScalarFunctions::HTMLExtractTableRowsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &html_vector = args.data[0];
 	auto count = args.size();
-	
+
 	for (idx_t i = 0; i < count; i++) {
 		auto html_str = FlatVector::GetData<string_t>(html_vector)[i];
 		std::string html_string = html_str.GetString();
-		
+
 		auto tables = XMLUtils::ExtractHTMLTables(html_string);
-		
+
 		vector<Value> row_values;
-		
+
 		// Process each table
 		for (size_t table_idx = 0; table_idx < tables.size(); table_idx++) {
 			const auto &table = tables[table_idx];
-			
+
 			// Output header cells
 			for (size_t col_idx = 0; col_idx < table.headers.size(); col_idx++) {
 				child_list_t<Value> row_children;
@@ -915,7 +933,7 @@ void XMLScalarFunctions::HTMLExtractTableRowsFunction(DataChunk &args, Expressio
 				row_children.emplace_back("num_rows", Value::BIGINT(table.num_rows));
 				row_values.emplace_back(Value::STRUCT(row_children));
 			}
-			
+
 			// Output data rows
 			for (size_t row_idx = 0; row_idx < table.rows.size(); row_idx++) {
 				const auto &row = table.rows[row_idx];
@@ -933,18 +951,13 @@ void XMLScalarFunctions::HTMLExtractTableRowsFunction(DataChunk &args, Expressio
 				}
 			}
 		}
-		
-		auto table_row_struct_type = LogicalType::STRUCT({
-			make_pair("table_index", LogicalType::BIGINT),
-			make_pair("row_type", LogicalType::VARCHAR),
-			make_pair("row_index", LogicalType::BIGINT),
-			make_pair("column_index", LogicalType::BIGINT),
-			make_pair("cell_value", LogicalType::VARCHAR),
-			make_pair("line_number", LogicalType::BIGINT),
-			make_pair("num_columns", LogicalType::BIGINT),
-			make_pair("num_rows", LogicalType::BIGINT)
-		});
-		
+
+		auto table_row_struct_type = LogicalType::STRUCT(
+		    {make_pair("table_index", LogicalType::BIGINT), make_pair("row_type", LogicalType::VARCHAR),
+		     make_pair("row_index", LogicalType::BIGINT), make_pair("column_index", LogicalType::BIGINT),
+		     make_pair("cell_value", LogicalType::VARCHAR), make_pair("line_number", LogicalType::BIGINT),
+		     make_pair("num_columns", LogicalType::BIGINT), make_pair("num_rows", LogicalType::BIGINT)});
+
 		Value list_value = Value::LIST(table_row_struct_type, row_values);
 		result.SetValue(i, list_value);
 	}
@@ -953,27 +966,27 @@ void XMLScalarFunctions::HTMLExtractTableRowsFunction(DataChunk &args, Expressio
 void XMLScalarFunctions::HTMLExtractTablesJSONFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &html_vector = args.data[0];
 	auto count = args.size();
-	
+
 	for (idx_t i = 0; i < count; i++) {
 		auto html_str = FlatVector::GetData<string_t>(html_vector)[i];
 		std::string html_string = html_str.GetString();
-		
+
 		auto tables = XMLUtils::ExtractHTMLTables(html_string);
-		
+
 		vector<Value> table_values;
-		
+
 		// Process each table
 		for (size_t table_idx = 0; table_idx < tables.size(); table_idx++) {
 			const auto &table = tables[table_idx];
 			const auto &headers = table.headers;
 			const auto &rows = table.rows;
-			
+
 			// Create header values
 			vector<Value> header_values;
 			for (const auto &header : headers) {
 				header_values.push_back(Value(header));
 			}
-			
+
 			// Create data rows as list of lists
 			vector<Value> row_values;
 			for (const auto &row : rows) {
@@ -983,16 +996,16 @@ void XMLScalarFunctions::HTMLExtractTablesJSONFunction(DataChunk &args, Expressi
 				}
 				row_values.push_back(Value::LIST(cell_values));
 			}
-			
+
 			// Build JSON using DuckDB's native JSON construction
 			child_list_t<Value> json_children;
-			
+
 			// Headers array
 			json_children.push_back({"headers", Value::LIST(header_values)});
-			
-			// Data array (2D)  
+
+			// Data array (2D)
 			json_children.push_back({"data", Value::LIST(row_values)});
-			
+
 			// Rows as objects
 			vector<Value> object_rows;
 			for (const auto &row : rows) {
@@ -1003,20 +1016,20 @@ void XMLScalarFunctions::HTMLExtractTablesJSONFunction(DataChunk &args, Expressi
 				object_rows.push_back(Value::STRUCT(row_obj));
 			}
 			json_children.push_back({"rows", Value::LIST(object_rows)});
-			
+
 			// Metadata
 			child_list_t<Value> metadata_children;
 			metadata_children.push_back({"line_number", Value::BIGINT(table.line_number)});
 			metadata_children.push_back({"num_columns", Value::BIGINT(table.num_columns)});
 			metadata_children.push_back({"num_rows", Value::BIGINT(table.num_rows)});
 			json_children.push_back({"metadata", Value::STRUCT(metadata_children)});
-			
+
 			Value json_value = Value::STRUCT(json_children);
-			
-			// Build structure description 
+
+			// Build structure description
 			child_list_t<Value> structure_children;
 			structure_children.push_back({"table_name", Value("table_" + std::to_string(table_idx))});
-			
+
 			vector<Value> column_info;
 			for (size_t col_idx = 0; col_idx < headers.size(); col_idx++) {
 				child_list_t<Value> col_children;
@@ -1028,9 +1041,9 @@ void XMLScalarFunctions::HTMLExtractTablesJSONFunction(DataChunk &args, Expressi
 			structure_children.push_back({"columns", Value::LIST(column_info)});
 			structure_children.push_back({"row_count", Value::BIGINT(static_cast<int64_t>(rows.size()))});
 			structure_children.push_back({"source_line", Value::BIGINT(table.line_number)});
-			
+
 			Value structure_value = Value::STRUCT(structure_children);
-			
+
 			// Create struct for this table
 			child_list_t<Value> table_struct_children;
 			table_struct_children.push_back({"table_index", Value::BIGINT(static_cast<int64_t>(table_idx))});
@@ -1041,21 +1054,19 @@ void XMLScalarFunctions::HTMLExtractTablesJSONFunction(DataChunk &args, Expressi
 			table_struct_children.push_back({"table_data", Value::LIST(row_values)});
 			table_struct_children.push_back({"table_json", json_value});
 			table_struct_children.push_back({"json_structure", structure_value});
-			
+
 			table_values.push_back(Value::STRUCT(table_struct_children));
 		}
-		
+
 		auto table_json_struct_type = LogicalType::STRUCT({
-			make_pair("table_index", LogicalType::BIGINT),
-			make_pair("line_number", LogicalType::BIGINT),
-			make_pair("num_columns", LogicalType::BIGINT),
-			make_pair("num_rows", LogicalType::BIGINT),
-			make_pair("headers", LogicalType::LIST(LogicalType::VARCHAR)),
-			make_pair("table_data", LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR))),
-			make_pair("table_json", LogicalType::STRUCT({})), // Complex nested struct
-			make_pair("json_structure", LogicalType::STRUCT({})) // Complex nested struct
+		    make_pair("table_index", LogicalType::BIGINT), make_pair("line_number", LogicalType::BIGINT),
+		    make_pair("num_columns", LogicalType::BIGINT), make_pair("num_rows", LogicalType::BIGINT),
+		    make_pair("headers", LogicalType::LIST(LogicalType::VARCHAR)),
+		    make_pair("table_data", LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR))),
+		    make_pair("table_json", LogicalType::STRUCT({})),    // Complex nested struct
+		    make_pair("json_structure", LogicalType::STRUCT({})) // Complex nested struct
 		});
-		
+
 		Value list_value = Value::LIST(table_json_struct_type, table_values);
 		result.SetValue(i, list_value);
 	}
@@ -1063,38 +1074,38 @@ void XMLScalarFunctions::HTMLExtractTablesJSONFunction(DataChunk &args, Expressi
 
 void XMLScalarFunctions::ParseHTMLFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &file_path_vector = args.data[0];
-	
+
 	UnaryExecutor::Execute<string_t, string_t>(file_path_vector, result, args.size(), [&](string_t file_path_str) {
 		std::string file_path = file_path_str.GetString();
-		
+
 		try {
 			// Read the HTML file using DuckDB's file system
 			auto &fs = FileSystem::GetFileSystem(state.GetContext());
 			auto file_handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
 			auto file_size = fs.GetFileSize(*file_handle);
-			
+
 			// Handle empty HTML files gracefully (HTML is more permissive than XML)
 			if (file_size == 0) {
 				return string_t("<html></html>");
 			}
-			
+
 			// Read file content
 			string content;
 			content.resize(file_size);
-			file_handle->Read((void*)content.data(), file_size);
-			
+			file_handle->Read((void *)content.data(), file_size);
+
 			// Parse the HTML using the HTML parser to normalize it (removes DOCTYPE)
 			XMLDocRAII html_doc(content, true); // Use HTML parser
 			if (html_doc.IsValid()) {
 				// Serialize the document back to string (without DOCTYPE)
-				xmlChar* html_output = nullptr;
+				xmlChar *html_output = nullptr;
 				int output_size = 0;
 				xmlDocDumpMemory(html_doc.doc, &html_output, &output_size);
-				
+
 				if (html_output) {
 					XMLCharPtr html_ptr(html_output);
-					std::string normalized_html = std::string(reinterpret_cast<const char*>(html_ptr.get()));
-					
+					std::string normalized_html = std::string(reinterpret_cast<const char *>(html_ptr.get()));
+
 					// Remove XML declaration if present
 					size_t xml_decl_end = normalized_html.find("?>");
 					if (xml_decl_end != std::string::npos) {
@@ -1102,7 +1113,7 @@ void XMLScalarFunctions::ParseHTMLFunction(DataChunk &args, ExpressionState &sta
 						// Remove leading whitespace/newlines
 						normalized_html.erase(0, normalized_html.find_first_not_of(" \t\n\r"));
 					}
-					
+
 					// Remove DOCTYPE if present
 					size_t doctype_start = normalized_html.find("<!DOCTYPE");
 					if (doctype_start != std::string::npos) {
@@ -1113,14 +1124,14 @@ void XMLScalarFunctions::ParseHTMLFunction(DataChunk &args, ExpressionState &sta
 							normalized_html.erase(0, normalized_html.find_first_not_of(" \t\n\r"));
 						}
 					}
-					
+
 					// Minify HTML: remove whitespace between tags
 					std::string minified_html;
 					bool in_tag = false;
 					bool in_content = false;
 					for (size_t i = 0; i < normalized_html.length(); i++) {
 						char c = normalized_html[i];
-						
+
 						if (c == '<') {
 							in_tag = true;
 							in_content = false;
@@ -1136,21 +1147,21 @@ void XMLScalarFunctions::ParseHTMLFunction(DataChunk &args, ExpressionState &sta
 							// Between tags: trim whitespace but keep content
 							if (!std::isspace(c)) {
 								minified_html += c;
-							} else if (!minified_html.empty() && minified_html.back() != '>' && 
-							          i + 1 < normalized_html.length() && normalized_html[i + 1] != '<') {
+							} else if (!minified_html.empty() && minified_html.back() != '>' &&
+							           i + 1 < normalized_html.length() && normalized_html[i + 1] != '<') {
 								// Keep single space between words, but not between tags
 								minified_html += ' ';
 							}
 						}
 					}
-					
+
 					return StringVector::AddString(result, minified_html);
 				}
 			}
-			
+
 			// Fallback to original content if parsing fails
 			return StringVector::AddString(result, content);
-			
+
 		} catch (const std::exception &e) {
 			throw IOException("Failed to read HTML file '%s': %s", file_path, e.what());
 		}
@@ -1159,104 +1170,105 @@ void XMLScalarFunctions::ParseHTMLFunction(DataChunk &args, ExpressionState &sta
 
 void XMLScalarFunctions::ReadHTMLFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &html_content_vector = args.data[0];
-	
-	UnaryExecutor::Execute<string_t, string_t>(html_content_vector, result, args.size(), [&](string_t html_content_str) {
-		std::string html_content = html_content_str.GetString();
-		
-		// Handle empty HTML content gracefully
-		if (html_content.empty()) {
-			return string_t("<html></html>");
-		}
-		
-		try {
-			// Parse the HTML using the HTML parser to normalize it
-			XMLDocRAII html_doc(html_content, true); // Use HTML parser
-			if (html_doc.IsValid()) {
-				// Serialize the document back to string
-				xmlChar* html_output = nullptr;
-				int output_size = 0;
-				xmlDocDumpMemory(html_doc.doc, &html_output, &output_size);
-				
-				if (html_output) {
-					XMLCharPtr html_ptr(html_output);
-					std::string normalized_html = std::string(reinterpret_cast<const char*>(html_ptr.get()));
-					
-					// Remove XML declaration if present
-					size_t xml_decl_end = normalized_html.find("?>");
-					if (xml_decl_end != std::string::npos) {
-						normalized_html = normalized_html.substr(xml_decl_end + 2);
-						// Remove leading whitespace/newlines
-						normalized_html.erase(0, normalized_html.find_first_not_of(" \t\n\r"));
-					}
-					
-					// Remove DOCTYPE if present
-					size_t doctype_start = normalized_html.find("<!DOCTYPE");
-					if (doctype_start != std::string::npos) {
-						size_t doctype_end = normalized_html.find(">", doctype_start);
-						if (doctype_end != std::string::npos) {
-							normalized_html.erase(doctype_start, doctype_end - doctype_start + 1);
-							// Remove leading whitespace/newlines after DOCTYPE removal
-							normalized_html.erase(0, normalized_html.find_first_not_of(" \t\n\r"));
-						}
-					}
-					
-					// Minify HTML: remove whitespace between tags
-					std::string minified_html;
-					bool inside_tag = false;
-					bool last_was_space = false;
-					bool between_tags = true; // Start assuming we're between tags
-					
-					for (size_t i = 0; i < normalized_html.length(); i++) {
-						char c = normalized_html[i];
-						
-						if (c == '<') {
-							inside_tag = true;
-							between_tags = false;
-							minified_html += c;
-							last_was_space = false;
-						} else if (c == '>') {
-							inside_tag = false;
-							between_tags = true;
-							minified_html += c;
-							last_was_space = false;
-						} else if (inside_tag) {
-							minified_html += c;
-							last_was_space = false;
-						} else {
-							if (std::isspace(c)) {
-								if (between_tags) {
-									// Skip all whitespace between tags
-									continue;
-								} else if (!last_was_space) {
-									// Keep single space between words within text content
-									minified_html += ' ';
-								}
-								last_was_space = true;
-							} else {
-								between_tags = false;
-								minified_html += c;
-								last_was_space = false;
-							}
-						}
-					}
-					
-					// Trim trailing whitespace
-					if (!minified_html.empty() && std::isspace(minified_html.back())) {
-						minified_html.erase(minified_html.find_last_not_of(" \t\n\r") + 1);
-					}
-					
-					return StringVector::AddString(result, minified_html);
-				}
-			}
-			
-			// Fallback to original content if parsing fails
-			return StringVector::AddString(result, html_content);
-			
-		} catch (const std::exception &e) {
-			// Return original content if there's an error parsing
-			return StringVector::AddString(result, html_content);
-		}
-	});
+
+	UnaryExecutor::Execute<string_t, string_t>(
+	    html_content_vector, result, args.size(), [&](string_t html_content_str) {
+		    std::string html_content = html_content_str.GetString();
+
+		    // Handle empty HTML content gracefully
+		    if (html_content.empty()) {
+			    return string_t("<html></html>");
+		    }
+
+		    try {
+			    // Parse the HTML using the HTML parser to normalize it
+			    XMLDocRAII html_doc(html_content, true); // Use HTML parser
+			    if (html_doc.IsValid()) {
+				    // Serialize the document back to string
+				    xmlChar *html_output = nullptr;
+				    int output_size = 0;
+				    xmlDocDumpMemory(html_doc.doc, &html_output, &output_size);
+
+				    if (html_output) {
+					    XMLCharPtr html_ptr(html_output);
+					    std::string normalized_html = std::string(reinterpret_cast<const char *>(html_ptr.get()));
+
+					    // Remove XML declaration if present
+					    size_t xml_decl_end = normalized_html.find("?>");
+					    if (xml_decl_end != std::string::npos) {
+						    normalized_html = normalized_html.substr(xml_decl_end + 2);
+						    // Remove leading whitespace/newlines
+						    normalized_html.erase(0, normalized_html.find_first_not_of(" \t\n\r"));
+					    }
+
+					    // Remove DOCTYPE if present
+					    size_t doctype_start = normalized_html.find("<!DOCTYPE");
+					    if (doctype_start != std::string::npos) {
+						    size_t doctype_end = normalized_html.find(">", doctype_start);
+						    if (doctype_end != std::string::npos) {
+							    normalized_html.erase(doctype_start, doctype_end - doctype_start + 1);
+							    // Remove leading whitespace/newlines after DOCTYPE removal
+							    normalized_html.erase(0, normalized_html.find_first_not_of(" \t\n\r"));
+						    }
+					    }
+
+					    // Minify HTML: remove whitespace between tags
+					    std::string minified_html;
+					    bool inside_tag = false;
+					    bool last_was_space = false;
+					    bool between_tags = true; // Start assuming we're between tags
+
+					    for (size_t i = 0; i < normalized_html.length(); i++) {
+						    char c = normalized_html[i];
+
+						    if (c == '<') {
+							    inside_tag = true;
+							    between_tags = false;
+							    minified_html += c;
+							    last_was_space = false;
+						    } else if (c == '>') {
+							    inside_tag = false;
+							    between_tags = true;
+							    minified_html += c;
+							    last_was_space = false;
+						    } else if (inside_tag) {
+							    minified_html += c;
+							    last_was_space = false;
+						    } else {
+							    if (std::isspace(c)) {
+								    if (between_tags) {
+									    // Skip all whitespace between tags
+									    continue;
+								    } else if (!last_was_space) {
+									    // Keep single space between words within text content
+									    minified_html += ' ';
+								    }
+								    last_was_space = true;
+							    } else {
+								    between_tags = false;
+								    minified_html += c;
+								    last_was_space = false;
+							    }
+						    }
+					    }
+
+					    // Trim trailing whitespace
+					    if (!minified_html.empty() && std::isspace(minified_html.back())) {
+						    minified_html.erase(minified_html.find_last_not_of(" \t\n\r") + 1);
+					    }
+
+					    return StringVector::AddString(result, minified_html);
+				    }
+			    }
+
+			    // Fallback to original content if parsing fails
+			    return StringVector::AddString(result, html_content);
+
+		    } catch (const std::exception &e) {
+			    // Return original content if there's an error parsing
+			    return StringVector::AddString(result, html_content);
+		    }
+	    });
 }
 
 } // namespace duckdb

--- a/src/xml_schema_inference.cpp
+++ b/src/xml_schema_inference.cpp
@@ -11,53 +11,53 @@ namespace duckdb {
 // Forward declaration for silent error handler from xml_utils.cpp
 void XMLSilentErrorHandler(void *ctx, const char *msg, ...);
 
-std::vector<XMLColumnInfo> XMLSchemaInference::InferSchema(const std::string& xml_content, 
-                                                            const XMLSchemaOptions& options) {
+std::vector<XMLColumnInfo> XMLSchemaInference::InferSchema(const std::string &xml_content,
+                                                           const XMLSchemaOptions &options) {
 	std::vector<XMLColumnInfo> columns;
-	
+
 	// First, analyze the document structure to detect patterns
 	auto patterns = AnalyzeDocumentStructure(xml_content, options);
-	
+
 	if (patterns.empty()) {
 		// Fallback: return filename and content columns
 		columns.emplace_back("filename", LogicalType::VARCHAR, false, "", 1.0);
 		columns.emplace_back("content", LogicalType::VARCHAR, false, "", 1.0);
 		return columns;
 	}
-	
+
 	// Calculate total element occurrences for frequency calculation
 	int32_t total_occurrences = 0;
-	for (const auto& pattern : patterns) {
+	for (const auto &pattern : patterns) {
 		total_occurrences += pattern.occurrence_count;
 	}
-	
+
 	// Create a map for pattern lookup during nested type inference
 	std::unordered_map<std::string, ElementPattern> pattern_map;
-	for (const auto& pattern : patterns) {
+	for (const auto &pattern : patterns) {
 		pattern_map[pattern.name] = pattern;
 	}
-	
+
 	// Convert patterns to column definitions
-	for (const auto& pattern : patterns) {
+	for (const auto &pattern : patterns) {
 		// Skip elements that appear very rarely (likely outliers)
 		if (total_occurrences > 0 && pattern.GetFrequency(total_occurrences) < 0.1) { // Less than 10% frequency
 			continue;
 		}
-		
+
 		LogicalType column_type;
 		bool should_create_column = false;
-		
+
 		// When unnest_as_columns=true, skip container elements that have children
 		// Only create columns for leaf elements or properly aggregated arrays
 		if (options.unnest_as_columns && pattern.has_children && !pattern.all_children_same_name) {
 			// Before skipping container element, extract its attributes as columns
 			if (options.include_attributes && options.attribute_mode == "columns") {
-				for (const auto& attr_pair : pattern.attribute_counts) {
+				for (const auto &attr_pair : pattern.attribute_counts) {
 					std::string attr_name = pattern.name + "_" + attr_pair.first;
 					if (!options.attribute_prefix.empty()) {
 						attr_name = options.attribute_prefix + attr_name;
 					}
-					
+
 					// For now, assume VARCHAR for attributes (could be enhanced with sampling)
 					auto xpath = GetElementXPath(pattern.name, true, attr_pair.first);
 					columns.emplace_back(attr_name, LogicalType::VARCHAR, true, xpath, 0.8);
@@ -66,164 +66,163 @@ std::vector<XMLColumnInfo> XMLSchemaInference::InferSchema(const std::string& xm
 			// Skip this container element - its children will be processed as individual columns
 			continue;
 		}
-		
+
 		// Skip individual elements that appear in homogeneous arrays (they'll be aggregated)
 		// Check if this element is a child of a homogeneous collection that will create a LIST column
 		if (options.unnest_as_columns && pattern.is_scalar) {
 			bool appears_in_homogeneous_collection = false;
-			
+
 			// Check if any other pattern contains this element as a homogeneous child collection
-			for (const auto& other_pattern : patterns) {
-				if (other_pattern.all_children_same_name && 
-					other_pattern.child_element_counts.size() == 1 &&
-					other_pattern.child_element_counts.find(pattern.name) != other_pattern.child_element_counts.end() &&
-					other_pattern.child_element_counts.at(pattern.name) > 1) {
+			for (const auto &other_pattern : patterns) {
+				if (other_pattern.all_children_same_name && other_pattern.child_element_counts.size() == 1 &&
+				    other_pattern.child_element_counts.find(pattern.name) != other_pattern.child_element_counts.end() &&
+				    other_pattern.child_element_counts.at(pattern.name) > 1) {
 					// This scalar element appears multiple times under another element
 					// The parent will create a LIST column, so skip this individual element
 					appears_in_homogeneous_collection = true;
 					break;
 				}
 			}
-			
+
 			if (appears_in_homogeneous_collection) {
 				continue;
 			}
 		}
-		
+
 		// Determine the appropriate type using 4-tier priority system
 		XMLTier tier = pattern.GetTier();
-		
+
 		switch (tier) {
-			case XMLTier::HOMOGENEOUS_CONFORMING:
-				// Can map to clean DuckDB types (SCALAR, LIST, STRUCT)
-				if (pattern.is_scalar) {
-					column_type = InferTypeFromSamples(pattern.sample_values, options);
-				} else {
-					column_type = InferNestedType(pattern, pattern_map, options);
-				}
-				should_create_column = true;
-				break;
-				
-			case XMLTier::HETEROGENEOUS_CONFORMING:
-				// Extractable but inconsistent structure - try nested types first
+		case XMLTier::HOMOGENEOUS_CONFORMING:
+			// Can map to clean DuckDB types (SCALAR, LIST, STRUCT)
+			if (pattern.is_scalar) {
+				column_type = InferTypeFromSamples(pattern.sample_values, options);
+			} else {
 				column_type = InferNestedType(pattern, pattern_map, options);
-				should_create_column = true;
-				break;
-				
-			case XMLTier::EXTRACTABLE_AS_FRAGMENT:
-				// Can unwrap as XMLFragment (content without parent wrapper)
-				column_type = XMLTypes::XMLFragmentType();
-				should_create_column = true;
-				break;
-				
-			case XMLTier::FALLBACK_TO_XML:
-			default:
-				// Must preserve full XML context
-				column_type = XMLTypes::XMLType();
-				should_create_column = true;
-				break;
+			}
+			should_create_column = true;
+			break;
+
+		case XMLTier::HETEROGENEOUS_CONFORMING:
+			// Extractable but inconsistent structure - try nested types first
+			column_type = InferNestedType(pattern, pattern_map, options);
+			should_create_column = true;
+			break;
+
+		case XMLTier::EXTRACTABLE_AS_FRAGMENT:
+			// Can unwrap as XMLFragment (content without parent wrapper)
+			column_type = XMLTypes::XMLFragmentType();
+			should_create_column = true;
+			break;
+
+		case XMLTier::FALLBACK_TO_XML:
+		default:
+			// Must preserve full XML context
+			column_type = XMLTypes::XMLType();
+			should_create_column = true;
+			break;
 		}
-		
+
 		if (should_create_column) {
 			auto xpath = GetElementXPath(pattern.name);
-			columns.emplace_back(pattern.name, column_type, false, xpath, 
-			                     pattern.GetFrequency(total_occurrences));
+			columns.emplace_back(pattern.name, column_type, false, xpath, pattern.GetFrequency(total_occurrences));
 		}
-		
+
 		// Create columns for attributes (if enabled)
 		if (options.include_attributes && options.attribute_mode == "columns") {
-			for (const auto& attr_pair : pattern.attribute_counts) {
+			for (const auto &attr_pair : pattern.attribute_counts) {
 				std::string attr_name = pattern.name + "_" + attr_pair.first;
 				if (!options.attribute_prefix.empty()) {
 					attr_name = options.attribute_prefix + attr_name;
 				}
-				
+
 				// For now, assume VARCHAR for attributes (could be enhanced with sampling)
 				auto xpath = GetElementXPath(pattern.name, true, attr_pair.first);
 				columns.emplace_back(attr_name, LogicalType::VARCHAR, true, xpath, 0.8);
 			}
 		}
 	}
-	
+
 	// Ensure we have at least some columns
 	if (columns.empty()) {
 		columns.emplace_back("filename", LogicalType::VARCHAR, false, "", 1.0);
 		columns.emplace_back("content", LogicalType::VARCHAR, false, "", 1.0);
 	}
-	
+
 	return columns;
 }
 
-std::vector<ElementPattern> XMLSchemaInference::AnalyzeDocumentStructure(const std::string& xml_content,
-                                                                          const XMLSchemaOptions& options) {
+std::vector<ElementPattern> XMLSchemaInference::AnalyzeDocumentStructure(const std::string &xml_content,
+                                                                         const XMLSchemaOptions &options) {
 	XMLDocRAII xml_doc(xml_content);
 	if (!xml_doc.IsValid()) {
 		return {};
 	}
-	
+
 	std::unordered_map<std::string, ElementPattern> pattern_map;
-	
+
 	// Find the root element or use specified root
 	xmlNodePtr root = xmlDocGetRootElement(xml_doc.doc);
 	if (!root) {
 		return {};
 	}
-	
+
 	// If a specific root element is specified, find it
 	if (!options.root_element.empty()) {
 		// Use XPath to find the specified root element
 		std::string xpath = "//" + options.root_element;
-		
+
 		// Suppress XPath warnings (e.g., undefined namespace prefixes)
 		xmlSetGenericErrorFunc(nullptr, XMLSilentErrorHandler);
-		
+
 		xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
-		
+
 		// Restore normal error handling
 		xmlSetGenericErrorFunc(nullptr, nullptr);
-		
+
 		if (xpath_obj && xpath_obj->nodesetval && xpath_obj->nodesetval->nodeNr > 0) {
 			root = xpath_obj->nodesetval->nodeTab[0];
 		}
-		
-		if (xpath_obj) xmlXPathFreeObject(xpath_obj);
+
+		if (xpath_obj)
+			xmlXPathFreeObject(xpath_obj);
 	}
-	
+
 	// Analyze child elements of the root
 	for (xmlNodePtr child = root->children; child; child = child->next) {
 		if (child->type == XML_ELEMENT_NODE) {
 			AnalyzeElement(child, pattern_map, options);
 		}
 	}
-	
+
 	// Second pass: compute children_have_attributes and all_children_conforming
-	for (auto& pattern_pair : pattern_map) {
-		auto& pattern = pattern_pair.second;
-		
+	for (auto &pattern_pair : pattern_map) {
+		auto &pattern = pattern_pair.second;
+
 		if (pattern.has_children) {
 			pattern.children_have_attributes = false;
 			pattern.all_children_conforming = true;
-			
+
 			// Check child attributes and consistency for proper tier detection
 			XMLTier first_child_tier = XMLTier::FALLBACK_TO_XML; // Use as invalid sentinel
 			bool children_have_consistent_tiers = true;
 			bool first_child_set = false;
-			
-			for (const auto& child_name_count : pattern.child_element_counts) {
-				const auto& child_name = child_name_count.first;
+
+			for (const auto &child_name_count : pattern.child_element_counts) {
+				const auto &child_name = child_name_count.first;
 				auto child_iter = pattern_map.find(child_name);
-				
+
 				if (child_iter != pattern_map.end()) {
-					const auto& child_pattern = child_iter->second;
-					
+					const auto &child_pattern = child_iter->second;
+
 					// Check if this child has attributes
 					if (!child_pattern.attribute_counts.empty()) {
 						pattern.children_have_attributes = true;
 					}
-					
+
 					// Check consistency: for homogeneous lists, all children must have same tier
 					XMLTier child_tier = child_pattern.GetTier();
-					
+
 					if (!first_child_set) {
 						// First child - set the expected tier
 						first_child_tier = child_tier;
@@ -239,46 +238,44 @@ std::vector<ElementPattern> XMLSchemaInference::AnalyzeDocumentStructure(const s
 					children_have_consistent_tiers = false;
 				}
 			}
-			
+
 			// Update conforming flag based on consistency check
 			pattern.all_children_conforming = children_have_consistent_tiers;
 		}
 	}
-	
+
 	// Convert map to vector and sort by frequency
 	std::vector<ElementPattern> patterns;
-	for (const auto& pair : pattern_map) {
+	for (const auto &pair : pattern_map) {
 		patterns.push_back(pair.second);
 	}
-	
-	std::sort(patterns.begin(), patterns.end(), 
-	          [](const ElementPattern& a, const ElementPattern& b) {
-		          return a.occurrence_count > b.occurrence_count;
-	          });
-	
+
+	std::sort(patterns.begin(), patterns.end(),
+	          [](const ElementPattern &a, const ElementPattern &b) { return a.occurrence_count > b.occurrence_count; });
+
 	return patterns;
 }
 
-void XMLSchemaInference::AnalyzeElement(xmlNodePtr node, std::unordered_map<std::string, ElementPattern>& patterns,
-                                        const XMLSchemaOptions& options, int32_t current_depth) {
+void XMLSchemaInference::AnalyzeElement(xmlNodePtr node, std::unordered_map<std::string, ElementPattern> &patterns,
+                                        const XMLSchemaOptions &options, int32_t current_depth) {
 	if (!node || node->type != XML_ELEMENT_NODE) {
 		return;
 	}
-	
+
 	// Optional depth limiting for performance (unlimited by default)
 	if (options.max_depth >= 0 && current_depth >= options.max_depth) {
 		return;
 	}
-	
-	std::string element_name((const char*)node->name);
-	auto& pattern = patterns[element_name];
+
+	std::string element_name((const char *)node->name);
+	auto &pattern = patterns[element_name];
 	pattern.name = element_name;
 	pattern.occurrence_count++;
-	
+
 	// Check for text content
-	xmlChar* content = xmlNodeGetContent(node);
+	xmlChar *content = xmlNodeGetContent(node);
 	if (content) {
-		std::string text_content = CleanTextContent((const char*)content);
+		std::string text_content = CleanTextContent((const char *)content);
 		if (!text_content.empty()) {
 			pattern.has_text = true;
 			if (pattern.sample_values.size() < 20) { // Limit sample size
@@ -287,41 +284,41 @@ void XMLSchemaInference::AnalyzeElement(xmlNodePtr node, std::unordered_map<std:
 		}
 		xmlFree(content);
 	}
-	
+
 	// Check for attributes
 	for (xmlAttrPtr attr = node->properties; attr; attr = attr->next) {
 		if (attr->name) {
-			std::string attr_name((const char*)attr->name);
+			std::string attr_name((const char *)attr->name);
 			pattern.attribute_counts[attr_name]++;
 		}
 	}
-	
+
 	// Check for child elements and analyze nested structure
 	bool has_element_children = false;
 	std::unordered_map<std::string, int32_t> child_counts;
 	std::vector<std::string> child_names_ordered;
-	
+
 	for (xmlNodePtr child = node->children; child; child = child->next) {
 		if (child->type == XML_ELEMENT_NODE) {
 			has_element_children = true;
-			std::string child_name((const char*)child->name);
-			
+			std::string child_name((const char *)child->name);
+
 			// Track child element frequencies
 			child_counts[child_name]++;
 			pattern.child_element_counts[child_name]++;
-			
+
 			// Track order of first occurrence for STRUCT detection
 			if (child_counts[child_name] == 1) {
 				child_names_ordered.push_back(child_name);
 			}
-			
+
 			// Recursively analyze children (but limit depth)
 			AnalyzeElement(child, patterns, options, current_depth + 1);
 		}
 	}
-	
+
 	pattern.has_children = has_element_children;
-	
+
 	// Analyze nested structure patterns
 	if (has_element_children) {
 		// Check if this looks like an array container (repeated elements of same type)
@@ -338,7 +335,7 @@ void XMLSchemaInference::AnalyzeElement(xmlNodePtr node, std::unordered_map<std:
 			// Multiple different child elements = potential STRUCT
 			// Check if structure is consistent (all children appear only once)
 			bool is_struct_like = true;
-			for (const auto& child_pair : child_counts) {
+			for (const auto &child_pair : child_counts) {
 				if (child_pair.second > 1) {
 					is_struct_like = false;
 					break;
@@ -348,52 +345,52 @@ void XMLSchemaInference::AnalyzeElement(xmlNodePtr node, std::unordered_map<std:
 				pattern.has_homogeneous_structure = true;
 			}
 		}
-		
+
 		// Store sample structure for consistency checking
 		if (pattern.child_structures.size() < 5) { // Limit samples
 			std::unordered_map<std::string, std::string> structure_sample;
-			for (const auto& child_name : child_names_ordered) {
+			for (const auto &child_name : child_names_ordered) {
 				structure_sample[child_name] = "element"; // Could enhance with type info
 			}
 			pattern.child_structures.push_back(structure_sample);
 		}
 	}
-	
+
 	// Compute flags for 6-tier priority system
 	pattern.is_scalar = pattern.has_text && !pattern.has_children;
 	pattern.has_attributes = !pattern.attribute_counts.empty();
-	
+
 	// Analyze child name patterns
 	if (pattern.has_children) {
 		pattern.all_children_same_name = (child_counts.size() == 1);
-		
+
 		// Check if all children have different names (no repeats)
 		pattern.all_children_different_name = true;
-		for (const auto& child_pair : child_counts) {
+		for (const auto &child_pair : child_counts) {
 			if (child_pair.second > 1) {
 				pattern.all_children_different_name = false;
 				break;
 			}
 		}
-		
-		// We'll compute children_have_attributes and all_children_conforming 
+
+		// We'll compute children_have_attributes and all_children_conforming
 		// in a second pass after all patterns are analyzed
 	}
 }
 
-LogicalType XMLSchemaInference::InferTypeFromSamples(const std::vector<std::string>& samples,
-                                                      const XMLSchemaOptions& options) {
+LogicalType XMLSchemaInference::InferTypeFromSamples(const std::vector<std::string> &samples,
+                                                     const XMLSchemaOptions &options) {
 	if (samples.empty()) {
 		return LogicalType::VARCHAR;
 	}
-	
+
 	std::vector<LogicalType> detected_types;
-	
-	for (const auto& sample : samples) {
+
+	for (const auto &sample : samples) {
 		if (sample.empty()) {
 			continue; // Skip empty values
 		}
-		
+
 		// Test types in order of specificity
 		if (options.boolean_detection && IsBoolean(sample)) {
 			detected_types.push_back(LogicalType::BOOLEAN);
@@ -411,30 +408,30 @@ LogicalType XMLSchemaInference::InferTypeFromSamples(const std::vector<std::stri
 			detected_types.push_back(LogicalType::VARCHAR);
 		}
 	}
-	
+
 	return GetMostSpecificType(detected_types);
 }
 
-LogicalType XMLSchemaInference::InferNestedType(const ElementPattern& pattern,
-                                                const std::unordered_map<std::string, ElementPattern>& all_patterns,
-                                                const XMLSchemaOptions& options) {
-	
+LogicalType XMLSchemaInference::InferNestedType(const ElementPattern &pattern,
+                                                const std::unordered_map<std::string, ElementPattern> &all_patterns,
+                                                const XMLSchemaOptions &options) {
+
 	// If this element doesn't have children, it's not a nested type
 	if (!pattern.has_children || pattern.child_element_counts.empty()) {
 		return LogicalType::VARCHAR; // Fallback
 	}
-	
+
 	XMLTier tier = pattern.GetTier();
-	
+
 	// Check if this is a homogeneous list (same-name children)
 	if (pattern.all_children_same_name && pattern.child_element_counts.size() == 1) {
 		// Homogeneous list - determine element type
 		auto child_name = pattern.child_element_counts.begin()->first;
 		auto child_pattern_iter = all_patterns.find(child_name);
-		
+
 		if (child_pattern_iter != all_patterns.end()) {
-			const auto& child_pattern = child_pattern_iter->second;
-			
+			const auto &child_pattern = child_pattern_iter->second;
+
 			// Recursively determine child type
 			LogicalType child_type;
 			if (child_pattern.is_scalar) {
@@ -443,20 +440,20 @@ LogicalType XMLSchemaInference::InferNestedType(const ElementPattern& pattern,
 				// Recursive nested type
 				child_type = InferNestedType(child_pattern, all_patterns, options);
 			}
-			
+
 			return LogicalType::LIST(child_type);
 		}
 	} else if (pattern.all_children_different_name) {
 		// Heterogeneous struct - different-name children
 		child_list_t<LogicalType> struct_fields;
-		
-		for (const auto& child_pair : pattern.child_element_counts) {
-			const auto& child_name = child_pair.first;
+
+		for (const auto &child_pair : pattern.child_element_counts) {
+			const auto &child_name = child_pair.first;
 			auto child_pattern_iter = all_patterns.find(child_name);
-			
+
 			if (child_pattern_iter != all_patterns.end()) {
-				const auto& child_pattern = child_pattern_iter->second;
-				
+				const auto &child_pattern = child_pattern_iter->second;
+
 				// Recursively determine child type
 				LogicalType child_type;
 				if (child_pattern.is_scalar) {
@@ -465,31 +462,30 @@ LogicalType XMLSchemaInference::InferNestedType(const ElementPattern& pattern,
 					// Recursive nested type
 					child_type = InferNestedType(child_pattern, all_patterns, options);
 				}
-				
+
 				struct_fields.push_back(make_pair(child_name, child_type));
 			}
 		}
-		
+
 		if (!struct_fields.empty()) {
 			return LogicalType::STRUCT(struct_fields);
 		}
 	}
-	
+
 	// Fallback to VARCHAR (shouldn't happen with proper tier detection)
 	return LogicalType::VARCHAR;
 }
 
-bool XMLSchemaInference::IsBoolean(const std::string& value) {
+bool XMLSchemaInference::IsBoolean(const std::string &value) {
 	std::string lower = StringUtil::Lower(value);
-	return lower == "true" || lower == "false" || 
-	       lower == "yes" || lower == "no" ||
-	       lower == "1" || lower == "0" ||
+	return lower == "true" || lower == "false" || lower == "yes" || lower == "no" || lower == "1" || lower == "0" ||
 	       lower == "on" || lower == "off";
 }
 
-bool XMLSchemaInference::IsInteger(const std::string& value) {
-	if (value.empty()) return false;
-	
+bool XMLSchemaInference::IsInteger(const std::string &value) {
+	if (value.empty())
+		return false;
+
 	try {
 		size_t pos;
 		std::stoll(value, &pos);
@@ -499,9 +495,10 @@ bool XMLSchemaInference::IsInteger(const std::string& value) {
 	}
 }
 
-bool XMLSchemaInference::IsDouble(const std::string& value) {
-	if (value.empty()) return false;
-	
+bool XMLSchemaInference::IsDouble(const std::string &value) {
+	if (value.empty())
+		return false;
+
 	try {
 		size_t pos;
 		std::stod(value, &pos);
@@ -511,16 +508,16 @@ bool XMLSchemaInference::IsDouble(const std::string& value) {
 	}
 }
 
-bool XMLSchemaInference::IsDate(const std::string& value) {
+bool XMLSchemaInference::IsDate(const std::string &value) {
 	// Match common date formats: YYYY-MM-DD, DD/MM/YYYY, MM/DD/YYYY, etc.
 	std::regex date_patterns[] = {
-		std::regex(R"(\d{4}-\d{2}-\d{2})"),     // YYYY-MM-DD
-		std::regex(R"(\d{2}/\d{2}/\d{4})"),     // MM/DD/YYYY or DD/MM/YYYY
-		std::regex(R"(\d{4}/\d{2}/\d{2})"),     // YYYY/MM/DD
-		std::regex(R"(\d{2}-\d{2}-\d{4})"),     // MM-DD-YYYY or DD-MM-YYYY
+	    std::regex(R"(\d{4}-\d{2}-\d{2})"), // YYYY-MM-DD
+	    std::regex(R"(\d{2}/\d{2}/\d{4})"), // MM/DD/YYYY or DD/MM/YYYY
+	    std::regex(R"(\d{4}/\d{2}/\d{2})"), // YYYY/MM/DD
+	    std::regex(R"(\d{2}-\d{2}-\d{4})"), // MM-DD-YYYY or DD-MM-YYYY
 	};
-	
-	for (const auto& pattern : date_patterns) {
+
+	for (const auto &pattern : date_patterns) {
 		if (std::regex_match(value, pattern)) {
 			return true;
 		}
@@ -528,15 +525,15 @@ bool XMLSchemaInference::IsDate(const std::string& value) {
 	return false;
 }
 
-bool XMLSchemaInference::IsTime(const std::string& value) {
+bool XMLSchemaInference::IsTime(const std::string &value) {
 	// Match time formats: HH:MM:SS, HH:MM, HH:MM:SS.sss
 	std::regex time_patterns[] = {
-		std::regex(R"(\d{2}:\d{2}:\d{2})"),           // HH:MM:SS
-		std::regex(R"(\d{2}:\d{2})"),                 // HH:MM
-		std::regex(R"(\d{2}:\d{2}:\d{2}\.\d+)"),      // HH:MM:SS.sss
+	    std::regex(R"(\d{2}:\d{2}:\d{2})"),      // HH:MM:SS
+	    std::regex(R"(\d{2}:\d{2})"),            // HH:MM
+	    std::regex(R"(\d{2}:\d{2}:\d{2}\.\d+)"), // HH:MM:SS.sss
 	};
-	
-	for (const auto& pattern : time_patterns) {
+
+	for (const auto &pattern : time_patterns) {
 		if (std::regex_match(value, pattern)) {
 			return true;
 		}
@@ -544,16 +541,16 @@ bool XMLSchemaInference::IsTime(const std::string& value) {
 	return false;
 }
 
-bool XMLSchemaInference::IsTimestamp(const std::string& value) {
+bool XMLSchemaInference::IsTimestamp(const std::string &value) {
 	// Match ISO timestamp formats and common variations
 	std::regex timestamp_patterns[] = {
-		std::regex(R"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})"),       // YYYY-MM-DDTHH:MM:SS
-		std::regex(R"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})"),       // YYYY-MM-DD HH:MM:SS
-		std::regex(R"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+)"),  // YYYY-MM-DDTHH:MM:SS.sss
-		std::regex(R"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)"),      // YYYY-MM-DDTHH:MM:SSZ
+	    std::regex(R"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})"),      // YYYY-MM-DDTHH:MM:SS
+	    std::regex(R"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})"),      // YYYY-MM-DD HH:MM:SS
+	    std::regex(R"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+)"), // YYYY-MM-DDTHH:MM:SS.sss
+	    std::regex(R"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)"),     // YYYY-MM-DDTHH:MM:SSZ
 	};
-	
-	for (const auto& pattern : timestamp_patterns) {
+
+	for (const auto &pattern : timestamp_patterns) {
 		if (std::regex_match(value, pattern)) {
 			return true;
 		}
@@ -561,8 +558,8 @@ bool XMLSchemaInference::IsTimestamp(const std::string& value) {
 	return false;
 }
 
-std::string XMLSchemaInference::GetElementXPath(const std::string& element_name, bool is_attribute,
-                                                 const std::string& attribute_name) {
+std::string XMLSchemaInference::GetElementXPath(const std::string &element_name, bool is_attribute,
+                                                const std::string &attribute_name) {
 	if (is_attribute) {
 		return "//" + element_name + "/@" + attribute_name;
 	} else {
@@ -570,77 +567,77 @@ std::string XMLSchemaInference::GetElementXPath(const std::string& element_name,
 	}
 }
 
-LogicalType XMLSchemaInference::GetMostSpecificType(const std::vector<LogicalType>& types) {
+LogicalType XMLSchemaInference::GetMostSpecificType(const std::vector<LogicalType> &types) {
 	if (types.empty()) {
 		return LogicalType::VARCHAR;
 	}
-	
+
 	// Count occurrences of each type
 	std::unordered_map<LogicalTypeId, int> type_counts;
-	for (const auto& type : types) {
+	for (const auto &type : types) {
 		type_counts[type.id()]++;
 	}
-	
+
 	// If more than 80% of values are the same type, use that type
 	double threshold = 0.8;
 	int total = types.size();
-	
-	for (const auto& pair : type_counts) {
+
+	for (const auto &pair : type_counts) {
 		if (static_cast<double>(pair.second) / total >= threshold) {
 			return LogicalType(pair.first);
 		}
 	}
-	
+
 	// Fallback: if we have mixed types, prefer VARCHAR for safety
 	return LogicalType::VARCHAR;
 }
 
-std::string XMLSchemaInference::CleanTextContent(const std::string& text) {
+std::string XMLSchemaInference::CleanTextContent(const std::string &text) {
 	// Remove leading/trailing whitespace and normalize
 	std::string cleaned = text;
 	StringUtil::Trim(cleaned);
-	
+
 	// Remove excessive whitespace
 	std::regex multiple_spaces(R"(\s+)");
 	cleaned = std::regex_replace(cleaned, multiple_spaces, " ");
-	
+
 	return cleaned;
 }
 
-std::vector<std::vector<Value>> XMLSchemaInference::ExtractData(const std::string& xml_content,
-                                                                const XMLSchemaOptions& options) {
+std::vector<std::vector<Value>> XMLSchemaInference::ExtractData(const std::string &xml_content,
+                                                                const XMLSchemaOptions &options) {
 	std::vector<std::vector<Value>> rows;
-	
+
 	// First, infer the schema to know what columns we need to extract
 	auto schema = InferSchema(xml_content, options);
-	
+
 	if (schema.empty()) {
 		return rows; // No data to extract
 	}
-	
+
 	// Parse XML document
 	XMLDocRAII doc(xml_content);
 	if (!doc.IsValid()) {
 		return rows; // Invalid XML
 	}
-	
+
 	xmlNodePtr root = xmlDocGetRootElement(doc.doc);
 	if (!root) {
 		return rows; // No root element
 	}
-	
+
 	// Find the repeating element pattern (e.g., "employee" elements in the employees.xml)
 	// For now, assume the first child elements are the records
 	xmlNodePtr current = root->children;
-	
+
 	while (current) {
 		if (current->type == XML_ELEMENT_NODE) {
 			// Extract data for this record
 			std::vector<Value> row;
-			
-			for (const auto& column : schema) {
+
+			for (const auto &column : schema) {
 				Value value;
-				
+
 				if (column.is_attribute) {
 					// Extract attribute value
 					std::string attr_name = column.name;
@@ -649,10 +646,10 @@ std::vector<std::vector<Value>> XMLSchemaInference::ExtractData(const std::strin
 					if (underscore_pos != std::string::npos) {
 						attr_name = attr_name.substr(underscore_pos + 1);
 					}
-					
-					xmlChar* attr_value = xmlGetProp(current, (const xmlChar*)attr_name.c_str());
+
+					xmlChar *attr_value = xmlGetProp(current, (const xmlChar *)attr_name.c_str());
 					if (attr_value) {
-						std::string str_value = (const char*)attr_value;
+						std::string str_value = (const char *)attr_value;
 						value = ConvertToValue(str_value, column.type);
 						xmlFree(attr_value);
 					} else {
@@ -662,11 +659,11 @@ std::vector<std::vector<Value>> XMLSchemaInference::ExtractData(const std::strin
 					// Extract element text content
 					xmlNodePtr child = current->children;
 					std::string element_text;
-					
+
 					while (child) {
-						if (child->type == XML_ELEMENT_NODE && 
-						    xmlStrcmp(child->name, (const xmlChar*)column.name.c_str()) == 0) {
-							
+						if (child->type == XML_ELEMENT_NODE &&
+						    xmlStrcmp(child->name, (const xmlChar *)column.name.c_str()) == 0) {
+
 							// Check if this element has child elements (container) or just text
 							bool has_element_children = false;
 							for (xmlNodePtr grandchild = child->children; grandchild; grandchild = grandchild->next) {
@@ -675,39 +672,41 @@ std::vector<std::vector<Value>> XMLSchemaInference::ExtractData(const std::strin
 									break;
 								}
 							}
-							
+
 							if (has_element_children) {
 								// Container element - check for structured types first
-								if (column.type.id() == LogicalTypeId::LIST || column.type.id() == LogicalTypeId::STRUCT) {
+								if (column.type.id() == LogicalTypeId::LIST ||
+								    column.type.id() == LogicalTypeId::STRUCT) {
 									// Use structured extraction for LIST and STRUCT types
 									value = ExtractValueFromNode(child, column.type);
 									element_text = ""; // Clear element_text to avoid double processing
 									break;
 								}
-								
+
 								// Check for XML[] type
 								if (XMLTypes::IsXMLArrayType(column.type)) {
 									value = ExtractXMLArrayFromNode(child);
 									element_text = ""; // Clear element_text to avoid double processing
 									break;
 								}
-								
+
 								// Fall back to XML/XMLFragment format for unstructured types
 								bool use_fragment = (column.type.HasAlias() && column.type.GetAlias() == "xmlfragment");
-								
+
 								if (use_fragment) {
 									// XMLFragment: return unwrapped child elements
 									xmlBufferPtr buffer = xmlBufferCreate();
 									if (buffer) {
-										for (xmlNodePtr grandchild = child->children; grandchild; grandchild = grandchild->next) {
+										for (xmlNodePtr grandchild = child->children; grandchild;
+										     grandchild = grandchild->next) {
 											if (grandchild->type == XML_ELEMENT_NODE) {
 												xmlNodeDump(buffer, grandchild->doc, grandchild, 0, 1);
 											}
 										}
 										// RAII: Copy the content before freeing the buffer
-										const xmlChar* content = xmlBufferContent(buffer);
+										const xmlChar *content = xmlBufferContent(buffer);
 										if (content) {
-											element_text = std::string((const char*)content);
+											element_text = std::string((const char *)content);
 										}
 										xmlBufferFree(buffer);
 									}
@@ -717,18 +716,18 @@ std::vector<std::vector<Value>> XMLSchemaInference::ExtractData(const std::strin
 									if (buffer) {
 										xmlNodeDump(buffer, child->doc, child, 0, 1);
 										// RAII: Copy the content before freeing the buffer
-										const xmlChar* content = xmlBufferContent(buffer);
+										const xmlChar *content = xmlBufferContent(buffer);
 										if (content) {
-											element_text = std::string((const char*)content);
+											element_text = std::string((const char *)content);
 										}
 										xmlBufferFree(buffer);
 									}
 								}
 							} else {
 								// Leaf element - return text content
-								xmlChar* text_content = xmlNodeGetContent(child);
+								xmlChar *text_content = xmlNodeGetContent(child);
 								if (text_content) {
-									element_text = CleanTextContent((const char*)text_content);
+									element_text = CleanTextContent((const char *)text_content);
 									xmlFree(text_content);
 								}
 							}
@@ -736,138 +735,138 @@ std::vector<std::vector<Value>> XMLSchemaInference::ExtractData(const std::strin
 						}
 						child = child->next;
 					}
-					
+
 					// Only convert text value if we haven't already extracted a structured value
 					if (value.IsNull()) {
 						value = ConvertToValue(element_text, column.type);
 					}
 				}
-				
+
 				row.push_back(value);
 			}
-			
+
 			rows.push_back(row);
 		}
 		current = current->next;
 	}
-	
+
 	return rows;
 }
 
-std::vector<std::vector<Value>> XMLSchemaInference::ExtractDataWithSchema(const std::string& xml_content,
-                                                                           const std::vector<std::string>& column_names,
-                                                                           const std::vector<LogicalType>& column_types,
-                                                                           const XMLSchemaOptions& options) {
+std::vector<std::vector<Value>> XMLSchemaInference::ExtractDataWithSchema(const std::string &xml_content,
+                                                                          const std::vector<std::string> &column_names,
+                                                                          const std::vector<LogicalType> &column_types,
+                                                                          const XMLSchemaOptions &options) {
 	std::vector<std::vector<Value>> rows;
-	
+
 	if (column_names.size() != column_types.size()) {
 		return rows; // Mismatch in schema specification
 	}
-	
+
 	if (column_names.empty()) {
 		return rows; // No columns to extract
 	}
-	
+
 	// Parse XML document
 	XMLDocRAII doc(xml_content);
 	if (!doc.IsValid()) {
 		return rows; // Invalid XML
 	}
-	
+
 	xmlNodePtr root = xmlDocGetRootElement(doc.doc);
 	if (!root) {
 		return rows; // No root element
 	}
-	
+
 	// Find the repeating element pattern (e.g., "employee" elements)
 	// For now, assume the first child elements are the records
 	xmlNodePtr current = root->children;
-	
+
 	while (current) {
 		if (current->type == XML_ELEMENT_NODE) {
 			// Extract data for this record according to explicit schema
 			std::vector<Value> row;
-			
+
 			for (size_t col_idx = 0; col_idx < column_names.size(); col_idx++) {
-				const auto& column_name = column_names[col_idx];
-				const auto& column_type = column_types[col_idx];
-				
+				const auto &column_name = column_names[col_idx];
+				const auto &column_type = column_types[col_idx];
+
 				// Find the specific child element or attribute for this column
 				Value value;
-				
+
 				// First check if it's an attribute
-				xmlChar* attr_value = xmlGetProp(current, (const xmlChar*)column_name.c_str());
+				xmlChar *attr_value = xmlGetProp(current, (const xmlChar *)column_name.c_str());
 				if (attr_value) {
-					std::string str_value = (const char*)attr_value;
+					std::string str_value = (const char *)attr_value;
 					value = ConvertToValue(str_value, column_type);
 					xmlFree(attr_value);
 				} else {
 					// Look for child element with matching name
 					xmlNodePtr child = current->children;
 					while (child) {
-						if (child->type == XML_ELEMENT_NODE && 
-						    xmlStrcmp(child->name, (const xmlChar*)column_name.c_str()) == 0) {
+						if (child->type == XML_ELEMENT_NODE &&
+						    xmlStrcmp(child->name, (const xmlChar *)column_name.c_str()) == 0) {
 							// Found matching child element - extract recursively
 							value = ExtractValueFromNode(child, column_type);
 							break;
 						}
 						child = child->next;
 					}
-					
+
 					// If no matching child found, use NULL
 					if (child == nullptr) {
 						value = Value(column_type);
 					}
 				}
-				
+
 				row.push_back(value);
 			}
-			
+
 			rows.push_back(row);
 		}
 		current = current->next;
 	}
-	
+
 	return rows;
 }
 
-Value XMLSchemaInference::ConvertToValue(const std::string& text, const LogicalType& target_type) {
+Value XMLSchemaInference::ConvertToValue(const std::string &text, const LogicalType &target_type) {
 	if (text.empty()) {
 		return Value(); // NULL value
 	}
-	
+
 	try {
 		switch (target_type.id()) {
-			case LogicalTypeId::BOOLEAN: {
-				std::string lower = text;
-				std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-				if (lower == "true" || lower == "yes" || lower == "1" || lower == "on") {
-					return Value::BOOLEAN(true);
-				} else if (lower == "false" || lower == "no" || lower == "0" || lower == "off") {
-					return Value::BOOLEAN(false);
-				}
-				return Value(); // NULL for unrecognized boolean
+		case LogicalTypeId::BOOLEAN: {
+			std::string lower = text;
+			std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+			if (lower == "true" || lower == "yes" || lower == "1" || lower == "on") {
+				return Value::BOOLEAN(true);
+			} else if (lower == "false" || lower == "no" || lower == "0" || lower == "off") {
+				return Value::BOOLEAN(false);
 			}
-			case LogicalTypeId::INTEGER:
-				return Value::INTEGER(std::stoi(text));
-			case LogicalTypeId::BIGINT:
-				return Value::BIGINT(std::stoll(text));
-			case LogicalTypeId::DOUBLE:
-				return Value::DOUBLE(std::stod(text));
-			case LogicalTypeId::DATE: {
-				// Try to parse date - simplified for now
-				if (text.length() == 10 && text[4] == '-' && text[7] == '-') {
-					return Value::DATE(Date::FromString(text));
-				}
-				return Value(text); // Fallback to string
+			return Value(); // NULL for unrecognized boolean
+		}
+		case LogicalTypeId::INTEGER:
+			return Value::INTEGER(std::stoi(text));
+		case LogicalTypeId::BIGINT:
+			return Value::BIGINT(std::stoll(text));
+		case LogicalTypeId::DOUBLE:
+			return Value::DOUBLE(std::stod(text));
+		case LogicalTypeId::DATE: {
+			// Try to parse date - simplified for now
+			if (text.length() == 10 && text[4] == '-' && text[7] == '-') {
+				return Value::DATE(Date::FromString(text));
 			}
-			case LogicalTypeId::TIMESTAMP: {
-				// Try to parse timestamp
-				return Value::TIMESTAMP(Timestamp::FromString(text, false));
-			}
-			case LogicalTypeId::VARCHAR:
-			default:
-				return Value(text);
+			return Value(text); // Fallback to string
+		}
+		case LogicalTypeId::TIMESTAMP: {
+			// Try to parse timestamp
+			return Value::TIMESTAMP(Timestamp::FromString(text, false));
+		}
+		case LogicalTypeId::VARCHAR:
+		default:
+			return Value(text);
 		}
 	} catch (...) {
 		// If conversion fails, return as VARCHAR
@@ -875,78 +874,77 @@ Value XMLSchemaInference::ConvertToValue(const std::string& text, const LogicalT
 	}
 }
 
-Value XMLSchemaInference::ExtractValueFromNode(xmlNodePtr node, const LogicalType& target_type) {
+Value XMLSchemaInference::ExtractValueFromNode(xmlNodePtr node, const LogicalType &target_type) {
 	if (!node) {
 		return Value(); // NULL value
 	}
-	
+
 	switch (target_type.id()) {
-		case LogicalTypeId::LIST:
-			return ExtractListFromNode(node, target_type);
-		case LogicalTypeId::STRUCT:
-			return ExtractStructFromNode(node, target_type);
-		default: {
-			// For primitive types, extract text content and convert
-			xmlChar* text_content = xmlNodeGetContent(node);
-			if (text_content) {
-				std::string text = CleanTextContent((const char*)text_content);
-				xmlFree(text_content);
-				return ConvertToValue(text, target_type);
-			}
-			return Value(); // NULL value
+	case LogicalTypeId::LIST:
+		return ExtractListFromNode(node, target_type);
+	case LogicalTypeId::STRUCT:
+		return ExtractStructFromNode(node, target_type);
+	default: {
+		// For primitive types, extract text content and convert
+		xmlChar *text_content = xmlNodeGetContent(node);
+		if (text_content) {
+			std::string text = CleanTextContent((const char *)text_content);
+			xmlFree(text_content);
+			return ConvertToValue(text, target_type);
 		}
+		return Value(); // NULL value
+	}
 	}
 }
 
-Value XMLSchemaInference::ExtractStructFromNode(xmlNodePtr node, const LogicalType& struct_type) {
+Value XMLSchemaInference::ExtractStructFromNode(xmlNodePtr node, const LogicalType &struct_type) {
 	if (!node || struct_type.id() != LogicalTypeId::STRUCT) {
 		return Value(); // NULL value
 	}
-	
+
 	auto &struct_children = StructType::GetChildTypes(struct_type);
 	child_list_t<Value> struct_values;
-	
+
 	// Extract each field of the struct
-	for (const auto& field : struct_children) {
-		const auto& field_name = field.first;
-		const auto& field_type = field.second;
-		
+	for (const auto &field : struct_children) {
+		const auto &field_name = field.first;
+		const auto &field_type = field.second;
+
 		// Find child element with matching name
 		xmlNodePtr child = node->children;
 		Value field_value;
-		
+
 		while (child) {
-			if (child->type == XML_ELEMENT_NODE && 
-			    xmlStrcmp(child->name, (const xmlChar*)field_name.c_str()) == 0) {
+			if (child->type == XML_ELEMENT_NODE && xmlStrcmp(child->name, (const xmlChar *)field_name.c_str()) == 0) {
 				// Found matching child element - extract recursively
 				field_value = ExtractValueFromNode(child, field_type);
 				break;
 			}
 			child = child->next;
 		}
-		
+
 		// If field not found, use NULL
 		if (child == nullptr) {
 			field_value = Value(field_type);
 		}
-		
+
 		struct_values.push_back(make_pair(field_name, field_value));
 	}
-	
+
 	return Value::STRUCT(struct_values);
 }
 
-Value XMLSchemaInference::ExtractListFromNode(xmlNodePtr node, const LogicalType& list_type) {
+Value XMLSchemaInference::ExtractListFromNode(xmlNodePtr node, const LogicalType &list_type) {
 	if (!node || list_type.id() != LogicalTypeId::LIST) {
 		return Value(); // NULL value
 	}
-	
+
 	auto element_type = ListType::GetChildType(list_type);
 	vector<Value> list_values;
-	
+
 	// Collect all child elements of the same type
 	xmlNodePtr child = node->children;
-	
+
 	while (child) {
 		if (child->type == XML_ELEMENT_NODE) {
 			// Extract each child element according to the list element type
@@ -955,7 +953,7 @@ Value XMLSchemaInference::ExtractListFromNode(xmlNodePtr node, const LogicalType
 		}
 		child = child->next;
 	}
-	
+
 	return Value::LIST(element_type, list_values);
 }
 
@@ -963,21 +961,21 @@ Value XMLSchemaInference::ExtractXMLArrayFromNode(xmlNodePtr node) {
 	if (!node) {
 		return Value(); // NULL value
 	}
-	
+
 	vector<Value> xml_values;
 	xmlNodePtr child = node->children;
-	
+
 	while (child) {
 		if (child->type == XML_ELEMENT_NODE) {
 			// Each child element becomes a well-formed XML string
 			xmlBufferPtr buffer = xmlBufferCreate();
 			if (buffer) {
 				xmlNodeDump(buffer, child->doc, child, 0, 1);
-				
+
 				// RAII: Copy the content before freeing the buffer
-				const xmlChar* content = xmlBufferContent(buffer);
+				const xmlChar *content = xmlBufferContent(buffer);
 				if (content) {
-					std::string xml_string((const char*)content);
+					std::string xml_string((const char *)content);
 					// Create XML-typed value
 					Value xml_value(xml_string);
 					xml_values.push_back(xml_value);
@@ -987,7 +985,7 @@ Value XMLSchemaInference::ExtractXMLArrayFromNode(xmlNodePtr node) {
 		}
 		child = child->next;
 	}
-	
+
 	// Return as LIST<XML>
 	return Value::LIST(XMLTypes::XMLType(), xml_values);
 }

--- a/src/xml_types.cpp
+++ b/src/xml_types.cpp
@@ -33,19 +33,19 @@ LogicalType XMLTypes::XMLArrayType() {
 	return LogicalType::LIST(XMLType());
 }
 
-bool XMLTypes::IsXMLType(const LogicalType& type) {
+bool XMLTypes::IsXMLType(const LogicalType &type) {
 	return type.id() == LogicalTypeId::VARCHAR && type.HasAlias() && type.GetAlias() == "XML";
 }
 
-bool XMLTypes::IsXMLFragmentType(const LogicalType& type) {
+bool XMLTypes::IsXMLFragmentType(const LogicalType &type) {
 	return type.id() == LogicalTypeId::VARCHAR && type.HasAlias() && type.GetAlias() == "xmlfragment";
 }
 
-bool XMLTypes::IsXMLArrayType(const LogicalType& type) {
+bool XMLTypes::IsXMLArrayType(const LogicalType &type) {
 	return type.id() == LogicalTypeId::LIST && IsXMLType(ListType::GetChildType(type));
 }
 
-bool XMLTypes::IsHTMLType(const LogicalType& type) {
+bool XMLTypes::IsHTMLType(const LogicalType &type) {
 	return type.id() == LogicalTypeId::VARCHAR && type.HasAlias() && type.GetAlias() == "HTML";
 }
 
@@ -105,38 +105,38 @@ bool XMLTypes::HTMLToXMLCast(Vector &source, Vector &result, idx_t count, CastPa
 void XMLTypes::Register(ExtensionLoader &loader) {
 	// For now, register XML as a simple type alias
 	// This creates a user-defined type that acts like VARCHAR but with the name "XML"
-	
+
 	auto xml_type = LogicalType(LogicalType::VARCHAR);
 	xml_type.SetAlias("XML");
-	
+
 	// Register the XML type through the extension utility
 	loader.RegisterType("XML", xml_type);
-	
+
 	// Register XMLFragment type
 	auto xml_fragment_type = LogicalType(LogicalType::VARCHAR);
 	xml_fragment_type.SetAlias("XMLFragment");
 	loader.RegisterType("XMLFragment", xml_fragment_type);
-	
+
 	// Register HTML type
 	auto html_type = LogicalType(LogicalType::VARCHAR);
 	html_type.SetAlias("HTML");
 	loader.RegisterType("HTML", html_type);
-	
+
 	// Register cast functions for XML type conversion
 	loader.RegisterCastFunction(LogicalType::VARCHAR, xml_type, VarcharToXMLCast);
 	loader.RegisterCastFunction(xml_type, LogicalType::VARCHAR, XMLToVarcharCast);
-	
+
 	// Register cast functions for XMLFragment type conversion
 	loader.RegisterCastFunction(LogicalType::VARCHAR, xml_fragment_type, VarcharToXMLCast);
 	loader.RegisterCastFunction(xml_fragment_type, LogicalType::VARCHAR, XMLToVarcharCast);
 	loader.RegisterCastFunction(xml_fragment_type, xml_type, VarcharToXMLCast);
-	
+
 	// Register cast functions for HTML type conversion
 	loader.RegisterCastFunction(LogicalType::VARCHAR, html_type, VarcharToHTMLCast);
 	loader.RegisterCastFunction(html_type, LogicalType::VARCHAR, HTMLToVarcharCast);
 	loader.RegisterCastFunction(xml_type, html_type, XMLToHTMLCast);
 	loader.RegisterCastFunction(html_type, xml_type, HTMLToXMLCast);
-	
+
 	// Register JSON to XML cast (JSON extension is loaded during XML extension initialization)
 	try {
 		auto json_type = LogicalType::JSON();

--- a/src/xml_utils.cpp
+++ b/src/xml_utils.cpp
@@ -38,14 +38,14 @@ void XMLSilentSchemaErrorHandler(void *ctx, const char *msg, ...) {
 	xml_parse_error_occurred = true;
 }
 
-XMLDocRAII::XMLDocRAII(const std::string& xml_str) {
+XMLDocRAII::XMLDocRAII(const std::string &xml_str) {
 	// Reset error state
 	xml_parse_error_occurred = false;
 	xml_parse_error_message.clear();
-	
+
 	// Set error handler
 	xmlSetGenericErrorFunc(nullptr, XMLErrorHandler);
-	
+
 	// Parse the XML with default options to preserve comments and CDATA
 	xmlParserCtxtPtr parser_ctx = xmlNewParserCtxt();
 	if (parser_ctx) {
@@ -53,26 +53,26 @@ XMLDocRAII::XMLDocRAII(const std::string& xml_str) {
 		doc = xmlCtxtReadMemory(parser_ctx, xml_str.c_str(), xml_str.length(), nullptr, nullptr, 0);
 		xmlFreeParserCtxt(parser_ctx);
 	}
-	
+
 	if (doc && !xml_parse_error_occurred) {
 		xpath_ctx = xmlXPathNewContext(doc);
 	}
-	
+
 	// Reset error handler
 	xmlSetGenericErrorFunc(nullptr, nullptr);
 }
 
-XMLDocRAII::XMLDocRAII(const std::string& content, bool is_html) {
+XMLDocRAII::XMLDocRAII(const std::string &content, bool is_html) {
 	// Reset error state
 	xml_parse_error_occurred = false;
 	xml_parse_error_message.clear();
-	
+
 	// Set error handler
 	xmlSetGenericErrorFunc(nullptr, XMLErrorHandler);
-	
+
 	if (is_html) {
 		// Parse as HTML using libxml2's HTML parser
-		doc = htmlReadMemory(content.c_str(), content.length(), nullptr, nullptr, 
+		doc = htmlReadMemory(content.c_str(), content.length(), nullptr, nullptr,
 		                     HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING);
 	} else {
 		// Parse as XML (same as original constructor)
@@ -82,11 +82,11 @@ XMLDocRAII::XMLDocRAII(const std::string& content, bool is_html) {
 			xmlFreeParserCtxt(parser_ctx);
 		}
 	}
-	
+
 	if (doc && !xml_parse_error_occurred) {
 		xpath_ctx = xmlXPathNewContext(doc);
 	}
-	
+
 	// Reset error handler
 	xmlSetGenericErrorFunc(nullptr, nullptr);
 }
@@ -102,18 +102,19 @@ XMLDocRAII::~XMLDocRAII() {
 	}
 }
 
-XMLDocRAII::XMLDocRAII(XMLDocRAII&& other) noexcept 
-	: doc(other.doc), xpath_ctx(other.xpath_ctx) {
+XMLDocRAII::XMLDocRAII(XMLDocRAII &&other) noexcept : doc(other.doc), xpath_ctx(other.xpath_ctx) {
 	other.doc = nullptr;
 	other.xpath_ctx = nullptr;
 }
 
-XMLDocRAII& XMLDocRAII::operator=(XMLDocRAII&& other) noexcept {
+XMLDocRAII &XMLDocRAII::operator=(XMLDocRAII &&other) noexcept {
 	if (this != &other) {
 		// Clean up current resources
-		if (xpath_ctx) xmlXPathFreeContext(xpath_ctx);
-		if (doc) xmlFreeDoc(doc);
-		
+		if (xpath_ctx)
+			xmlXPathFreeContext(xpath_ctx);
+		if (doc)
+			xmlFreeDoc(doc);
+
 		// Move from other
 		doc = other.doc;
 		xpath_ctx = other.xpath_ctx;
@@ -132,111 +133,112 @@ void XMLUtils::CleanupLibXML() {
 	xmlCleanupParser();
 }
 
-bool XMLUtils::IsValidXML(const std::string& xml_str) {
+bool XMLUtils::IsValidXML(const std::string &xml_str) {
 	XMLDocRAII xml_doc(xml_str);
 	return xml_doc.IsValid() && !xml_parse_error_occurred;
 }
 
-bool XMLUtils::IsWellFormedXML(const std::string& xml_str) {
+bool XMLUtils::IsWellFormedXML(const std::string &xml_str) {
 	return IsValidXML(xml_str);
 }
 
 std::string XMLUtils::GetNodePath(xmlNodePtr node) {
-	if (!node) return "";
-	
+	if (!node)
+		return "";
+
 	std::vector<std::string> path_parts;
 	xmlNodePtr current = node;
-	
+
 	while (current && current->type == XML_ELEMENT_NODE) {
 		if (current->name) {
-			path_parts.insert(path_parts.begin(), std::string((const char*)current->name));
+			path_parts.insert(path_parts.begin(), std::string((const char *)current->name));
 		}
 		current = current->parent;
 	}
-	
+
 	std::string path = "/";
-	for (const auto& part : path_parts) {
+	for (const auto &part : path_parts) {
 		path += part + "/";
 	}
-	return path.substr(0, path.length() - 1);  // Remove trailing slash
+	return path.substr(0, path.length() - 1); // Remove trailing slash
 }
 
 XMLElement XMLUtils::ProcessXMLNode(xmlNodePtr node) {
 	XMLElement element;
-	
-	if (!node) return element;
-	
+
+	if (!node)
+		return element;
+
 	// Handle text nodes differently
 	if (node->type == XML_TEXT_NODE) {
 		element.name = "#text";
 		if (node->content) {
-			element.text_content = std::string((const char*)node->content);
+			element.text_content = std::string((const char *)node->content);
 		}
 		element.line_number = xmlGetLineNo(node);
 		return element;
 	}
-	
+
 	// Set name
 	if (node->name) {
-		element.name = std::string((const char*)node->name);
+		element.name = std::string((const char *)node->name);
 	}
-	
+
 	// Set text content (for element nodes, get direct text content only)
 	if (node->type == XML_ELEMENT_NODE) {
 		// Get only direct text children, not all descendants
 		for (xmlNodePtr child = node->children; child; child = child->next) {
 			if (child->type == XML_TEXT_NODE && child->content) {
-				element.text_content += std::string((const char*)child->content);
+				element.text_content += std::string((const char *)child->content);
 			}
 		}
 	} else {
-		xmlChar* content = xmlNodeGetContent(node);
+		xmlChar *content = xmlNodeGetContent(node);
 		if (content) {
-			element.text_content = std::string((const char*)content);
+			element.text_content = std::string((const char *)content);
 			xmlFree(content);
 		}
 	}
-	
+
 	// Set attributes
 	for (xmlAttrPtr attr = node->properties; attr; attr = attr->next) {
 		if (attr->name && attr->children && attr->children->content) {
-			std::string attr_name((const char*)attr->name);
-			std::string attr_value((const char*)attr->children->content);
+			std::string attr_name((const char *)attr->name);
+			std::string attr_value((const char *)attr->children->content);
 			element.attributes[attr_name] = attr_value;
 		}
 	}
-	
+
 	// Set namespace URI
 	if (node->ns && node->ns->href) {
-		element.namespace_uri = std::string((const char*)node->ns->href);
+		element.namespace_uri = std::string((const char *)node->ns->href);
 	}
-	
+
 	// Set path
 	element.path = GetNodePath(node);
-	
+
 	// Set line number
 	element.line_number = xmlGetLineNo(node);
-	
+
 	return element;
 }
 
-std::vector<XMLElement> XMLUtils::ExtractByXPath(const std::string& xml_str, const std::string& xpath) {
+std::vector<XMLElement> XMLUtils::ExtractByXPath(const std::string &xml_str, const std::string &xpath) {
 	std::vector<XMLElement> results;
-	
+
 	XMLDocRAII xml_doc(xml_str);
 	if (!xml_doc.IsValid() || !xml_doc.xpath_ctx) {
 		return results;
 	}
-	
+
 	// Suppress XPath warnings (e.g., undefined namespace prefixes)
 	xmlSetGenericErrorFunc(nullptr, XMLSilentErrorHandler);
-	
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(
-		BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
-	
+
+	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+
 	// Restore normal error handling
 	xmlSetGenericErrorFunc(nullptr, nullptr);
-	
+
 	if (xpath_obj && xpath_obj->nodesetval) {
 		for (int i = 0; i < xpath_obj->nodesetval->nodeNr; i++) {
 			xmlNodePtr node = xpath_obj->nodesetval->nodeTab[i];
@@ -245,207 +247,206 @@ std::vector<XMLElement> XMLUtils::ExtractByXPath(const std::string& xml_str, con
 			}
 		}
 	}
-	
+
 	if (xpath_obj) {
 		xmlXPathFreeObject(xpath_obj);
 	}
-	
+
 	return results;
 }
 
-std::string XMLUtils::ExtractTextByXPath(const std::string& xml_str, const std::string& xpath) {
+std::string XMLUtils::ExtractTextByXPath(const std::string &xml_str, const std::string &xpath) {
 	XMLDocRAII xml_doc(xml_str);
 	if (!xml_doc.IsValid() || !xml_doc.xpath_ctx) {
 		return "";
 	}
-	
+
 	// Suppress XPath warnings (e.g., undefined namespace prefixes)
 	xmlSetGenericErrorFunc(nullptr, XMLSilentErrorHandler);
-	
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(
-		BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
-	
+
+	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+
 	// Restore normal error handling
 	xmlSetGenericErrorFunc(nullptr, nullptr);
-	
+
 	std::string result;
 	if (xpath_obj) {
 		if (xpath_obj->nodesetval && xpath_obj->nodesetval->nodeNr > 0) {
 			xmlNodePtr node = xpath_obj->nodesetval->nodeTab[0];
 			if (node) {
-				xmlChar* content = xmlNodeGetContent(node);
+				xmlChar *content = xmlNodeGetContent(node);
 				if (content) {
-					result = std::string((const char*)content);
+					result = std::string((const char *)content);
 					xmlFree(content);
 				}
 			}
 		}
 		xmlXPathFreeObject(xpath_obj);
 	}
-	
+
 	return result;
 }
 
-std::string XMLUtils::PrettyPrintXML(const std::string& xml_str) {
+std::string XMLUtils::PrettyPrintXML(const std::string &xml_str) {
 	XMLDocRAII xml_doc(xml_str);
 	if (!xml_doc.IsValid()) {
 		return xml_str; // Return original if parsing fails
 	}
-	
-	xmlChar* formatted_str = nullptr;
+
+	xmlChar *formatted_str = nullptr;
 	int size = 0;
 	xmlDocDumpFormatMemory(xml_doc.doc, &formatted_str, &size, 1); // format=1 for pretty printing
-	
+
 	XMLCharPtr formatted_ptr(formatted_str); // DuckDB-style smart pointer
-	return formatted_ptr ? std::string(reinterpret_cast<const char*>(formatted_ptr.get())) : xml_str;
+	return formatted_ptr ? std::string(reinterpret_cast<const char *>(formatted_ptr.get())) : xml_str;
 }
 
-std::string XMLUtils::MinifyXML(const std::string& xml_str) {
+std::string XMLUtils::MinifyXML(const std::string &xml_str) {
 	XMLDocRAII xml_doc(xml_str);
 	if (!xml_doc.IsValid()) {
 		return xml_str; // Return original if parsing fails
 	}
-	
-	xmlChar* minified_str = nullptr;
+
+	xmlChar *minified_str = nullptr;
 	int size = 0;
 	xmlDocDumpMemory(xml_doc.doc, &minified_str, &size); // No formatting
-	
+
 	XMLCharPtr minified_ptr(minified_str); // DuckDB-style smart pointer
-	return minified_ptr ? std::string(reinterpret_cast<const char*>(minified_ptr.get())) : xml_str;
+	return minified_ptr ? std::string(reinterpret_cast<const char *>(minified_ptr.get())) : xml_str;
 }
 
-bool XMLUtils::ValidateXMLSchema(const std::string& xml_str, const std::string& xsd_schema) {
+bool XMLUtils::ValidateXMLSchema(const std::string &xml_str, const std::string &xsd_schema) {
 	// Suppress schema validation warnings
 	xmlSetGenericErrorFunc(nullptr, XMLSilentErrorHandler);
-	
+
 	// Parse the XSD schema using DuckDB-style smart pointers
 	XMLSchemaParserPtr parser_ctx(xmlSchemaNewMemParserCtxt(xsd_schema.c_str(), xsd_schema.length()));
 	if (!parser_ctx) {
 		xmlSetGenericErrorFunc(nullptr, nullptr);
 		return false;
 	}
-	
+
 	// Set silent error handler for schema parsing
 	xmlSchemaSetParserErrors(parser_ctx.get(), XMLSilentSchemaErrorHandler, XMLSilentSchemaErrorHandler, nullptr);
-	
+
 	XMLSchemaPtr schema(xmlSchemaParse(parser_ctx.get()));
 	if (!schema) {
 		xmlSetGenericErrorFunc(nullptr, nullptr);
 		return false;
 	}
-	
+
 	// Create validation context
 	XMLSchemaValidPtr valid_ctx(xmlSchemaNewValidCtxt(schema.get()));
 	if (!valid_ctx) {
 		xmlSetGenericErrorFunc(nullptr, nullptr);
 		return false;
 	}
-	
+
 	// Set silent error handler for validation
 	xmlSchemaSetValidErrors(valid_ctx.get(), XMLSilentSchemaErrorHandler, XMLSilentSchemaErrorHandler, nullptr);
-	
+
 	// Parse and validate the XML document
 	XMLDocRAII xml_doc(xml_str);
 	if (!xml_doc.IsValid()) {
 		xmlSetGenericErrorFunc(nullptr, nullptr);
 		return false;
 	}
-	
+
 	int validation_result = xmlSchemaValidateDoc(valid_ctx.get(), xml_doc.doc);
-	
+
 	// Restore normal error handling
 	xmlSetGenericErrorFunc(nullptr, nullptr);
-	
+
 	return (validation_result == 0);
 }
 
-std::vector<XMLComment> XMLUtils::ExtractComments(const std::string& xml_str) {
+std::vector<XMLComment> XMLUtils::ExtractComments(const std::string &xml_str) {
 	std::vector<XMLComment> comments;
 	XMLDocRAII xml_doc(xml_str);
-	
+
 	if (!xml_doc.IsValid()) {
 		return comments;
 	}
-	
+
 	std::function<void(xmlNodePtr)> traverse_comments = [&](xmlNodePtr node) {
 		for (xmlNodePtr cur = node; cur; cur = cur->next) {
 			if (cur->type == XML_COMMENT_NODE) {
 				XMLComment comment;
 				if (cur->content) {
-					comment.content = std::string((const char*)cur->content);
+					comment.content = std::string((const char *)cur->content);
 				}
 				comment.line_number = xmlGetLineNo(cur);
 				comments.push_back(comment);
 			}
-			
+
 			// Traverse children
 			if (cur->children) {
 				traverse_comments(cur->children);
 			}
 		}
 	};
-	
+
 	// Start from the document children to catch comments at document level
 	xmlNodePtr doc_children = xml_doc.doc->children;
 	if (doc_children) {
 		traverse_comments(doc_children);
 	}
-	
+
 	return comments;
 }
 
-std::vector<XMLComment> XMLUtils::ExtractCData(const std::string& xml_str) {
+std::vector<XMLComment> XMLUtils::ExtractCData(const std::string &xml_str) {
 	std::vector<XMLComment> cdata_sections;
 	XMLDocRAII xml_doc(xml_str);
-	
+
 	if (!xml_doc.IsValid()) {
 		return cdata_sections;
 	}
-	
+
 	std::function<void(xmlNodePtr)> traverse_cdata = [&](xmlNodePtr node) {
 		for (xmlNodePtr cur = node; cur; cur = cur->next) {
 			if (cur->type == XML_CDATA_SECTION_NODE) {
 				XMLComment cdata;
 				if (cur->content) {
-					cdata.content = std::string((const char*)cur->content);
+					cdata.content = std::string((const char *)cur->content);
 				}
 				cdata.line_number = xmlGetLineNo(cur);
 				cdata_sections.push_back(cdata);
 			}
-			
+
 			// Traverse children
 			if (cur->children) {
 				traverse_cdata(cur->children);
 			}
 		}
 	};
-	
+
 	// Start from the document children to catch CDATA at all levels
 	xmlNodePtr doc_children = xml_doc.doc->children;
 	if (doc_children) {
 		traverse_cdata(doc_children);
 	}
-	
+
 	return cdata_sections;
 }
 
-std::vector<XMLNamespace> XMLUtils::ExtractNamespaces(const std::string& xml_str) {
+std::vector<XMLNamespace> XMLUtils::ExtractNamespaces(const std::string &xml_str) {
 	std::vector<XMLNamespace> namespaces;
 	XMLDocRAII xml_doc(xml_str);
-	
+
 	if (!xml_doc.IsValid()) {
 		return namespaces;
 	}
-	
+
 	std::set<std::pair<std::string, std::string>> seen_namespaces;
-	
+
 	std::function<void(xmlNodePtr)> traverse_namespaces = [&](xmlNodePtr node) {
 		for (xmlNodePtr cur = node; cur; cur = cur->next) {
 			// Check node's namespace
 			if (cur->ns && cur->ns->href) {
-				std::string prefix = cur->ns->prefix ? std::string((const char*)cur->ns->prefix) : "";
-				std::string uri = std::string((const char*)cur->ns->href);
-				
+				std::string prefix = cur->ns->prefix ? std::string((const char *)cur->ns->prefix) : "";
+				std::string uri = std::string((const char *)cur->ns->href);
+
 				if (seen_namespaces.find({prefix, uri}) == seen_namespaces.end()) {
 					seen_namespaces.insert({prefix, uri});
 					XMLNamespace ns;
@@ -454,13 +455,13 @@ std::vector<XMLNamespace> XMLUtils::ExtractNamespaces(const std::string& xml_str
 					namespaces.push_back(ns);
 				}
 			}
-			
+
 			// Check namespace declarations
 			for (xmlNsPtr ns = cur->nsDef; ns; ns = ns->next) {
 				if (ns->href) {
-					std::string prefix = ns->prefix ? std::string((const char*)ns->prefix) : "";
-					std::string uri = std::string((const char*)ns->href);
-					
+					std::string prefix = ns->prefix ? std::string((const char *)ns->prefix) : "";
+					std::string uri = std::string((const char *)ns->href);
+
 					if (seen_namespaces.find({prefix, uri}) == seen_namespaces.end()) {
 						seen_namespaces.insert({prefix, uri});
 						XMLNamespace namespace_decl;
@@ -470,46 +471,46 @@ std::vector<XMLNamespace> XMLUtils::ExtractNamespaces(const std::string& xml_str
 					}
 				}
 			}
-			
+
 			// Traverse children
 			if (cur->children) {
 				traverse_namespaces(cur->children);
 			}
 		}
 	};
-	
+
 	traverse_namespaces(xmlDocGetRootElement(xml_doc.doc));
 	return namespaces;
 }
 
-XMLStats XMLUtils::GetXMLStats(const std::string& xml_str) {
+XMLStats XMLUtils::GetXMLStats(const std::string &xml_str) {
 	XMLStats stats = {0, 0, 0, 0, 0};
 	XMLDocRAII xml_doc(xml_str);
-	
+
 	if (!xml_doc.IsValid()) {
 		return stats;
 	}
-	
+
 	stats.size_bytes = xml_str.length();
 	std::set<std::string> unique_namespaces;
-	
+
 	std::function<void(xmlNodePtr, int)> traverse_stats = [&](xmlNodePtr node, int depth) {
 		stats.max_depth = std::max(stats.max_depth, (int64_t)depth);
-		
+
 		for (xmlNodePtr cur = node; cur; cur = cur->next) {
 			if (cur->type == XML_ELEMENT_NODE) {
 				stats.element_count++;
-				
+
 				// Count attributes
 				for (xmlAttrPtr attr = cur->properties; attr; attr = attr->next) {
 					stats.attribute_count++;
 				}
-				
+
 				// Track namespaces
 				if (cur->ns && cur->ns->href) {
-					unique_namespaces.insert(std::string((const char*)cur->ns->href));
+					unique_namespaces.insert(std::string((const char *)cur->ns->href));
 				}
-				
+
 				// Traverse element children only for depth calculation
 				if (cur->children) {
 					traverse_stats(cur->children, depth + 1);
@@ -517,142 +518,147 @@ XMLStats XMLUtils::GetXMLStats(const std::string& xml_str) {
 			}
 		}
 	};
-	
+
 	traverse_stats(xmlDocGetRootElement(xml_doc.doc), 1);
 	stats.namespace_count = unique_namespaces.size();
-	
+
 	return stats;
 }
 
-std::string XMLUtils::XMLToJSON(const std::string& xml_str) {
+std::string XMLUtils::XMLToJSON(const std::string &xml_str) {
 	XMLDocRAII xml_doc(xml_str);
 	if (!xml_doc.IsValid()) {
 		return "{}";
 	}
-	
+
 	std::function<std::string(xmlNodePtr, bool)> node_to_json = [&](xmlNodePtr node, bool is_root) -> std::string {
 		if (!node || node->type != XML_ELEMENT_NODE) {
 			return "null";
 		}
-		
-		std::string node_name = std::string((const char*)node->name);
+
+		std::string node_name = std::string((const char *)node->name);
 		std::string result = "{";
-		
+
 		// Add attributes if any
 		bool has_content = false;
 		for (xmlAttrPtr attr = node->properties; attr; attr = attr->next) {
-			if (has_content) result += ",";
-			std::string attr_name = std::string((const char*)attr->name);
-			
+			if (has_content)
+				result += ",";
+			std::string attr_name = std::string((const char *)attr->name);
+
 			XMLCharPtr attr_value(xmlNodeListGetString(xml_doc.doc, attr->children, 1)); // DuckDB-style smart pointer
-			std::string attr_val = attr_value ? std::string(reinterpret_cast<const char*>(attr_value.get())) : "";
-			
+			std::string attr_val = attr_value ? std::string(reinterpret_cast<const char *>(attr_value.get())) : "";
+
 			result += "\"@" + attr_name + "\":\"" + attr_val + "\"";
 			has_content = true;
 		}
-		
+
 		// Get direct text content only (not including children text)
 		std::string direct_text;
 		for (xmlNodePtr child = node->children; child; child = child->next) {
 			if (child->type == XML_TEXT_NODE && child->content) {
-				direct_text += std::string((const char*)child->content);
+				direct_text += std::string((const char *)child->content);
 			}
 		}
-		
+
 		// Clean up whitespace
 		direct_text.erase(0, direct_text.find_first_not_of(" \t\n\r"));
 		direct_text.erase(direct_text.find_last_not_of(" \t\n\r") + 1);
-		
+
 		if (!direct_text.empty()) {
-			if (has_content) result += ",";
+			if (has_content)
+				result += ",";
 			result += "\"#text\":\"" + direct_text + "\"";
 			has_content = true;
 		}
-		
+
 		// Add children elements
 		std::map<std::string, std::vector<std::string>> children_by_name;
 		for (xmlNodePtr child = node->children; child; child = child->next) {
 			if (child->type == XML_ELEMENT_NODE) {
-				std::string child_name = std::string((const char*)child->name);
+				std::string child_name = std::string((const char *)child->name);
 				std::string child_json = node_to_json(child, false);
 				children_by_name[child_name].push_back(child_json);
 			}
 		}
-		
-		for (const auto& child_group : children_by_name) {
-			if (has_content) result += ",";
-			
+
+		for (const auto &child_group : children_by_name) {
+			if (has_content)
+				result += ",";
+
 			if (child_group.second.size() == 1) {
 				result += "\"" + child_group.first + "\":" + child_group.second[0];
 			} else {
 				result += "\"" + child_group.first + "\":[";
 				for (size_t i = 0; i < child_group.second.size(); i++) {
-					if (i > 0) result += ",";
+					if (i > 0)
+						result += ",";
 					result += child_group.second[i];
 				}
 				result += "]";
 			}
 			has_content = true;
 		}
-		
+
 		result += "}";
-		
+
 		// For the root element, wrap it with the element name
 		if (is_root) {
 			return "{\"" + node_name + "\":" + result + "}";
 		}
-		
+
 		return result;
 	};
-	
+
 	xmlNodePtr root = xmlDocGetRootElement(xml_doc.doc);
 	if (root) {
 		return node_to_json(root, true);
 	}
-	
+
 	return "{}";
 }
 
-std::string XMLUtils::XMLToJSON(const std::string& xml_str, const XMLToJSONOptions& options) {
+std::string XMLUtils::XMLToJSON(const std::string &xml_str, const XMLToJSONOptions &options) {
 	XMLDocRAII xml_doc(xml_str);
 	if (!xml_doc.IsValid()) {
 		return "{}";
 	}
-	
+
 	// Create a set for fast lookup of force_list elements
 	std::unordered_set<std::string> force_list_set(options.force_list.begin(), options.force_list.end());
-	
+
 	std::function<std::string(xmlNodePtr, bool)> node_to_json = [&](xmlNodePtr node, bool is_root) -> std::string {
 		if (!node || node->type != XML_ELEMENT_NODE) {
 			return "null";
 		}
-		
+
 		// Get node name based on namespace handling mode
 		std::string node_name;
-		std::string local_name = std::string((const char*)node->name);
+		std::string local_name = std::string((const char *)node->name);
 
 		if (options.namespaces == "strip") {
 			// Strip namespaces: use local name only
 			node_name = local_name;
 		} else if (options.namespaces == "expand" && node->ns && node->ns->href) {
 			// Expand: use full URI as prefix
-			node_name = std::string((const char*)node->ns->href) + ":" + local_name;
+			node_name = std::string((const char *)node->ns->href) + ":" + local_name;
 		} else if (options.namespaces == "keep" && node->ns && node->ns->prefix) {
 			// Keep: preserve namespace prefix
-			node_name = std::string((const char*)node->ns->prefix) + ":" + local_name;
+			node_name = std::string((const char *)node->ns->prefix) + ":" + local_name;
 		} else {
 			// No namespace or keep mode without prefix
 			node_name = local_name;
 		}
-		
+
 		std::string result = "{";
-		
+
 		// Add attributes if any
 		bool has_content = false;
 		for (xmlAttrPtr attr = node->properties; attr; attr = attr->next) {
-			if (has_content) result += ",";
+			if (has_content)
+				result += ",";
 
-			std::string attr_local_name = std::string((const char*)attr->name);
+			std::string attr_local_name = std::string((const char *)attr->name);
 			std::string attr_name;
 
 			if (options.namespaces == "strip") {
@@ -660,17 +666,17 @@ std::string XMLUtils::XMLToJSON(const std::string& xml_str, const XMLToJSONOptio
 				attr_name = attr_local_name;
 			} else if (options.namespaces == "expand" && attr->ns && attr->ns->href) {
 				// Expand: use full URI as prefix
-				attr_name = std::string((const char*)attr->ns->href) + ":" + attr_local_name;
+				attr_name = std::string((const char *)attr->ns->href) + ":" + attr_local_name;
 			} else if (options.namespaces == "keep" && attr->ns && attr->ns->prefix) {
 				// Keep: preserve namespace prefix
-				attr_name = std::string((const char*)attr->ns->prefix) + ":" + attr_local_name;
+				attr_name = std::string((const char *)attr->ns->prefix) + ":" + attr_local_name;
 			} else {
 				// No namespace or keep mode without prefix
 				attr_name = attr_local_name;
 			}
 
 			XMLCharPtr attr_value(xmlNodeListGetString(xml_doc.doc, attr->children, 1));
-			std::string attr_val = attr_value ? std::string(reinterpret_cast<const char*>(attr_value.get())) : "";
+			std::string attr_val = attr_value ? std::string(reinterpret_cast<const char *>(attr_value.get())) : "";
 
 			result += "\"" + options.attr_prefix + attr_name + "\":\"" + attr_val + "\"";
 			has_content = true;
@@ -683,8 +689,8 @@ std::string XMLUtils::XMLToJSON(const std::string& xml_str, const XMLToJSONOptio
 
 			// Get all namespace definitions on this node
 			for (xmlNsPtr ns = node->nsDef; ns; ns = ns->next) {
-				std::string prefix = ns->prefix ? std::string((const char*)ns->prefix) : "";
-				std::string href = ns->href ? std::string((const char*)ns->href) : "";
+				std::string prefix = ns->prefix ? std::string((const char *)ns->prefix) : "";
+				std::string href = ns->href ? std::string((const char *)ns->href) : "";
 				if (!href.empty()) {
 					namespaces[prefix] = href;
 				}
@@ -692,11 +698,13 @@ std::string XMLUtils::XMLToJSON(const std::string& xml_str, const XMLToJSONOptio
 
 			// Add xmlns metadata if any namespaces found
 			if (!namespaces.empty()) {
-				if (has_content) result += ",";
+				if (has_content)
+					result += ",";
 				result += "\"" + options.xmlns_key + "\":{";
 				bool first_ns = true;
-				for (const auto& ns_pair : namespaces) {
-					if (!first_ns) result += ",";
+				for (const auto &ns_pair : namespaces) {
+					if (!first_ns)
+						result += ",";
 					result += "\"" + ns_pair.first + "\":\"" + ns_pair.second + "\"";
 					first_ns = false;
 				}
@@ -704,39 +712,40 @@ std::string XMLUtils::XMLToJSON(const std::string& xml_str, const XMLToJSONOptio
 				has_content = true;
 			}
 		}
-		
+
 		// Get direct text content only (not including children text)
 		std::string direct_text;
 		for (xmlNodePtr child = node->children; child; child = child->next) {
 			if (child->type == XML_TEXT_NODE && child->content) {
-				direct_text += std::string((const char*)child->content);
+				direct_text += std::string((const char *)child->content);
 			}
 		}
-		
+
 		// Clean up whitespace
 		direct_text.erase(0, direct_text.find_first_not_of(" \t\n\r"));
 		direct_text.erase(direct_text.find_last_not_of(" \t\n\r") + 1);
-		
+
 		if (!direct_text.empty()) {
-			if (has_content) result += ",";
+			if (has_content)
+				result += ",";
 			result += "\"" + options.text_key + "\":\"" + direct_text + "\"";
 			has_content = true;
 		}
-		
+
 		// Add children elements
 		std::map<std::string, std::vector<std::string>> children_by_name;
 		for (xmlNodePtr child = node->children; child; child = child->next) {
 			if (child->type == XML_ELEMENT_NODE) {
 				// Get child name using same namespace logic as parent
-				std::string child_local_name = std::string((const char*)child->name);
+				std::string child_local_name = std::string((const char *)child->name);
 				std::string child_name;
 
 				if (options.namespaces == "strip") {
 					child_name = child_local_name;
 				} else if (options.namespaces == "expand" && child->ns && child->ns->href) {
-					child_name = std::string((const char*)child->ns->href) + ":" + child_local_name;
+					child_name = std::string((const char *)child->ns->href) + ":" + child_local_name;
 				} else if (options.namespaces == "keep" && child->ns && child->ns->prefix) {
-					child_name = std::string((const char*)child->ns->prefix) + ":" + child_local_name;
+					child_name = std::string((const char *)child->ns->prefix) + ":" + child_local_name;
 				} else {
 					child_name = child_local_name;
 				}
@@ -745,17 +754,19 @@ std::string XMLUtils::XMLToJSON(const std::string& xml_str, const XMLToJSONOptio
 				children_by_name[child_name].push_back(child_json);
 			}
 		}
-		
-		for (const auto& child_group : children_by_name) {
-			if (has_content) result += ",";
-			
+
+		for (const auto &child_group : children_by_name) {
+			if (has_content)
+				result += ",";
+
 			// Check if this element should be forced to a list OR has multiple instances
 			bool should_be_array = force_list_set.count(child_group.first) > 0 || child_group.second.size() > 1;
-			
+
 			if (should_be_array) {
 				result += "\"" + child_group.first + "\":[";
 				for (size_t i = 0; i < child_group.second.size(); i++) {
-					if (i > 0) result += ",";
+					if (i > 0)
+						result += ",";
 					result += child_group.second[i];
 				}
 				result += "]";
@@ -764,7 +775,7 @@ std::string XMLUtils::XMLToJSON(const std::string& xml_str, const XMLToJSONOptio
 			}
 			has_content = true;
 		}
-		
+
 		// Handle empty elements if no content was added
 		if (!has_content) {
 			if (options.empty_elements == "null") {
@@ -774,55 +785,55 @@ std::string XMLUtils::XMLToJSON(const std::string& xml_str, const XMLToJSONOptio
 			}
 			// Default "object" case - return empty object
 		}
-		
+
 		result += "}";
-		
+
 		// For the root element, wrap it with the element name
 		if (is_root) {
 			return "{\"" + node_name + "\":" + result + "}";
 		}
-		
+
 		return result;
 	};
-	
+
 	xmlNodePtr root = xmlDocGetRootElement(xml_doc.doc);
 	if (root) {
 		return node_to_json(root, true);
 	}
-	
+
 	return "{}";
 }
 
-std::string XMLUtils::JSONToXML(const std::string& json_str) {
+std::string XMLUtils::JSONToXML(const std::string &json_str) {
 	if (json_str.empty() || json_str == "{}") {
 		return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root></root>";
 	}
-	
+
 	// Create a new XML document
 	XMLDocPtr doc(xmlNewDoc(BAD_CAST "1.0"));
 	if (!doc) {
 		return "<?xml version=\"1.0\"?>\n<root></root>\n";
 	}
-	
+
 	// Simple JSON parser implementation
 	// This handles basic JSON structures: objects, arrays, strings, numbers, booleans, null
-	std::function<xmlNodePtr(const std::string&, const std::string&, xmlDocPtr)> json_to_node = 
-		[&](const std::string& json_value, const std::string& node_name, xmlDocPtr document) -> xmlNodePtr {
-		
+	std::function<xmlNodePtr(const std::string &, const std::string &, xmlDocPtr)> json_to_node =
+	    [&](const std::string &json_value, const std::string &node_name, xmlDocPtr document) -> xmlNodePtr {
 		std::string trimmed = json_value;
 		// Trim whitespace
 		trimmed.erase(0, trimmed.find_first_not_of(" \t\n\r"));
 		trimmed.erase(trimmed.find_last_not_of(" \t\n\r") + 1);
-		
+
 		xmlNodePtr node = xmlNewNode(nullptr, BAD_CAST node_name.c_str());
-		if (!node) return nullptr;
-		
+		if (!node)
+			return nullptr;
+
 		if (trimmed.empty() || trimmed == "null") {
 			// Empty node for null values
 			return node;
 		}
-		
-		if (trimmed[0] == '"' && trimmed[trimmed.length()-1] == '"') {
+
+		if (trimmed[0] == '"' && trimmed[trimmed.length() - 1] == '"') {
 			// String value - remove quotes and set as text content
 			std::string str_content = trimmed.substr(1, trimmed.length() - 2);
 			xmlNodePtr text_node = xmlNewText(BAD_CAST str_content.c_str());
@@ -831,153 +842,165 @@ std::string XMLUtils::JSONToXML(const std::string& json_str) {
 			}
 			return node;
 		}
-		
-		if (trimmed[0] == '[' && trimmed[trimmed.length()-1] == ']') {
+
+		if (trimmed[0] == '[' && trimmed[trimmed.length() - 1] == ']') {
 			// Array - each element becomes a child with same name
 			std::string array_content = trimmed.substr(1, trimmed.length() - 2);
-			
+
 			// Simple array parsing
 			std::vector<std::string> elements;
 			int brace_depth = 0;
 			int bracket_depth = 0;
 			bool in_string = false;
 			size_t element_start = 0;
-			
+
 			for (size_t i = 0; i < array_content.length(); i++) {
 				char c = array_content[i];
-				
+
 				if (!in_string) {
-					if (c == '"') in_string = true;
-					else if (c == '{') brace_depth++;
-					else if (c == '}') brace_depth--;
-					else if (c == '[') bracket_depth++;
-					else if (c == ']') bracket_depth--;
+					if (c == '"')
+						in_string = true;
+					else if (c == '{')
+						brace_depth++;
+					else if (c == '}')
+						brace_depth--;
+					else if (c == '[')
+						bracket_depth++;
+					else if (c == ']')
+						bracket_depth--;
 					else if (c == ',' && brace_depth == 0 && bracket_depth == 0) {
 						elements.push_back(array_content.substr(element_start, i - element_start));
 						element_start = i + 1;
 					}
 				} else {
-					if (c == '"' && (i == 0 || array_content[i-1] != '\\')) {
+					if (c == '"' && (i == 0 || array_content[i - 1] != '\\')) {
 						in_string = false;
 					}
 				}
 			}
-			
+
 			// Add the last element
 			if (element_start < array_content.length()) {
 				elements.push_back(array_content.substr(element_start));
 			}
-			
+
 			// Convert each array element to a child node
-			for (const auto& element : elements) {
+			for (const auto &element : elements) {
 				xmlNodePtr child = json_to_node(element, node_name, document);
 				if (child) {
 					xmlAddChild(node, child);
 				}
 			}
-			
+
 			// Change parent node name to indicate it's a list
-			xmlNodeSetName(node, BAD_CAST (node_name + "_list").c_str());
+			xmlNodeSetName(node, BAD_CAST(node_name + "_list").c_str());
 			return node;
 		}
-		
-		if (trimmed[0] == '{' && trimmed[trimmed.length()-1] == '}') {
+
+		if (trimmed[0] == '{' && trimmed[trimmed.length() - 1] == '}') {
 			// Object - each property becomes a child element
 			std::string object_content = trimmed.substr(1, trimmed.length() - 2);
-			
+
 			// Simple object parsing
 			std::map<std::string, std::string> properties;
 			int brace_depth = 0;
 			int bracket_depth = 0;
 			bool in_string = false;
 			size_t prop_start = 0;
-			
+
 			for (size_t i = 0; i < object_content.length(); i++) {
 				char c = object_content[i];
-				
+
 				if (!in_string) {
-					if (c == '"') in_string = true;
-					else if (c == '{') brace_depth++;
-					else if (c == '}') brace_depth--;
-					else if (c == '[') bracket_depth++;
-					else if (c == ']') bracket_depth--;
+					if (c == '"')
+						in_string = true;
+					else if (c == '{')
+						brace_depth++;
+					else if (c == '}')
+						brace_depth--;
+					else if (c == '[')
+						bracket_depth++;
+					else if (c == ']')
+						bracket_depth--;
 					else if (c == ',' && brace_depth == 0 && bracket_depth == 0) {
 						std::string prop = object_content.substr(prop_start, i - prop_start);
-						
+
 						// Parse key:value pair
 						size_t colon_pos = prop.find(':');
 						if (colon_pos != std::string::npos) {
 							std::string key = prop.substr(0, colon_pos);
 							std::string value = prop.substr(colon_pos + 1);
-							
+
 							// Trim and remove quotes from key
 							key.erase(0, key.find_first_not_of(" \t\n\r"));
 							key.erase(key.find_last_not_of(" \t\n\r") + 1);
-							if (key.length() >= 2 && key[0] == '"' && key[key.length()-1] == '"') {
+							if (key.length() >= 2 && key[0] == '"' && key[key.length() - 1] == '"') {
 								key = key.substr(1, key.length() - 2);
 							}
-							
+
 							// Trim value
 							value.erase(0, value.find_first_not_of(" \t\n\r"));
 							value.erase(value.find_last_not_of(" \t\n\r") + 1);
-							
+
 							properties[key] = value;
 						}
-						
+
 						prop_start = i + 1;
 					}
 				} else {
-					if (c == '"' && (i == 0 || object_content[i-1] != '\\')) {
+					if (c == '"' && (i == 0 || object_content[i - 1] != '\\')) {
 						in_string = false;
 					}
 				}
 			}
-			
+
 			// Add the last property
 			if (prop_start < object_content.length()) {
 				std::string prop = object_content.substr(prop_start);
-				
+
 				size_t colon_pos = prop.find(':');
 				if (colon_pos != std::string::npos) {
 					std::string key = prop.substr(0, colon_pos);
 					std::string value = prop.substr(colon_pos + 1);
-					
+
 					// Trim and remove quotes from key
 					key.erase(0, key.find_first_not_of(" \t\n\r"));
 					key.erase(key.find_last_not_of(" \t\n\r") + 1);
-					if (key.length() >= 2 && key[0] == '"' && key[key.length()-1] == '"') {
+					if (key.length() >= 2 && key[0] == '"' && key[key.length() - 1] == '"') {
 						key = key.substr(1, key.length() - 2);
 					}
-					
+
 					// Trim value
 					value.erase(0, value.find_first_not_of(" \t\n\r"));
 					value.erase(value.find_last_not_of(" \t\n\r") + 1);
-					
+
 					properties[key] = value;
 				}
 			}
-			
+
 			// Handle properties - separate attributes from elements
 			std::string text_content;
-			
-			for (const auto& prop : properties) {
+
+			for (const auto &prop : properties) {
 				if (prop.first.length() > 0 && prop.first[0] == '@') {
 					// This is an attribute (starts with @)
 					std::string attr_name = prop.first.substr(1); // Remove @ prefix
 					std::string attr_value = prop.second;
-					
+
 					// Remove quotes from attribute value if present
-					if (attr_value.length() >= 2 && attr_value[0] == '"' && attr_value[attr_value.length()-1] == '"') {
+					if (attr_value.length() >= 2 && attr_value[0] == '"' &&
+					    attr_value[attr_value.length() - 1] == '"') {
 						attr_value = attr_value.substr(1, attr_value.length() - 2);
 					}
-					
+
 					xmlSetProp(node, BAD_CAST attr_name.c_str(), BAD_CAST attr_value.c_str());
 				} else if (prop.first == "#text") {
 					// This is text content
 					text_content = prop.second;
-					
+
 					// Remove quotes from text content if present
-					if (text_content.length() >= 2 && text_content[0] == '"' && text_content[text_content.length()-1] == '"') {
+					if (text_content.length() >= 2 && text_content[0] == '"' &&
+					    text_content[text_content.length() - 1] == '"') {
 						text_content = text_content.substr(1, text_content.length() - 2);
 					}
 				} else {
@@ -988,7 +1011,7 @@ std::string XMLUtils::JSONToXML(const std::string& json_str) {
 					}
 				}
 			}
-			
+
 			// Add text content if present
 			if (!text_content.empty()) {
 				xmlNodePtr text_node = xmlNewText(BAD_CAST text_content.c_str());
@@ -996,29 +1019,29 @@ std::string XMLUtils::JSONToXML(const std::string& json_str) {
 					xmlAddChild(node, text_node);
 				}
 			}
-			
+
 			return node;
 		}
-		
+
 		// Primitive value (number, boolean) - set as text content
 		xmlNodePtr text_node = xmlNewText(BAD_CAST trimmed.c_str());
 		if (text_node) {
 			xmlAddChild(node, text_node);
 		}
-		
+
 		return node;
 	};
-	
+
 	// Check if JSON is an object with a single key that could be the root element name
 	std::string trimmed = json_str;
 	trimmed.erase(0, trimmed.find_first_not_of(" \t\n\r"));
 	trimmed.erase(trimmed.find_last_not_of(" \t\n\r") + 1);
-	
+
 	std::string root_element_name = "root";
 	std::string actual_json_content = json_str;
-	
+
 	// Check if JSON has the pattern {"root_name": {...}} and extract it
-	if (trimmed.length() > 4 && trimmed[0] == '{' && trimmed[trimmed.length()-1] == '}') {
+	if (trimmed.length() > 4 && trimmed[0] == '{' && trimmed[trimmed.length() - 1] == '}') {
 		// Simple parsing to find first key
 		size_t first_quote = trimmed.find('"', 1);
 		if (first_quote != std::string::npos) {
@@ -1027,39 +1050,44 @@ std::string XMLUtils::JSONToXML(const std::string& json_str) {
 				size_t colon = trimmed.find(':', second_quote);
 				if (colon != std::string::npos) {
 					std::string potential_root = trimmed.substr(first_quote + 1, second_quote - first_quote - 1);
-					
+
 					// Check if the value is an object (indicating this should be the root element)
 					size_t value_start = colon + 1;
-					while (value_start < trimmed.length() && (trimmed[value_start] == ' ' || trimmed[value_start] == '\t')) {
+					while (value_start < trimmed.length() &&
+					       (trimmed[value_start] == ' ' || trimmed[value_start] == '\t')) {
 						value_start++;
 					}
-					
+
 					if (value_start < trimmed.length() && trimmed[value_start] == '{') {
 						// Find the matching closing brace
 						int brace_count = 1;
 						size_t value_end = value_start + 1;
 						bool in_string = false;
-						
+
 						while (value_end < trimmed.length() && brace_count > 0) {
 							char c = trimmed[value_end];
 							if (!in_string) {
-								if (c == '"') in_string = true;
-								else if (c == '{') brace_count++;
-								else if (c == '}') brace_count--;
+								if (c == '"')
+									in_string = true;
+								else if (c == '{')
+									brace_count++;
+								else if (c == '}')
+									brace_count--;
 							} else {
-								if (c == '"' && (value_end == 0 || trimmed[value_end-1] != '\\')) {
+								if (c == '"' && (value_end == 0 || trimmed[value_end - 1] != '\\')) {
 									in_string = false;
 								}
 							}
 							value_end++;
 						}
-						
+
 						// Check if this is the only key-value pair in the object
 						size_t remaining_start = value_end;
-						while (remaining_start < trimmed.length() && (trimmed[remaining_start] == ' ' || trimmed[remaining_start] == '\t')) {
+						while (remaining_start < trimmed.length() &&
+						       (trimmed[remaining_start] == ' ' || trimmed[remaining_start] == '\t')) {
 							remaining_start++;
 						}
-						
+
 						if (remaining_start < trimmed.length() && trimmed[remaining_start] == '}') {
 							// This is the only key, use it as root element and extract its value
 							root_element_name = potential_root;
@@ -1070,51 +1098,52 @@ std::string XMLUtils::JSONToXML(const std::string& json_str) {
 			}
 		}
 	}
-	
+
 	// Convert JSON to XML node
 	xmlNodePtr root_node = json_to_node(actual_json_content, root_element_name, doc.get());
 	if (root_node) {
 		xmlDocSetRootElement(doc.get(), root_node);
 	}
-	
+
 	// Convert to string with encoding="UTF-8"
-	xmlChar* xml_string = nullptr;
+	xmlChar *xml_string = nullptr;
 	int size = 0;
 	xmlDocDumpFormatMemoryEnc(doc.get(), &xml_string, &size, "UTF-8", 0);
-	
+
 	XMLCharPtr xml_ptr(xml_string);
-	std::string result = xml_ptr ? std::string(reinterpret_cast<const char*>(xml_ptr.get())) : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root></root>";
-	
+	std::string result = xml_ptr ? std::string(reinterpret_cast<const char *>(xml_ptr.get()))
+	                             : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root></root>";
+
 	// Remove trailing newline to match expected test format
 	if (!result.empty() && result.back() == '\n') {
 		result.pop_back();
 	}
-	
+
 	return result;
 }
 
-std::string XMLUtils::ExtractXMLFragment(const std::string& xml_str, const std::string& xpath) {
+std::string XMLUtils::ExtractXMLFragment(const std::string &xml_str, const std::string &xpath) {
 	XMLDocRAII xml_doc(xml_str);
 	if (!xml_doc.IsValid() || !xml_doc.xpath_ctx) {
 		return "";
 	}
-	
+
 	// Suppress XPath warnings (e.g., undefined namespace prefixes)
 	xmlSetGenericErrorFunc(nullptr, XMLSilentErrorHandler);
-	
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(
-		BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
-	
+
+	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+
 	// Restore normal error handling
 	xmlSetGenericErrorFunc(nullptr, nullptr);
-	
+
 	if (!xpath_obj || !xpath_obj->nodesetval) {
-		if (xpath_obj) xmlXPathFreeObject(xpath_obj);
+		if (xpath_obj)
+			xmlXPathFreeObject(xpath_obj);
 		return "";
 	}
-	
+
 	std::string fragment_xml;
-	
+
 	// Return only the first matching node
 	if (xpath_obj->nodesetval->nodeNr > 0) {
 		xmlNodePtr node = xpath_obj->nodesetval->nodeTab[0];
@@ -1126,16 +1155,16 @@ std::string XMLUtils::ExtractXMLFragment(const std::string& xml_str, const std::
 				xmlNodePtr copied_node = xmlCopyNode(node, 1); // 1 = recursive copy
 				if (copied_node) {
 					xmlDocSetRootElement(temp_doc.get(), copied_node);
-					
+
 					// Dump the node as XML string
-					xmlChar* node_str = nullptr;
+					xmlChar *node_str = nullptr;
 					int size = 0;
 					xmlDocDumpMemory(temp_doc.get(), &node_str, &size);
-					
+
 					if (node_str) {
 						XMLCharPtr node_ptr(node_str);
-						std::string node_xml = std::string(reinterpret_cast<const char*>(node_ptr.get()));
-						
+						std::string node_xml = std::string(reinterpret_cast<const char *>(node_ptr.get()));
+
 						// Remove XML declaration from individual nodes
 						size_t xml_decl_end = node_xml.find("?>");
 						if (xml_decl_end != std::string::npos) {
@@ -1143,46 +1172,46 @@ std::string XMLUtils::ExtractXMLFragment(const std::string& xml_str, const std::
 							// Remove leading whitespace/newlines
 							node_xml.erase(0, node_xml.find_first_not_of(" \t\n\r"));
 						}
-						
+
 						// Remove trailing whitespace/newlines
 						size_t end = node_xml.find_last_not_of(" \t\n\r");
 						if (end != std::string::npos) {
 							node_xml = node_xml.substr(0, end + 1);
 						}
-						
+
 						fragment_xml = node_xml;
 					}
 				}
 			}
 		}
 	}
-	
+
 	xmlXPathFreeObject(xpath_obj);
 	return fragment_xml;
 }
 
-std::string XMLUtils::ExtractXMLFragmentAll(const std::string& xml_str, const std::string& xpath) {
+std::string XMLUtils::ExtractXMLFragmentAll(const std::string &xml_str, const std::string &xpath) {
 	XMLDocRAII xml_doc(xml_str);
 	if (!xml_doc.IsValid() || !xml_doc.xpath_ctx) {
 		return "";
 	}
-	
+
 	// Suppress XPath warnings (e.g., undefined namespace prefixes)
 	xmlSetGenericErrorFunc(nullptr, XMLSilentErrorHandler);
-	
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(
-		BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
-	
+
+	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+
 	// Restore normal error handling
 	xmlSetGenericErrorFunc(nullptr, nullptr);
-	
+
 	if (!xpath_obj || !xpath_obj->nodesetval) {
-		if (xpath_obj) xmlXPathFreeObject(xpath_obj);
+		if (xpath_obj)
+			xmlXPathFreeObject(xpath_obj);
 		return "";
 	}
-	
+
 	std::string fragment_xml;
-	
+
 	// Return ALL matching nodes, separated by newlines
 	for (int i = 0; i < xpath_obj->nodesetval->nodeNr; i++) {
 		xmlNodePtr node = xpath_obj->nodesetval->nodeTab[i];
@@ -1194,16 +1223,16 @@ std::string XMLUtils::ExtractXMLFragmentAll(const std::string& xml_str, const st
 				xmlNodePtr copied_node = xmlCopyNode(node, 1); // 1 = recursive copy
 				if (copied_node) {
 					xmlDocSetRootElement(temp_doc.get(), copied_node);
-					
+
 					// Dump the node as XML string
-					xmlChar* node_str = nullptr;
+					xmlChar *node_str = nullptr;
 					int size = 0;
 					xmlDocDumpMemory(temp_doc.get(), &node_str, &size);
-					
+
 					if (node_str) {
 						XMLCharPtr node_ptr(node_str);
-						std::string node_xml = std::string(reinterpret_cast<const char*>(node_ptr.get()));
-						
+						std::string node_xml = std::string(reinterpret_cast<const char *>(node_ptr.get()));
+
 						// Remove XML declaration from individual nodes
 						size_t xml_decl_end = node_xml.find("?>");
 						if (xml_decl_end != std::string::npos) {
@@ -1211,13 +1240,13 @@ std::string XMLUtils::ExtractXMLFragmentAll(const std::string& xml_str, const st
 							// Remove leading whitespace/newlines
 							node_xml.erase(0, node_xml.find_first_not_of(" \t\n\r"));
 						}
-						
+
 						// Remove trailing whitespace/newlines
 						size_t end = node_xml.find_last_not_of(" \t\n\r");
 						if (end != std::string::npos) {
 							node_xml = node_xml.substr(0, end + 1);
 						}
-						
+
 						if (!fragment_xml.empty()) {
 							fragment_xml += "\n";
 						}
@@ -1227,86 +1256,87 @@ std::string XMLUtils::ExtractXMLFragmentAll(const std::string& xml_str, const st
 			}
 		}
 	}
-	
+
 	xmlXPathFreeObject(xpath_obj);
-	
+
 	// Add trailing newline for consistent string splitting
 	if (!fragment_xml.empty()) {
 		fragment_xml += "\n";
 	}
-	
+
 	return fragment_xml;
 }
 
-std::string XMLUtils::ScalarToXML(const std::string& value, const std::string& node_name) {
+std::string XMLUtils::ScalarToXML(const std::string &value, const std::string &node_name) {
 	// Use RAII-safe libxml2 document creation
 	XMLDocPtr doc(xmlNewDoc(BAD_CAST "1.0"));
 	if (!doc) {
 		return "<" + node_name + "></" + node_name + ">";
 	}
-	
+
 	// Create root node
 	xmlNodePtr root_node = xmlNewNode(nullptr, BAD_CAST node_name.c_str());
 	if (!root_node) {
 		return "<" + node_name + "></" + node_name + ">";
 	}
-	
+
 	xmlDocSetRootElement(doc.get(), root_node);
-	
+
 	// Add text content (libxml2 handles XML escaping automatically)
 	xmlNodePtr text_node = xmlNewText(BAD_CAST value.c_str());
 	if (text_node) {
 		xmlAddChild(root_node, text_node);
 	}
-	
+
 	// Convert to string using RAII-safe memory management
-	xmlChar* xml_string = nullptr;
+	xmlChar *xml_string = nullptr;
 	int size = 0;
 	xmlDocDumpMemory(doc.get(), &xml_string, &size);
-	
+
 	// Use XMLCharPtr for automatic cleanup
 	XMLCharPtr xml_ptr(xml_string);
-	
+
 	if (xml_ptr) {
-		return std::string(reinterpret_cast<const char*>(xml_ptr.get()));
+		return std::string(reinterpret_cast<const char *>(xml_ptr.get()));
 	} else {
 		return "<" + node_name + ">" + value + "</" + node_name + ">";
 	}
 }
 
-void XMLUtils::ConvertListToXML(Vector &input_vector, Vector &result, idx_t count, const std::string& node_name) {
+void XMLUtils::ConvertListToXML(Vector &input_vector, Vector &result, idx_t count, const std::string &node_name) {
 	auto list_suffix = "_list";
 	auto element_name = node_name;
-	
+
 	for (idx_t i = 0; i < count; i++) {
 		auto list_value = FlatVector::GetData<list_entry_t>(input_vector)[i];
 		auto &child_vector = ListVector::GetEntry(input_vector);
 		auto child_type = ListType::GetChildType(input_vector.GetType());
-		
+
 		XMLDocPtr doc(xmlNewDoc(BAD_CAST "1.0"));
 		if (!doc) {
 			result.SetValue(i, Value("<" + node_name + list_suffix + "></" + node_name + list_suffix + ">"));
 			continue;
 		}
-		
-		// Create root container element 
-		xmlNodePtr root_node = xmlNewNode(nullptr, BAD_CAST (node_name + list_suffix).c_str());
+
+		// Create root container element
+		xmlNodePtr root_node = xmlNewNode(nullptr, BAD_CAST(node_name + list_suffix).c_str());
 		xmlDocSetRootElement(doc.get(), root_node);
-		
+
 		// Process each list element
 		for (idx_t j = 0; j < list_value.length; j++) {
 			idx_t child_idx = list_value.offset + j;
-			
+
 			// Create element node for each list item
 			xmlNodePtr item_node = xmlNewNode(nullptr, BAD_CAST element_name.c_str());
 			xmlAddChild(root_node, item_node);
-			
+
 			// Convert the child value based on its type
 			if (child_type.id() == LogicalTypeId::VARCHAR) {
 				auto child_data = FlatVector::GetData<string_t>(child_vector);
 				std::string child_str = child_data[child_idx].GetString();
 				xmlNodePtr text_node = xmlNewText(BAD_CAST child_str.c_str());
-				if (text_node) xmlAddChild(item_node, text_node);
+				if (text_node)
+					xmlAddChild(item_node, text_node);
 			} else {
 				// For other types, convert recursively
 				Value child_value = child_vector.GetValue(child_idx);
@@ -1325,48 +1355,47 @@ void XMLUtils::ConvertListToXML(Vector &input_vector, Vector &result, idx_t coun
 				}
 			}
 		}
-		
+
 		// Convert document to string
-		xmlChar* xml_string = nullptr;
+		xmlChar *xml_string = nullptr;
 		int size = 0;
 		xmlDocDumpMemory(doc.get(), &xml_string, &size);
-		
+
 		XMLCharPtr xml_ptr(xml_string);
-		std::string xml_result = xml_ptr ? 
-			std::string(reinterpret_cast<const char*>(xml_ptr.get())) :
-			"<" + node_name + list_suffix + "></" + node_name + list_suffix + ">";
-		
+		std::string xml_result = xml_ptr ? std::string(reinterpret_cast<const char *>(xml_ptr.get()))
+		                                 : "<" + node_name + list_suffix + "></" + node_name + list_suffix + ">";
+
 		result.SetValue(i, Value(xml_result));
 	}
 }
 
-void XMLUtils::ConvertStructToXML(Vector &input_vector, Vector &result, idx_t count, const std::string& node_name) {
+void XMLUtils::ConvertStructToXML(Vector &input_vector, Vector &result, idx_t count, const std::string &node_name) {
 	auto struct_type = input_vector.GetType();
 	auto &child_types = StructType::GetChildTypes(struct_type);
-	
+
 	for (idx_t i = 0; i < count; i++) {
 		XMLDocPtr doc(xmlNewDoc(BAD_CAST "1.0"));
 		if (!doc) {
 			result.SetValue(i, Value("<" + node_name + "></" + node_name + ">"));
 			continue;
 		}
-		
+
 		// Create root element
 		xmlNodePtr root_node = xmlNewNode(nullptr, BAD_CAST node_name.c_str());
 		xmlDocSetRootElement(doc.get(), root_node);
-		
+
 		// Process each struct field
 		for (idx_t field_idx = 0; field_idx < child_types.size(); field_idx++) {
 			auto &field_name = child_types[field_idx].first;
 			auto &field_type = child_types[field_idx].second;
-			
+
 			// Get the child vector for this field
 			auto &field_vector = StructVector::GetEntries(input_vector)[field_idx];
-			
+
 			// Create field element
 			xmlNodePtr field_node = xmlNewNode(nullptr, BAD_CAST field_name.c_str());
 			xmlAddChild(root_node, field_node);
-			
+
 			// Get field value and convert recursively using new node-based function
 			Value field_value = field_vector->GetValue(i);
 			if (!field_value.IsNull()) {
@@ -1389,60 +1418,62 @@ void XMLUtils::ConvertStructToXML(Vector &input_vector, Vector &result, idx_t co
 				// For NULL values, field_node remains empty
 			}
 		}
-		
+
 		// Convert document to string
-		xmlChar* xml_string = nullptr;
+		xmlChar *xml_string = nullptr;
 		int size = 0;
 		xmlDocDumpMemory(doc.get(), &xml_string, &size);
-		
+
 		XMLCharPtr xml_ptr(xml_string);
-		std::string xml_result = xml_ptr ? 
-			std::string(reinterpret_cast<const char*>(xml_ptr.get())) :
-			"<" + node_name + "></" + node_name + ">";
-		
+		std::string xml_result = xml_ptr ? std::string(reinterpret_cast<const char *>(xml_ptr.get()))
+		                                 : "<" + node_name + "></" + node_name + ">";
+
 		result.SetValue(i, Value(xml_result));
 	}
 }
 
-xmlNodePtr XMLUtils::ConvertValueToXMLNode(const Value& value, const LogicalType& type, const std::string& node_name, xmlDocPtr doc) {
+xmlNodePtr XMLUtils::ConvertValueToXMLNode(const Value &value, const LogicalType &type, const std::string &node_name,
+                                           xmlDocPtr doc) {
 	if (!doc) {
 		return nullptr;
 	}
-	
+
 	// Create the main node for this value
 	xmlNodePtr node = xmlNewNode(nullptr, BAD_CAST node_name.c_str());
 	if (!node) {
 		return nullptr;
 	}
-	
+
 	if (value.IsNull()) {
 		// Empty node for NULL values
 		return node;
 	}
-	
+
 	// Handle type hierarchy similar to ValueToXMLFunction
 	if (XMLTypes::IsXMLFragmentType(type)) {
 		// XMLFragment → Insert verbatim as text
 		std::string content = value.GetValue<string>();
 		xmlNodePtr text_node = xmlNewText(BAD_CAST content.c_str());
-		if (text_node) xmlAddChild(node, text_node);
+		if (text_node)
+			xmlAddChild(node, text_node);
 		return node;
 	} else if (XMLTypes::IsXMLType(type)) {
 		// XML → Insert verbatim as text
 		std::string content = value.GetValue<string>();
 		xmlNodePtr text_node = xmlNewText(BAD_CAST content.c_str());
-		if (text_node) xmlAddChild(node, text_node);
+		if (text_node)
+			xmlAddChild(node, text_node);
 		return node;
 	} else if (type.id() == LogicalTypeId::LIST) {
 		// LIST → Create list structure with _list suffix
 		// Change node name to include _list suffix
-		xmlNodeSetName(node, BAD_CAST (node_name + "_list").c_str());
-		
+		xmlNodeSetName(node, BAD_CAST(node_name + "_list").c_str());
+
 		auto child_type = ListType::GetChildType(type);
 		auto list_value = ListValue::GetChildren(value);
-		
+
 		// Add each list element as a child node
-		for (const auto& child_value : list_value) {
+		for (const auto &child_value : list_value) {
 			xmlNodePtr child_node = ConvertValueToXMLNode(child_value, child_type, node_name, doc);
 			if (child_node) {
 				xmlAddChild(node, child_node);
@@ -1452,14 +1483,14 @@ xmlNodePtr XMLUtils::ConvertValueToXMLNode(const Value& value, const LogicalType
 	} else if (type.id() == LogicalTypeId::STRUCT) {
 		// STRUCT → Create struct with field names as tags
 		auto struct_value = StructValue::GetChildren(value);
-		auto& child_types = StructType::GetChildTypes(type);
-		
+		auto &child_types = StructType::GetChildTypes(type);
+
 		// Add each struct field as a child node
 		for (size_t i = 0; i < child_types.size(); i++) {
-			auto& field_name = child_types[i].first;
-			auto& field_type = child_types[i].second;
-			auto& field_value = struct_value[i];
-			
+			auto &field_name = child_types[i].first;
+			auto &field_type = child_types[i].second;
+			auto &field_value = struct_value[i];
+
 			xmlNodePtr field_node = ConvertValueToXMLNode(field_value, field_type, field_name, doc);
 			if (field_node) {
 				xmlAddChild(node, field_node);
@@ -1468,21 +1499,19 @@ xmlNodePtr XMLUtils::ConvertValueToXMLNode(const Value& value, const LogicalType
 		return node;
 	} else {
 		// Check if this is an explicit JSON type (has JSON alias)
-		bool is_json_type = (type.id() == LogicalTypeId::VARCHAR && 
-							 type.HasAlias() && 
-							 type.GetAlias() == "JSON");
-		
+		bool is_json_type = (type.id() == LogicalTypeId::VARCHAR && type.HasAlias() && type.GetAlias() == "JSON");
+
 		if (is_json_type) {
 			// JSON → Structural conversion
 			// For now, treat as text - could be enhanced to parse JSON and create nodes
 			std::string json_str = value.GetValue<string>();
 			std::string xml_result = JSONToXML(json_str);
-			
+
 			// Parse the XML result and add child nodes
 			xmlDocPtr temp_doc = xmlParseMemory(xml_result.c_str(), xml_result.length());
 			if (temp_doc && xmlDocGetRootElement(temp_doc)) {
 				xmlNodePtr temp_root = xmlDocGetRootElement(temp_doc);
-				
+
 				// Copy children from temp root to our node
 				xmlNodePtr child = temp_root->children;
 				while (child) {
@@ -1495,7 +1524,8 @@ xmlNodePtr XMLUtils::ConvertValueToXMLNode(const Value& value, const LogicalType
 			} else {
 				// Fallback to text
 				xmlNodePtr text_node = xmlNewText(BAD_CAST json_str.c_str());
-				if (text_node) xmlAddChild(node, text_node);
+				if (text_node)
+					xmlAddChild(node, text_node);
 			}
 			return node;
 		} else {
@@ -1506,7 +1536,7 @@ xmlNodePtr XMLUtils::ConvertValueToXMLNode(const Value& value, const LogicalType
 			} else {
 				value_str = value.ToString();
 			}
-			
+
 			// Check if input is already valid XML
 			if (type.id() == LogicalTypeId::VARCHAR && IsValidXML(value_str)) {
 				// Parse and add as child nodes
@@ -1521,12 +1551,14 @@ xmlNodePtr XMLUtils::ConvertValueToXMLNode(const Value& value, const LogicalType
 				} else {
 					// Fallback to text
 					xmlNodePtr text_node = xmlNewText(BAD_CAST value_str.c_str());
-					if (text_node) xmlAddChild(node, text_node);
+					if (text_node)
+						xmlAddChild(node, text_node);
 				}
 			} else {
 				// Simple text content
 				xmlNodePtr text_node = xmlNewText(BAD_CAST value_str.c_str());
-				if (text_node) xmlAddChild(node, text_node);
+				if (text_node)
+					xmlAddChild(node, text_node);
 			}
 			return node;
 		}
@@ -1534,289 +1566,288 @@ xmlNodePtr XMLUtils::ConvertValueToXMLNode(const Value& value, const LogicalType
 }
 
 // HTML-specific extraction functions
-std::vector<HTMLLink> XMLUtils::ExtractHTMLLinks(const std::string& html_str) {
+std::vector<HTMLLink> XMLUtils::ExtractHTMLLinks(const std::string &html_str) {
 	std::vector<HTMLLink> links;
-	
+
 	XMLDocRAII html_doc(html_str, true); // Use HTML parser
 	if (!html_doc.IsValid() || !html_doc.xpath_ctx) {
 		return links;
 	}
-	
+
 	// Find all <a> elements with href attributes
 	xmlSetGenericErrorFunc(nullptr, XMLSilentErrorHandler);
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(
-		BAD_CAST "//a[@href]", html_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST "//a[@href]", html_doc.xpath_ctx);
 	xmlSetGenericErrorFunc(nullptr, nullptr);
-	
+
 	if (!xpath_obj || !xpath_obj->nodesetval) {
-		if (xpath_obj) xmlXPathFreeObject(xpath_obj);
+		if (xpath_obj)
+			xmlXPathFreeObject(xpath_obj);
 		return links;
 	}
-	
+
 	for (int i = 0; i < xpath_obj->nodesetval->nodeNr; i++) {
 		xmlNodePtr node = xpath_obj->nodesetval->nodeTab[i];
 		if (node && node->type == XML_ELEMENT_NODE) {
 			HTMLLink link;
-			
+
 			// Get href attribute using RAII
 			XMLCharPtr href(xmlGetProp(node, BAD_CAST "href"));
 			if (href) {
-				link.url = std::string(reinterpret_cast<const char*>(href.get()));
+				link.url = std::string(reinterpret_cast<const char *>(href.get()));
 			}
-			
+
 			// Get title attribute using RAII
 			XMLCharPtr title(xmlGetProp(node, BAD_CAST "title"));
 			if (title) {
-				link.title = std::string(reinterpret_cast<const char*>(title.get()));
+				link.title = std::string(reinterpret_cast<const char *>(title.get()));
 			}
-			
+
 			// Get text content using RAII
 			XMLCharPtr text(xmlNodeGetContent(node));
 			if (text) {
-				link.text = std::string(reinterpret_cast<const char*>(text.get()));
+				link.text = std::string(reinterpret_cast<const char *>(text.get()));
 			}
-			
+
 			link.line_number = node->line;
 			links.push_back(link);
 		}
 	}
-	
+
 	xmlXPathFreeObject(xpath_obj);
 	return links;
 }
 
-std::vector<HTMLImage> XMLUtils::ExtractHTMLImages(const std::string& html_str) {
+std::vector<HTMLImage> XMLUtils::ExtractHTMLImages(const std::string &html_str) {
 	std::vector<HTMLImage> images;
-	
+
 	XMLDocRAII html_doc(html_str, true); // Use HTML parser
 	if (!html_doc.IsValid() || !html_doc.xpath_ctx) {
 		return images;
 	}
-	
+
 	// Find all <img> elements
 	xmlSetGenericErrorFunc(nullptr, XMLSilentErrorHandler);
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(
-		BAD_CAST "//img", html_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST "//img", html_doc.xpath_ctx);
 	xmlSetGenericErrorFunc(nullptr, nullptr);
-	
+
 	if (!xpath_obj || !xpath_obj->nodesetval) {
-		if (xpath_obj) xmlXPathFreeObject(xpath_obj);
+		if (xpath_obj)
+			xmlXPathFreeObject(xpath_obj);
 		return images;
 	}
-	
+
 	for (int i = 0; i < xpath_obj->nodesetval->nodeNr; i++) {
 		xmlNodePtr node = xpath_obj->nodesetval->nodeTab[i];
 		if (node && node->type == XML_ELEMENT_NODE) {
 			HTMLImage image;
-			
+
 			// Get src attribute using RAII
 			XMLCharPtr src(xmlGetProp(node, BAD_CAST "src"));
 			if (src) {
-				image.src = std::string(reinterpret_cast<const char*>(src.get()));
+				image.src = std::string(reinterpret_cast<const char *>(src.get()));
 			}
-			
+
 			// Get alt attribute using RAII
 			XMLCharPtr alt(xmlGetProp(node, BAD_CAST "alt"));
 			if (alt) {
-				image.alt_text = std::string(reinterpret_cast<const char*>(alt.get()));
+				image.alt_text = std::string(reinterpret_cast<const char *>(alt.get()));
 			}
-			
+
 			// Get title attribute using RAII
 			XMLCharPtr title(xmlGetProp(node, BAD_CAST "title"));
 			if (title) {
-				image.title = std::string(reinterpret_cast<const char*>(title.get()));
+				image.title = std::string(reinterpret_cast<const char *>(title.get()));
 			}
-			
+
 			// Get width attribute using RAII
 			XMLCharPtr width(xmlGetProp(node, BAD_CAST "width"));
 			if (width) {
 				try {
-					image.width = std::stoll(std::string(reinterpret_cast<const char*>(width.get())));
+					image.width = std::stoll(std::string(reinterpret_cast<const char *>(width.get())));
 				} catch (...) {
 					image.width = 0;
 				}
 			}
-			
+
 			// Get height attribute using RAII
 			XMLCharPtr height(xmlGetProp(node, BAD_CAST "height"));
 			if (height) {
 				try {
-					image.height = std::stoll(std::string(reinterpret_cast<const char*>(height.get())));
+					image.height = std::stoll(std::string(reinterpret_cast<const char *>(height.get())));
 				} catch (...) {
 					image.height = 0;
 				}
 			}
-			
+
 			image.line_number = node->line;
 			images.push_back(image);
 		}
 	}
-	
+
 	xmlXPathFreeObject(xpath_obj);
 	return images;
 }
 
-std::vector<HTMLTable> XMLUtils::ExtractHTMLTables(const std::string& html_str) {
+std::vector<HTMLTable> XMLUtils::ExtractHTMLTables(const std::string &html_str) {
 	std::vector<HTMLTable> tables;
-	
+
 	XMLDocRAII html_doc(html_str, true); // Use HTML parser
 	if (!html_doc.IsValid() || !html_doc.xpath_ctx) {
 		return tables;
 	}
-	
+
 	// Find all <table> elements
 	xmlSetGenericErrorFunc(nullptr, XMLSilentErrorHandler);
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(
-		BAD_CAST "//table", html_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST "//table", html_doc.xpath_ctx);
 	xmlSetGenericErrorFunc(nullptr, nullptr);
-	
+
 	if (!xpath_obj || !xpath_obj->nodesetval) {
-		if (xpath_obj) xmlXPathFreeObject(xpath_obj);
+		if (xpath_obj)
+			xmlXPathFreeObject(xpath_obj);
 		return tables;
 	}
-	
+
 	for (int i = 0; i < xpath_obj->nodesetval->nodeNr; i++) {
 		xmlNodePtr table_node = xpath_obj->nodesetval->nodeTab[i];
 		if (table_node && table_node->type == XML_ELEMENT_NODE) {
 			HTMLTable table;
 			table.line_number = table_node->line;
-			
+
 			// Extract header row from thead/th or first tr/th
 			xmlXPathContextPtr local_ctx = xmlXPathNewContext(html_doc.doc);
 			if (local_ctx) {
 				// Set context to this table node
 				local_ctx->node = table_node;
-				
+
 				// Look for header cells (th elements)
-				xmlXPathObjectPtr header_obj = xmlXPathEvalExpression(
-					BAD_CAST ".//thead//th | .//tr[1]//th", local_ctx);
-				
+				xmlXPathObjectPtr header_obj =
+				    xmlXPathEvalExpression(BAD_CAST ".//thead//th | .//tr[1]//th", local_ctx);
+
 				if (header_obj && header_obj->nodesetval && header_obj->nodesetval->nodeNr > 0) {
 					// Found th elements - use as headers
 					for (int j = 0; j < header_obj->nodesetval->nodeNr; j++) {
 						xmlNodePtr th_node = header_obj->nodesetval->nodeTab[j];
 						XMLCharPtr text(xmlNodeGetContent(th_node));
 						if (text) {
-							table.headers.push_back(std::string(reinterpret_cast<const char*>(text.get())));
+							table.headers.push_back(std::string(reinterpret_cast<const char *>(text.get())));
 						} else {
 							table.headers.push_back("");
 						}
 					}
 				}
-				
-				if (header_obj) xmlXPathFreeObject(header_obj);
-				
+
+				if (header_obj)
+					xmlXPathFreeObject(header_obj);
+
 				// Extract data rows (all rows for tables without th headers)
 				bool has_th_headers = !table.headers.empty();
-				std::string data_xpath = has_th_headers ? 
-					".//tbody//tr | .//tr[not(th)]" : 
-					".//tbody//tr | .//tr";
-				
-				xmlXPathObjectPtr rows_obj = xmlXPathEvalExpression(
-					BAD_CAST data_xpath.c_str(), local_ctx);
-				
+				std::string data_xpath = has_th_headers ? ".//tbody//tr | .//tr[not(th)]" : ".//tbody//tr | .//tr";
+
+				xmlXPathObjectPtr rows_obj = xmlXPathEvalExpression(BAD_CAST data_xpath.c_str(), local_ctx);
+
 				if (rows_obj && rows_obj->nodesetval) {
 					for (int j = 0; j < rows_obj->nodesetval->nodeNr; j++) {
 						xmlNodePtr row_node = rows_obj->nodesetval->nodeTab[j];
 						std::vector<std::string> row_data;
-						
+
 						// Extract td elements from this row
 						xmlXPathContextPtr row_ctx = xmlXPathNewContext(html_doc.doc);
 						if (row_ctx) {
 							row_ctx->node = row_node;
-							xmlXPathObjectPtr cells_obj = xmlXPathEvalExpression(
-								BAD_CAST ".//td", row_ctx);
-							
+							xmlXPathObjectPtr cells_obj = xmlXPathEvalExpression(BAD_CAST ".//td", row_ctx);
+
 							if (cells_obj && cells_obj->nodesetval) {
 								for (int k = 0; k < cells_obj->nodesetval->nodeNr; k++) {
 									xmlNodePtr cell_node = cells_obj->nodesetval->nodeTab[k];
 									XMLCharPtr text(xmlNodeGetContent(cell_node));
 									if (text) {
-										row_data.push_back(std::string(reinterpret_cast<const char*>(text.get())));
+										row_data.push_back(std::string(reinterpret_cast<const char *>(text.get())));
 									} else {
 										row_data.push_back("");
 									}
 								}
 							}
-							
-							if (cells_obj) xmlXPathFreeObject(cells_obj);
+
+							if (cells_obj)
+								xmlXPathFreeObject(cells_obj);
 							xmlXPathFreeContext(row_ctx);
 						}
-						
+
 						if (!row_data.empty()) {
 							table.rows.push_back(row_data);
 						}
 					}
 				}
-				
-				if (rows_obj) xmlXPathFreeObject(rows_obj);
+
+				if (rows_obj)
+					xmlXPathFreeObject(rows_obj);
 				xmlXPathFreeContext(local_ctx);
 			}
-			
+
 			// Set table metadata
 			table.num_columns = static_cast<int64_t>(table.headers.size());
 			table.num_rows = static_cast<int64_t>(table.rows.size());
-			
+
 			// Only add table if it has content
 			if (table.num_columns > 0 || table.num_rows > 0) {
 				tables.push_back(table);
 			}
 		}
 	}
-	
+
 	xmlXPathFreeObject(xpath_obj);
 	return tables;
 }
 
-std::string XMLUtils::ExtractHTMLText(const std::string& html_str, const std::string& selector) {
+std::string XMLUtils::ExtractHTMLText(const std::string &html_str, const std::string &selector) {
 	XMLDocRAII html_doc(html_str, true); // Use HTML parser
 	if (!html_doc.IsValid() || !html_doc.xpath_ctx) {
 		return "";
 	}
-	
+
 	std::string xpath = selector.empty() ? "//text()" : selector;
-	
+
 	xmlSetGenericErrorFunc(nullptr, XMLSilentErrorHandler);
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(
-		BAD_CAST xpath.c_str(), html_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), html_doc.xpath_ctx);
 	xmlSetGenericErrorFunc(nullptr, nullptr);
-	
+
 	if (!xpath_obj || !xpath_obj->nodesetval) {
-		if (xpath_obj) xmlXPathFreeObject(xpath_obj);
+		if (xpath_obj)
+			xmlXPathFreeObject(xpath_obj);
 		return "";
 	}
-	
+
 	std::string text_content;
 	for (int i = 0; i < xpath_obj->nodesetval->nodeNr; i++) {
 		xmlNodePtr node = xpath_obj->nodesetval->nodeTab[i];
 		if (node) {
 			XMLCharPtr content(xmlNodeGetContent(node));
 			if (content) {
-				text_content += std::string(reinterpret_cast<const char*>(content.get()));
+				text_content += std::string(reinterpret_cast<const char *>(content.get()));
 			}
 		}
 	}
-	
+
 	xmlXPathFreeObject(xpath_obj);
 	return text_content;
 }
 
-std::string XMLUtils::ExtractHTMLTextByXPath(const std::string& html_str, const std::string& xpath) {
+std::string XMLUtils::ExtractHTMLTextByXPath(const std::string &html_str, const std::string &xpath) {
 	XMLDocRAII html_doc(html_str, true); // Use HTML parser
 	if (!html_doc.IsValid() || !html_doc.xpath_ctx) {
 		return "";
 	}
-	
+
 	xmlSetGenericErrorFunc(nullptr, XMLSilentErrorHandler);
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(
-		BAD_CAST xpath.c_str(), html_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), html_doc.xpath_ctx);
 	xmlSetGenericErrorFunc(nullptr, nullptr);
-	
+
 	if (!xpath_obj || !xpath_obj->nodesetval) {
-		if (xpath_obj) xmlXPathFreeObject(xpath_obj);
+		if (xpath_obj)
+			xmlXPathFreeObject(xpath_obj);
 		return "";
 	}
-	
+
 	std::string text_content;
 	// Return only the first match
 	if (xpath_obj->nodesetval->nodeNr > 0) {
@@ -1824,11 +1855,11 @@ std::string XMLUtils::ExtractHTMLTextByXPath(const std::string& html_str, const 
 		if (node) {
 			XMLCharPtr content(xmlNodeGetContent(node));
 			if (content) {
-				text_content = std::string(reinterpret_cast<const char*>(content.get()));
+				text_content = std::string(reinterpret_cast<const char *>(content.get()));
 			}
 		}
 	}
-	
+
 	xmlXPathFreeObject(xpath_obj);
 	return text_content;
 }


### PR DESCRIPTION
Building on top of the new knowledge from #11 I noticed that the `clang-format` has not been used for sometime.

I created this separate commit for just formatting changes.

If you want to start using the git commit hooks and claude config from #11 then you can ensure that claude always will format the files with the rules from `.clang-format` which is inhereted from https://github.com/duckdb/extension-template