### PR TITLE
Add union_by_name parameter for read_xml() and read_html()

### DIFF
--- a/src/include/xml_reader_functions.hpp
+++ b/src/include/xml_reader_functions.hpp
@@ -7,8 +7,8 @@ namespace duckdb {
 
 // Parse mode for document reading
 enum class ParseMode {
-	XML,  // Strict XML parsing
-	HTML  // Lenient HTML parsing
+	XML, // Strict XML parsing
+	HTML // Lenient HTML parsing
 };
 
 class XMLReaderFunctions {
@@ -22,15 +22,14 @@ public:
 private:
 	// Internal unified functions (used by both XML and HTML)
 	static unique_ptr<FunctionData> ReadDocumentObjectsBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                         vector<LogicalType> &return_types, vector<string> &names,
-	                                                         ParseMode mode);
+	                                                        vector<LogicalType> &return_types, vector<string> &names,
+	                                                        ParseMode mode);
 	static unique_ptr<FunctionData> ReadDocumentBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                  vector<LogicalType> &return_types, vector<string> &names,
-	                                                  ParseMode mode);
+	                                                 vector<LogicalType> &return_types, vector<string> &names,
+	                                                 ParseMode mode);
 	static void ReadDocumentObjectsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static void ReadDocumentFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
-	static unique_ptr<GlobalTableFunctionState> ReadDocumentInit(ClientContext &context,
-	                                                              TableFunctionInitInput &input);
+	static unique_ptr<GlobalTableFunctionState> ReadDocumentInit(ClientContext &context, TableFunctionInitInput &input);
 
 	// Public XML functions (delegate to internal functions)
 	static void ReadXMLObjectsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
@@ -47,9 +46,9 @@ private:
 	// Public HTML functions (delegate to internal functions)
 	static void ReadHTMLObjectsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static unique_ptr<FunctionData> ReadHTMLObjectsBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                     vector<LogicalType> &return_types, vector<string> &names);
+	                                                    vector<LogicalType> &return_types, vector<string> &names);
 	static unique_ptr<GlobalTableFunctionState> ReadHTMLObjectsInit(ClientContext &context,
-	                                                                 TableFunctionInitInput &input);
+	                                                                TableFunctionInitInput &input);
 
 	static void ReadHTMLFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static unique_ptr<FunctionData> ReadHTMLBind(ClientContext &context, TableFunctionBindInput &input,
@@ -68,7 +67,7 @@ private:
 struct XMLReadFunctionData : public TableFunctionData {
 	vector<string> files;
 	bool ignore_errors = false;
-	idx_t max_file_size = 16777216; // 16MB default
+	idx_t max_file_size = 16777216;        // 16MB default
 	ParseMode parse_mode = ParseMode::XML; // Parsing mode (XML or HTML)
 
 	// For _objects functions
@@ -81,6 +80,9 @@ struct XMLReadFunctionData : public TableFunctionData {
 
 	// Schema inference options (for read_xml with auto schema detection)
 	XMLSchemaOptions schema_options;
+
+	// Union by name - combine files with different schemas
+	bool union_by_name = false;
 };
 
 struct XMLReadGlobalState : public GlobalTableFunctionState {

--- a/src/xml_reader_functions.cpp
+++ b/src/xml_reader_functions.cpp
@@ -18,9 +18,9 @@ namespace duckdb {
 // =============================================================================
 
 unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentObjectsBind(ClientContext &context,
-                                                                      TableFunctionBindInput &input,
-                                                                      vector<LogicalType> &return_types,
-                                                                      vector<string> &names, ParseMode mode) {
+                                                                     TableFunctionBindInput &input,
+                                                                     vector<LogicalType> &return_types,
+                                                                     vector<string> &names, ParseMode mode) {
 	auto result = make_uniq<XMLReadFunctionData>();
 	result->parse_mode = mode;
 
@@ -99,7 +99,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentObjectsBind(ClientConte
 }
 
 unique_ptr<GlobalTableFunctionState> XMLReaderFunctions::ReadDocumentInit(ClientContext &context,
-                                                                           TableFunctionInitInput &input) {
+                                                                          TableFunctionInitInput &input) {
 	auto result = make_uniq<XMLReadGlobalState>();
 	auto &bind_data = input.bind_data->Cast<XMLReadFunctionData>();
 
@@ -110,8 +110,8 @@ unique_ptr<GlobalTableFunctionState> XMLReaderFunctions::ReadDocumentInit(Client
 }
 
 unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &context, TableFunctionBindInput &input,
-                                                               vector<LogicalType> &return_types, vector<string> &names,
-                                                               ParseMode mode) {
+                                                              vector<LogicalType> &return_types, vector<string> &names,
+                                                              ParseMode mode) {
 	auto result = make_uniq<XMLReadFunctionData>();
 	result->parse_mode = mode;
 
@@ -169,6 +169,8 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 		if (kv.first == "ignore_errors") {
 			result->ignore_errors = kv.second.GetValue<bool>();
 			schema_options.ignore_errors = result->ignore_errors;
+		} else if (kv.first == "union_by_name") {
+			result->union_by_name = kv.second.GetValue<bool>();
 		} else if (kv.first == "maximum_file_size") {
 			result->max_file_size = kv.second.GetValue<idx_t>();
 			schema_options.maximum_file_size = result->max_file_size;
@@ -284,16 +286,94 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 	// Perform schema inference only if no explicit columns were provided
 	if (!has_explicit_columns) {
 		try {
-			auto first_file = result->files[0];
-			auto file_handle = fs.OpenFile(first_file, FileFlags::FILE_FLAGS_READ);
-			auto file_size = fs.GetFileSize(*file_handle);
+			// Determine which files to scan for schema inference
+			std::vector<std::string> files_to_scan;
+			if (result->union_by_name) {
+				// Scan all files to build union schema
+				files_to_scan = result->files;
+			} else {
+				// Scan only first file
+				files_to_scan.push_back(result->files[0]);
+			}
 
-			if (file_size > result->max_file_size) {
-				if (!result->ignore_errors) {
-					throw InvalidInputException("File %s exceeds maximum size limit (%llu bytes)", first_file,
-					                            result->max_file_size);
+			// Map to track all unique columns and their types across files
+			std::unordered_map<std::string, LogicalType> union_schema;
+			std::vector<std::string> column_order; // Track order of first appearance
+
+			// Scan each file for schema
+			for (const auto &file_path : files_to_scan) {
+				try {
+					auto file_handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
+					auto file_size = fs.GetFileSize(*file_handle);
+
+					if (file_size > result->max_file_size) {
+						if (!result->ignore_errors) {
+							throw InvalidInputException("File %s exceeds maximum size limit (%llu bytes)", file_path,
+							                            result->max_file_size);
+						}
+						continue; // Skip this file
+					}
+
+					// Read file content for schema inference
+					string content;
+					content.resize(file_size);
+					file_handle->Read((void *)content.data(), file_size);
+
+					// For XML mode, validate; for HTML mode, be more lenient
+					if (mode == ParseMode::XML) {
+						if (!XMLUtils::IsValidXML(content)) {
+							if (!result->ignore_errors) {
+								throw InvalidInputException("File %s contains invalid XML", file_path);
+							}
+							continue; // Skip this file
+						}
+					}
+					// HTML mode: skip validation, let libxml2's HTML parser handle malformed content
+
+					// Perform schema inference (works for both XML and HTML since both produce xmlDoc)
+					auto inferred_columns = XMLSchemaInference::InferSchema(content, schema_options);
+
+					// Merge columns into union schema
+					for (const auto &col_info : inferred_columns) {
+						auto it = union_schema.find(col_info.name);
+						if (it == union_schema.end()) {
+							// New column - add it
+							union_schema[col_info.name] = col_info.type;
+							column_order.push_back(col_info.name);
+						} else {
+							// Column exists - check if type needs to be generalized
+							// If types differ, use VARCHAR as the most general type
+							if (it->second != col_info.type) {
+								// For now, use VARCHAR for conflicting types
+								// TODO: Implement proper type widening (e.g., INTEGER -> BIGINT -> DOUBLE -> VARCHAR)
+								it->second = LogicalType::VARCHAR;
+							}
+						}
+					}
+
+				} catch (const Exception &e) {
+					if (!result->ignore_errors) {
+						throw;
+					}
+					// Skip this file and continue
 				}
-				// Fallback to simple schema based on mode
+			}
+
+			// Convert union schema to return types
+			if (!union_schema.empty()) {
+				for (const auto &col_name : column_order) {
+					names.push_back(col_name);
+					return_types.push_back(union_schema[col_name]);
+				}
+
+				// Store union schema as explicit schema for execution
+				if (result->union_by_name) {
+					result->has_explicit_schema = true;
+					result->column_names = names;
+					result->column_types = return_types;
+				}
+			} else {
+				// Fallback to simple schema if no columns were inferred
 				if (mode == ParseMode::HTML) {
 					return_types.push_back(XMLTypes::HTMLType());
 					names.push_back("html");
@@ -301,35 +381,6 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 					return_types.push_back(XMLTypes::XMLType());
 					names.push_back("xml");
 				}
-				return std::move(result);
-			}
-
-			// Read file content for schema inference
-			string content;
-			content.resize(file_size);
-			file_handle->Read((void *)content.data(), file_size);
-
-			// For XML mode, validate; for HTML mode, be more lenient
-			if (mode == ParseMode::XML) {
-				if (!XMLUtils::IsValidXML(content)) {
-					if (!result->ignore_errors) {
-						throw InvalidInputException("File %s contains invalid XML", first_file);
-					}
-					// Fallback to simple schema
-					return_types.push_back(XMLTypes::XMLType());
-					names.push_back("xml");
-					return std::move(result);
-				}
-			}
-			// HTML mode: skip validation, let libxml2's HTML parser handle malformed content
-
-			// Perform schema inference (works for both XML and HTML since both produce xmlDoc)
-			auto inferred_columns = XMLSchemaInference::InferSchema(content, schema_options);
-
-			// Convert to DuckDB schema
-			for (const auto &col_info : inferred_columns) {
-				return_types.push_back(col_info.type);
-				names.push_back(col_info.name);
 			}
 
 		} catch (const Exception &e) {
@@ -362,7 +413,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 }
 
 void XMLReaderFunctions::ReadDocumentObjectsFunction(ClientContext &context, TableFunctionInput &data_p,
-                                                      DataChunk &output) {
+                                                     DataChunk &output) {
 	auto &bind_data = data_p.bind_data->Cast<XMLReadFunctionData>();
 	auto &gstate = data_p.global_state->Cast<XMLReadGlobalState>();
 
@@ -738,6 +789,8 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context,
 		if (kv.first == "ignore_errors") {
 			result->ignore_errors = kv.second.GetValue<bool>();
 			schema_options.ignore_errors = result->ignore_errors;
+		} else if (kv.first == "union_by_name") {
+			result->union_by_name = kv.second.GetValue<bool>();
 		} else if (kv.first == "maximum_file_size") {
 			result->max_file_size = kv.second.GetValue<idx_t>();
 			schema_options.maximum_file_size = result->max_file_size;
@@ -852,44 +905,93 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context,
 	// Perform schema inference only if no explicit columns were provided
 	if (!has_explicit_columns) {
 		try {
-			auto first_file = result->files[0];
-			auto file_handle = fs.OpenFile(first_file, FileFlags::FILE_FLAGS_READ);
-			auto file_size = fs.GetFileSize(*file_handle);
-
-			if (file_size > result->max_file_size) {
-				if (!result->ignore_errors) {
-					throw InvalidInputException("File %s exceeds maximum size limit (%llu bytes)", first_file,
-					                            result->max_file_size);
-				}
-				// Fallback to simple schema
-				return_types.push_back(XMLTypes::XMLType());
-				names.push_back("xml");
-				return std::move(result);
+			// Determine which files to scan for schema inference
+			std::vector<std::string> files_to_scan;
+			if (result->union_by_name) {
+				// Scan all files to build union schema
+				files_to_scan = result->files;
+			} else {
+				// Scan only first file
+				files_to_scan.push_back(result->files[0]);
 			}
 
-			// Read file content for schema inference
-			string content;
-			content.resize(file_size);
-			file_handle->Read((void *)content.data(), file_size);
+			// Map to track all unique columns and their types across files
+			std::unordered_map<std::string, LogicalType> union_schema;
+			std::vector<std::string> column_order; // Track order of first appearance
 
-			// Validate XML
-			if (!XMLUtils::IsValidXML(content)) {
-				if (!result->ignore_errors) {
-					throw InvalidInputException("File %s contains invalid XML", first_file);
+			// Scan each file for schema
+			for (const auto &file_path : files_to_scan) {
+				try {
+					auto file_handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
+					auto file_size = fs.GetFileSize(*file_handle);
+
+					if (file_size > result->max_file_size) {
+						if (!result->ignore_errors) {
+							throw InvalidInputException("File %s exceeds maximum size limit (%llu bytes)", file_path,
+							                            result->max_file_size);
+						}
+						continue; // Skip this file
+					}
+
+					// Read file content for schema inference
+					string content;
+					content.resize(file_size);
+					file_handle->Read((void *)content.data(), file_size);
+
+					// Validate XML
+					if (!XMLUtils::IsValidXML(content)) {
+						if (!result->ignore_errors) {
+							throw InvalidInputException("File %s contains invalid XML", file_path);
+						}
+						continue; // Skip this file
+					}
+
+					// Perform schema inference
+					auto inferred_columns = XMLSchemaInference::InferSchema(content, schema_options);
+
+					// Merge columns into union schema
+					for (const auto &col_info : inferred_columns) {
+						auto it = union_schema.find(col_info.name);
+						if (it == union_schema.end()) {
+							// New column - add it
+							union_schema[col_info.name] = col_info.type;
+							column_order.push_back(col_info.name);
+						} else {
+							// Column exists - check if type needs to be generalized
+							// If types differ, use VARCHAR as the most general type
+							if (it->second != col_info.type) {
+								// For now, use VARCHAR for conflicting types
+								// TODO: Implement proper type widening (e.g., INTEGER -> BIGINT -> DOUBLE -> VARCHAR)
+								it->second = LogicalType::VARCHAR;
+							}
+						}
+					}
+
+				} catch (const Exception &e) {
+					if (!result->ignore_errors) {
+						throw;
+					}
+					// Skip this file and continue
 				}
-				// Fallback to simple schema
-				return_types.push_back(XMLTypes::XMLType());
-				names.push_back("xml");
-				return std::move(result);
 			}
 
-			// Perform schema inference
-			auto inferred_columns = XMLSchemaInference::InferSchema(content, schema_options);
+			// Convert union schema to return types
+			if (!union_schema.empty()) {
+				for (const auto &col_name : column_order) {
+					names.push_back(col_name);
+					return_types.push_back(union_schema[col_name]);
+				}
 
-			// Convert to DuckDB schema
-			for (const auto &col_info : inferred_columns) {
-				return_types.push_back(col_info.type);
-				names.push_back(col_info.name);
+				// Store union schema as explicit schema for execution
+				if (result->union_by_name) {
+					result->has_explicit_schema = true;
+					result->column_names = names;
+					result->column_types = return_types;
+				}
+			} else {
+				// Fallback to simple schema if no columns were inferred
+				return_types.push_back(XMLTypes::XMLType());
+				names.push_back("xml");
 			}
 
 		} catch (const Exception &e) {
@@ -1031,28 +1133,28 @@ unique_ptr<TableRef> XMLReaderFunctions::ReadXMLReplacement(ClientContext &conte
 // =============================================================================
 
 unique_ptr<FunctionData> XMLReaderFunctions::ReadHTMLObjectsBind(ClientContext &context, TableFunctionBindInput &input,
-                                                                  vector<LogicalType> &return_types,
-                                                                  vector<string> &names) {
+                                                                 vector<LogicalType> &return_types,
+                                                                 vector<string> &names) {
 	return ReadDocumentObjectsBind(context, input, return_types, names, ParseMode::HTML);
 }
 
 unique_ptr<GlobalTableFunctionState> XMLReaderFunctions::ReadHTMLObjectsInit(ClientContext &context,
-                                                                               TableFunctionInitInput &input) {
+                                                                             TableFunctionInitInput &input) {
 	return ReadDocumentInit(context, input);
 }
 
 void XMLReaderFunctions::ReadHTMLObjectsFunction(ClientContext &context, TableFunctionInput &data_p,
-                                                  DataChunk &output) {
+                                                 DataChunk &output) {
 	return ReadDocumentObjectsFunction(context, data_p, output);
 }
 
 unique_ptr<FunctionData> XMLReaderFunctions::ReadHTMLBind(ClientContext &context, TableFunctionBindInput &input,
-                                                           vector<LogicalType> &return_types, vector<string> &names) {
+                                                          vector<LogicalType> &return_types, vector<string> &names) {
 	return ReadDocumentBind(context, input, return_types, names, ParseMode::HTML);
 }
 
 unique_ptr<GlobalTableFunctionState> XMLReaderFunctions::ReadHTMLInit(ClientContext &context,
-                                                                       TableFunctionInitInput &input) {
+                                                                      TableFunctionInitInput &input) {
 	return ReadDocumentInit(context, input);
 }
 
@@ -1089,18 +1191,22 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	TableFunction read_xml_single("read_xml", {LogicalType::VARCHAR}, ReadXMLFunction, ReadXMLBind, ReadXMLInit);
 	read_xml_single.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
 	read_xml_single.named_parameters["maximum_file_size"] = LogicalType::BIGINT;
+	read_xml_single.named_parameters["union_by_name"] = LogicalType::BOOLEAN;
 	// Schema inference parameters
 	read_xml_single.named_parameters["root_element"] = LogicalType::VARCHAR;
-	read_xml_single.named_parameters["attr_mode"] = LogicalType::VARCHAR;       // 'columns' | 'prefixed' | 'map' | 'discard'
-	read_xml_single.named_parameters["attr_prefix"] = LogicalType::VARCHAR;     // Prefix for attributes when attr_mode='prefixed'
-	read_xml_single.named_parameters["text_key"] = LogicalType::VARCHAR;        // Key for mixed text content
-	read_xml_single.named_parameters["namespaces"] = LogicalType::VARCHAR;      // 'strip' | 'expand' | 'keep'
-	read_xml_single.named_parameters["empty_elements"] = LogicalType::VARCHAR;  // 'null' | 'string' | 'object'
+	read_xml_single.named_parameters["attr_mode"] = LogicalType::VARCHAR; // 'columns' | 'prefixed' | 'map' | 'discard'
+	read_xml_single.named_parameters["attr_prefix"] =
+	    LogicalType::VARCHAR; // Prefix for attributes when attr_mode='prefixed'
+	read_xml_single.named_parameters["text_key"] = LogicalType::VARCHAR;       // Key for mixed text content
+	read_xml_single.named_parameters["namespaces"] = LogicalType::VARCHAR;     // 'strip' | 'expand' | 'keep'
+	read_xml_single.named_parameters["empty_elements"] = LogicalType::VARCHAR; // 'null' | 'string' | 'object'
 	read_xml_single.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
 	read_xml_single.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_xml_single.named_parameters["unnest_as"] = LogicalType::VARCHAR; // 'columns' (default) or 'struct' (future)
-	read_xml_single.named_parameters["record_element"] = LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
-	read_xml_single.named_parameters["force_list"] = LogicalType::ANY; // VARCHAR or LIST(VARCHAR): element names that should always be LIST type
+	read_xml_single.named_parameters["record_element"] =
+	    LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
+	read_xml_single.named_parameters["force_list"] =
+	    LogicalType::ANY; // VARCHAR or LIST(VARCHAR): element names that should always be LIST type
 	// Explicit schema specification (like JSON extension)
 	read_xml_single.named_parameters["columns"] = LogicalType::ANY;
 	read_xml_set.AddFunction(read_xml_single);
@@ -1110,18 +1216,22 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	                             ReadXMLInit);
 	read_xml_array.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
 	read_xml_array.named_parameters["maximum_file_size"] = LogicalType::BIGINT;
+	read_xml_array.named_parameters["union_by_name"] = LogicalType::BOOLEAN;
 	// Schema inference parameters
 	read_xml_array.named_parameters["root_element"] = LogicalType::VARCHAR;
-	read_xml_array.named_parameters["attr_mode"] = LogicalType::VARCHAR;       // 'columns' | 'prefixed' | 'map' | 'discard'
-	read_xml_array.named_parameters["attr_prefix"] = LogicalType::VARCHAR;     // Prefix for attributes when attr_mode='prefixed'
-	read_xml_array.named_parameters["text_key"] = LogicalType::VARCHAR;        // Key for mixed text content
-	read_xml_array.named_parameters["namespaces"] = LogicalType::VARCHAR;      // 'strip' | 'expand' | 'keep'
-	read_xml_array.named_parameters["empty_elements"] = LogicalType::VARCHAR;  // 'null' | 'string' | 'object'
+	read_xml_array.named_parameters["attr_mode"] = LogicalType::VARCHAR; // 'columns' | 'prefixed' | 'map' | 'discard'
+	read_xml_array.named_parameters["attr_prefix"] =
+	    LogicalType::VARCHAR; // Prefix for attributes when attr_mode='prefixed'
+	read_xml_array.named_parameters["text_key"] = LogicalType::VARCHAR;       // Key for mixed text content
+	read_xml_array.named_parameters["namespaces"] = LogicalType::VARCHAR;     // 'strip' | 'expand' | 'keep'
+	read_xml_array.named_parameters["empty_elements"] = LogicalType::VARCHAR; // 'null' | 'string' | 'object'
 	read_xml_array.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
 	read_xml_array.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_xml_array.named_parameters["unnest_as"] = LogicalType::VARCHAR; // 'columns' (default) or 'struct' (future)
-	read_xml_array.named_parameters["record_element"] = LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
-	read_xml_array.named_parameters["force_list"] = LogicalType::ANY; // VARCHAR or LIST(VARCHAR): element names that should always be LIST type
+	read_xml_array.named_parameters["record_element"] =
+	    LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
+	read_xml_array.named_parameters["force_list"] =
+	    LogicalType::ANY; // VARCHAR or LIST(VARCHAR): element names that should always be LIST type
 	// Explicit schema specification (like JSON extension)
 	read_xml_array.named_parameters["columns"] = LogicalType::ANY;
 	read_xml_set.AddFunction(read_xml_array);
@@ -1135,19 +1245,23 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	TableFunction read_html_single("read_html", {LogicalType::VARCHAR}, ReadHTMLFunction, ReadHTMLBind, ReadHTMLInit);
 	read_html_single.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
 	read_html_single.named_parameters["maximum_file_size"] = LogicalType::BIGINT;
+	read_html_single.named_parameters["union_by_name"] = LogicalType::BOOLEAN;
 	read_html_single.named_parameters["filename"] = LogicalType::BOOLEAN;
 	// Schema inference parameters (same as read_xml for API consistency)
 	read_html_single.named_parameters["root_element"] = LogicalType::VARCHAR;
-	read_html_single.named_parameters["attr_mode"] = LogicalType::VARCHAR;       // 'columns' | 'prefixed' | 'map' | 'discard'
-	read_html_single.named_parameters["attr_prefix"] = LogicalType::VARCHAR;     // Prefix for attributes when attr_mode='prefixed'
-	read_html_single.named_parameters["text_key"] = LogicalType::VARCHAR;        // Key for mixed text content
-	read_html_single.named_parameters["namespaces"] = LogicalType::VARCHAR;      // 'strip' | 'expand' | 'keep'
-	read_html_single.named_parameters["empty_elements"] = LogicalType::VARCHAR;  // 'null' | 'string' | 'object'
+	read_html_single.named_parameters["attr_mode"] = LogicalType::VARCHAR; // 'columns' | 'prefixed' | 'map' | 'discard'
+	read_html_single.named_parameters["attr_prefix"] =
+	    LogicalType::VARCHAR; // Prefix for attributes when attr_mode='prefixed'
+	read_html_single.named_parameters["text_key"] = LogicalType::VARCHAR;       // Key for mixed text content
+	read_html_single.named_parameters["namespaces"] = LogicalType::VARCHAR;     // 'strip' | 'expand' | 'keep'
+	read_html_single.named_parameters["empty_elements"] = LogicalType::VARCHAR; // 'null' | 'string' | 'object'
 	read_html_single.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
 	read_html_single.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_html_single.named_parameters["unnest_as"] = LogicalType::VARCHAR; // 'columns' (default) or 'struct' (future)
-	read_html_single.named_parameters["record_element"] = LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
-	read_html_single.named_parameters["force_list"] = LogicalType::ANY; // VARCHAR or LIST(VARCHAR): element names that should always be LIST type
+	read_html_single.named_parameters["record_element"] =
+	    LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
+	read_html_single.named_parameters["force_list"] =
+	    LogicalType::ANY; // VARCHAR or LIST(VARCHAR): element names that should always be LIST type
 	// Explicit schema specification (like JSON extension)
 	read_html_single.named_parameters["columns"] = LogicalType::ANY;
 	read_html_set.AddFunction(read_html_single);
@@ -1157,19 +1271,23 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	                              ReadHTMLBind, ReadHTMLInit);
 	read_html_array.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
 	read_html_array.named_parameters["maximum_file_size"] = LogicalType::BIGINT;
+	read_html_array.named_parameters["union_by_name"] = LogicalType::BOOLEAN;
 	read_html_array.named_parameters["filename"] = LogicalType::BOOLEAN;
 	// Schema inference parameters (same as read_xml for API consistency)
 	read_html_array.named_parameters["root_element"] = LogicalType::VARCHAR;
-	read_html_array.named_parameters["attr_mode"] = LogicalType::VARCHAR;       // 'columns' | 'prefixed' | 'map' | 'discard'
-	read_html_array.named_parameters["attr_prefix"] = LogicalType::VARCHAR;     // Prefix for attributes when attr_mode='prefixed'
-	read_html_array.named_parameters["text_key"] = LogicalType::VARCHAR;        // Key for mixed text content
-	read_html_array.named_parameters["namespaces"] = LogicalType::VARCHAR;      // 'strip' | 'expand' | 'keep'
-	read_html_array.named_parameters["empty_elements"] = LogicalType::VARCHAR;  // 'null' | 'string' | 'object'
+	read_html_array.named_parameters["attr_mode"] = LogicalType::VARCHAR; // 'columns' | 'prefixed' | 'map' | 'discard'
+	read_html_array.named_parameters["attr_prefix"] =
+	    LogicalType::VARCHAR; // Prefix for attributes when attr_mode='prefixed'
+	read_html_array.named_parameters["text_key"] = LogicalType::VARCHAR;       // Key for mixed text content
+	read_html_array.named_parameters["namespaces"] = LogicalType::VARCHAR;     // 'strip' | 'expand' | 'keep'
+	read_html_array.named_parameters["empty_elements"] = LogicalType::VARCHAR; // 'null' | 'string' | 'object'
 	read_html_array.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
 	read_html_array.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_html_array.named_parameters["unnest_as"] = LogicalType::VARCHAR; // 'columns' (default) or 'struct' (future)
-	read_html_array.named_parameters["record_element"] = LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
-	read_html_array.named_parameters["force_list"] = LogicalType::ANY; // VARCHAR or LIST(VARCHAR): element names that should always be LIST type
+	read_html_array.named_parameters["record_element"] =
+	    LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
+	read_html_array.named_parameters["force_list"] =
+	    LogicalType::ANY; // VARCHAR or LIST(VARCHAR): element names that should always be LIST type
 	// Explicit schema specification (like JSON extension)
 	read_html_array.named_parameters["columns"] = LogicalType::ANY;
 	read_html_set.AddFunction(read_html_array);
@@ -1202,7 +1320,6 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	                                           HTMLExtractTablesBind, HTMLExtractTablesInit);
 	loader.RegisterFunction(html_extract_tables_function);
 }
-
 
 unique_ptr<FunctionData> XMLReaderFunctions::HTMLExtractTablesBind(ClientContext &context,
                                                                    TableFunctionBindInput &input,

--- a/test/sql/xml_union_by_name.test
+++ b/test/sql/xml_union_by_name.test
@@ -1,0 +1,106 @@
+# name: test/sql/xml_union_by_name.test
+# description: Test union_by_name parameter for read_xml with files having different schemas
+# group: [sql]
+
+require webbed
+
+# Test 1: Without union_by_name (default behavior - only uses first file schema)
+query II
+SELECT COUNT(*), COUNT(link) as links_count
+FROM read_xml(['test/xml/union_test_file1.xml', 'test/xml/union_test_file2.xml']);
+----
+4	4
+
+# Test 2: With union_by_name=true (creates union of all columns)
+query IIIIII
+SELECT COUNT(*) as total,
+       COUNT(title) as has_title,
+       COUNT(link) as has_link,
+       COUNT(company) as has_company,
+       COUNT(description) as has_description,
+       COUNT(location) as has_location
+FROM read_xml(['test/xml/union_test_file1.xml', 'test/xml/union_test_file2.xml'], union_by_name = true);
+----
+4	4	2	2	2	2
+
+# Test 3: Verify NULL handling for missing columns
+query IIII
+SELECT
+  COUNT(*) FILTER (WHERE link IS NULL) as null_links,
+  COUNT(*) FILTER (WHERE company IS NULL) as null_companies,
+  COUNT(*) FILTER (WHERE description IS NULL) as null_descriptions,
+  COUNT(*) FILTER (WHERE location IS NULL) as null_locations
+FROM read_xml(['test/xml/union_test_file1.xml', 'test/xml/union_test_file2.xml'], union_by_name = true);
+----
+2	2	2	2
+
+# Test 4: Test with three files having different schemas
+query IIIIIII
+SELECT COUNT(*) as total,
+       COUNT(title) as has_title,
+       COUNT(link) as has_link,
+       COUNT(company) as has_company,
+       COUNT(description) as has_description,
+       COUNT(location) as has_location,
+       COUNT(salary) as has_salary
+FROM read_xml(['test/xml/union_test_file1.xml', 'test/xml/union_test_file2.xml', 'test/xml/union_test_file3.xml'], union_by_name = true);
+----
+5	5	3	2	3	2	1
+
+# Test 5: Verify actual data values with union_by_name
+query TTTTT
+SELECT title, link, company, description, location
+FROM read_xml(['test/xml/union_test_file1.xml', 'test/xml/union_test_file2.xml'], union_by_name = true)
+ORDER BY title;
+----
+Job 1	https://example.com/1	Company A	NULL	NULL
+Job 2	https://example.com/2	Company B	NULL	NULL
+Job 3	NULL	NULL	Description for job 3	New York
+Job 4	NULL	NULL	Description for job 4	San Francisco
+
+# Test 6: Test with single file (should work like normal read_xml)
+query III
+SELECT COUNT(*) as total, COUNT(link) as has_link, COUNT(company) as has_company
+FROM read_xml('test/xml/union_test_file1.xml', union_by_name = true);
+----
+2	2	2
+
+# Test 7: Test union_by_name with glob pattern
+query I
+SELECT COUNT(*) >= 5
+FROM read_xml('test/xml/union_test_file*.xml', union_by_name = true);
+----
+true
+
+# Test 8: Test union_by_name with ignore_errors
+query I
+SELECT COUNT(*) >= 4
+FROM read_xml(['test/xml/union_test_file1.xml', 'test/xml/union_test_file2.xml', 'test/xml/invalid.xml'],
+               union_by_name = true, ignore_errors = true);
+----
+true
+
+# Test 9: Verify schema has expected columns from both files
+statement ok
+CREATE TEMP TABLE read_xml_union AS
+  SELECT * FROM read_xml(['test/xml/union_test_file1.xml', 'test/xml/union_test_file2.xml'], union_by_name = true);
+
+query I
+SELECT COUNT(*) FROM pragma_table_info('read_xml_union')
+WHERE name IN ('title', 'link', 'company', 'description', 'location');
+----
+5
+
+# Test 10: Verify that union_by_name=false gives different column count than union_by_name=true
+statement ok
+CREATE TEMP TABLE without_union AS
+  SELECT * FROM read_xml(['test/xml/union_test_file1.xml', 'test/xml/union_test_file2.xml']);
+
+statement ok
+CREATE TEMP TABLE with_union AS
+  SELECT * FROM read_xml(['test/xml/union_test_file1.xml', 'test/xml/union_test_file2.xml'], union_by_name = true);
+
+query I
+SELECT (SELECT COUNT(*) FROM pragma_table_info('with_union')) > (SELECT COUNT(*) FROM pragma_table_info('without_union'));
+----
+true

--- a/test/xml/union_test_file1.xml
+++ b/test/xml/union_test_file1.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss>
+  <item>
+    <title>Job 1</title>
+    <link>https://example.com/1</link>
+    <company>Company A</company>
+  </item>
+  <item>
+    <title>Job 2</title>
+    <link>https://example.com/2</link>
+    <company>Company B</company>
+  </item>
+</rss>

--- a/test/xml/union_test_file2.xml
+++ b/test/xml/union_test_file2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss>
+  <item>
+    <title>Job 3</title>
+    <description>Description for job 3</description>
+    <location>New York</location>
+  </item>
+  <item>
+    <title>Job 4</title>
+    <description>Description for job 4</description>
+    <location>San Francisco</location>
+  </item>
+</rss>

--- a/test/xml/union_test_file3.xml
+++ b/test/xml/union_test_file3.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss>
+  <item>
+    <title>Job 5</title>
+    <link>https://example.com/5</link>
+    <description>Description for job 5</description>
+    <salary>100000</salary>
+  </item>
+</rss>


### PR DESCRIPTION
Parquet already had this nice feature:
```
SELECT *
FROM read_parquet('flights*.parquet', union_by_name = true);
```

I was reading array of rss files and one of them was missing the `item` column.

After adding this feature one can anyway read them and duckdb adds `NULL` to the missing values instead than failing with:
```
Referenced column "item" not found in FROM clause!
```

It also contains the automatic formatting changes from clang tidy.