### PR TITLE
feat: add preserve_whitespace parameter for read_xml/read_html

### DIFF
--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -96,6 +96,10 @@ Type Handling Parameters
      - BOOLEAN
      - true
      - Enable SAX-based streaming for files exceeding ``maximum_file_size``. When true (default), oversized files are parsed using SAX instead of raising an error. SAX processes XML as a stream without building a DOM tree, reducing peak memory to proportional to a single record. Set to false to error on oversized files (original behavior). Only supports simple tag names for ``record_element``. Not available for HTML.
+   * - ``preserve_whitespace``
+     - BOOLEAN
+     - true
+     - When true (v2.0.0 default), trims leading/trailing whitespace and normalizes CRLF/CR to LF per XML 1.0 §2.11 but preserves internal whitespace (newlines, tabs, multi-space runs). When false, collapses all internal whitespace runs to a single space (v1.x behavior).
 
 Attribute Handling Parameters
 -----------------------------

--- a/docs/superpowers/plans/2026-05-08-preserve-whitespace.md
+++ b/docs/superpowers/plans/2026-05-08-preserve-whitespace.md
@@ -1,0 +1,714 @@
+# preserve_whitespace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `preserve_whitespace` parameter (default `true`) to `read_xml`/`read_html` that preserves internal whitespace with CRLF/CR→LF normalization instead of collapsing all whitespace to single spaces.
+
+**Architecture:** Dual-mode `CleanTextContent()` function controlled by a boolean flag threaded from `XMLSchemaOptions` through all 8 DOM call sites. SAX path's `TrimWhitespace()` gains matching dual-mode behavior. A shared `NormalizeEOL()` helper handles CRLF/CR→LF normalization for both paths.
+
+**Tech Stack:** C++ (DuckDB extension), libxml2, DuckDB sqllogictest framework
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/include/xml_schema_inference.hpp` | Modify | Add `preserve_whitespace` to `XMLSchemaOptions`, update `CleanTextContent` declaration |
+| `src/xml_schema_inference.cpp` | Modify | Dual-mode `CleanTextContent()`, update 8 call sites |
+| `src/include/xml_sax_reader.hpp` | Modify | Add `preserve_whitespace` field to `SAXCallbackContext` |
+| `src/xml_sax_reader.cpp` | Modify | Dual-mode `ProcessTextContent()` replacing `TrimWhitespace()` |
+| `src/xml_reader_functions.cpp` | Modify | Bind parameter, thread to SAX context, register on table functions |
+| `test/xml/whitespace_cdata.xml` | Create | Test fixture: multi-line CDATA content |
+| `test/xml/whitespace_eol.xml` | Create | Test fixture: mixed CRLF/CR/LF line endings |
+| `test/sql/github_issue_73_preserve_whitespace.test` | Create | All tests for the feature |
+
+---
+
+### Task 1: Add `preserve_whitespace` to XMLSchemaOptions and update CleanTextContent signature
+
+**Files:**
+- Modify: `src/include/xml_schema_inference.hpp:62-66` (add field), `:250` (update declaration)
+
+- [ ] **Step 1: Add the option field**
+
+In `src/include/xml_schema_inference.hpp`, add `preserve_whitespace` after the `streaming` field (line 62):
+
+```cpp
+// SAX streaming controls
+bool streaming = true; // Enable SAX mode for files exceeding maximum_file_size (default: true)
+
+// Whitespace handling
+bool preserve_whitespace = true; // Preserve internal whitespace in text content (default: true for v2.0.0)
+```
+
+- [ ] **Step 2: Update CleanTextContent declaration**
+
+In `src/include/xml_schema_inference.hpp`, change the private declaration (line 250) from:
+
+```cpp
+static std::string CleanTextContent(const std::string &text);
+```
+
+to:
+
+```cpp
+static std::string CleanTextContent(const std::string &text, bool preserve_whitespace);
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `blq run build`
+Expected: Compile errors at all 8 `CleanTextContent` call sites (missing argument) plus the definition. This confirms we found all call sites.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/include/xml_schema_inference.hpp
+git commit -m "feat(#73): add preserve_whitespace option to XMLSchemaOptions"
+```
+
+---
+
+### Task 2: Implement dual-mode CleanTextContent
+
+**Files:**
+- Modify: `src/xml_schema_inference.cpp:1279-1313`
+
+- [ ] **Step 1: Write a test for preserve mode**
+
+Create `test/sql/github_issue_73_preserve_whitespace.test` with the first test — the exact reproduction case from the issue:
+
+```
+# name: test/sql/github_issue_73_preserve_whitespace.test
+# description: Test preserve_whitespace parameter for read_xml/read_html (GitHub Issue #73)
+# group: [sql]
+
+require webbed
+
+# =============================================================================
+# Test fixture setup
+# =============================================================================
+
+# Create test XML with multi-line CDATA content (the exact reproduction from issue #73)
+statement ok
+COPY (SELECT '<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <code><![CDATA[Let ( [
+  a = 1 ;
+  b = 2
+] ;
+  a + b
+)]]></code>
+</root>' AS xml) TO '__TEST_DIR__/whitespace_cdata.xml' (FORMAT 'csv', HEADER false, QUOTE '');
+
+# =============================================================================
+# SECTION 1: Default behavior (preserve_whitespace=true)
+# =============================================================================
+
+# Default: newlines are preserved in CDATA content
+query I
+SELECT length(code) - length(replace(code, chr(10), '')) AS lf_count
+FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'});
+----
+6
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `blq run test`
+Expected: FAIL — currently `CleanTextContent` has wrong arity (missing `bool` argument), won't compile.
+
+- [ ] **Step 3: Implement dual-mode CleanTextContent**
+
+Replace the `CleanTextContent` function body in `src/xml_schema_inference.cpp` (lines 1279-1313). The new implementation:
+
+```cpp
+std::string XMLSchemaInference::CleanTextContent(const std::string &text, bool preserve_whitespace) {
+	// UTF-8-safe trim: only strip ASCII whitespace.
+	// We avoid StringUtil::Trim() because its RTrim has a `ch > 0` guard
+	// that treats UTF-8 continuation bytes (negative as signed char) as
+	// characters to erase, destroying entire non-ASCII strings (issue #64).
+	auto is_ascii_space = [](unsigned char c) {
+		return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+	};
+
+	auto lstart = std::find_if_not(text.begin(), text.end(),
+	                               [&](char c) { return is_ascii_space(static_cast<unsigned char>(c)); });
+	auto rend = std::find_if_not(text.rbegin(), text.rend(), [&](char c) {
+		            return is_ascii_space(static_cast<unsigned char>(c));
+	            }).base();
+	if (lstart >= rend) {
+		return "";
+	}
+
+	if (preserve_whitespace) {
+		// Preserve internal whitespace, normalize CRLF/CR to LF (XML 1.0 §2.11)
+		std::string result;
+		result.reserve(static_cast<size_t>(rend - lstart));
+		for (auto it = lstart; it != rend; ++it) {
+			if (*it == '\r') {
+				result += '\n';
+				// Skip LF after CR (CRLF pair)
+				auto next = it + 1;
+				if (next != rend && *next == '\n') {
+					++it;
+				}
+			} else {
+				result += *it;
+			}
+		}
+		return result;
+	}
+
+	// Collapse runs of ASCII whitespace to a single space (original behavior)
+	std::string result;
+	result.reserve(static_cast<size_t>(rend - lstart));
+	bool in_space = false;
+	for (auto it = lstart; it != rend; ++it) {
+		if (is_ascii_space(static_cast<unsigned char>(*it))) {
+			if (!in_space) {
+				result += ' ';
+				in_space = true;
+			}
+		} else {
+			result += *it;
+			in_space = false;
+		}
+	}
+	return result;
+}
+```
+
+- [ ] **Step 4: Update all 8 call sites to pass `options.preserve_whitespace`**
+
+Each call site in `src/xml_schema_inference.cpp` changes from `CleanTextContent(...)` to `CleanTextContent(..., options.preserve_whitespace)`:
+
+Line 385 (InferColumnType — text samples):
+```cpp
+std::string text = CleanTextContent((const char *)content, options.preserve_whitespace);
+```
+
+Line 468 (InferColumnType — LIST with attributes):
+```cpp
+std::string text = CleanTextContent((const char *)content, options.preserve_whitespace);
+```
+
+Line 622 (InferColumnType — cross-record heterogeneous):
+```cpp
+std::string text = CleanTextContent((const char *)content, options.preserve_whitespace);
+```
+
+Line 859 (AnalyzeElement — pattern analysis):
+```cpp
+std::string text_content = CleanTextContent((const char *)content, options.preserve_whitespace);
+```
+
+Line 1446 (ExtractSingleRecord — leaf element):
+```cpp
+element_text = CleanTextContent((const char *)text_content, options.preserve_whitespace);
+```
+
+Line 1558 (ExtractSingleRecordWithSchema — datetime format):
+```cpp
+std::string text = CleanTextContent((const char *)text_content, options.preserve_whitespace);
+```
+
+Line 1761 (ExtractValueFromNode — primitive types):
+```cpp
+std::string text = CleanTextContent((const char *)text_content, options.preserve_whitespace);
+```
+
+Line 1791 (ExtractStructFromNode — #text field):
+```cpp
+std::string text = CleanTextContent((const char *)content, options.preserve_whitespace);
+```
+
+- [ ] **Step 5: Build and verify compilation**
+
+Run: `blq run build`
+Expected: OK — all call sites now have correct arity.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/xml_schema_inference.cpp
+git commit -m "feat(#73): implement dual-mode CleanTextContent with EOL normalization"
+```
+
+---
+
+### Task 3: Bind the parameter and register on table functions
+
+**Files:**
+- Modify: `src/xml_reader_functions.cpp:1284` (bind), `:1978-2002` and `:2042-2065` (register)
+
+- [ ] **Step 1: Add parameter binding**
+
+In `src/xml_reader_functions.cpp`, in the `ReadXMLBind()` named parameter loop, add after the `streaming` case (around line 1285):
+
+```cpp
+} else if (kv.first == "streaming") {
+    schema_options.streaming = kv.second.GetValue<bool>();
+} else if (kv.first == "preserve_whitespace") {
+    schema_options.preserve_whitespace = kv.second.GetValue<bool>();
+} else if (kv.first == "columns") {
+```
+
+- [ ] **Step 2: Register on read_xml_single (around line 2002)**
+
+Add after the `streaming` registration:
+
+```cpp
+read_xml_single.named_parameters["streaming"] = LogicalType::BOOLEAN;
+read_xml_single.named_parameters["preserve_whitespace"] = LogicalType::BOOLEAN;
+```
+
+- [ ] **Step 3: Register on read_xml_array (around line 2030)**
+
+Find the `read_xml_array` section and add after `streaming`:
+
+```cpp
+read_xml_array.named_parameters["streaming"] = LogicalType::BOOLEAN;
+read_xml_array.named_parameters["preserve_whitespace"] = LogicalType::BOOLEAN;
+```
+
+- [ ] **Step 4: Register on read_html_single (around line 2065)**
+
+Add after `nullstr`:
+
+```cpp
+read_html_single.named_parameters["nullstr"] = LogicalType::ANY;
+read_html_single.named_parameters["preserve_whitespace"] = LogicalType::BOOLEAN;
+```
+
+- [ ] **Step 5: Register on read_html_array (around line 2094)**
+
+Add after `nullstr`:
+
+```cpp
+read_html_array.named_parameters["nullstr"] = LogicalType::ANY;
+read_html_array.named_parameters["preserve_whitespace"] = LogicalType::BOOLEAN;
+```
+
+- [ ] **Step 6: Build and run the test**
+
+Run: `blq run build && blq run test`
+Expected: Build OK. The test from Task 2 should now PASS — the default `preserve_whitespace=true` preserves newlines.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/xml_reader_functions.cpp
+git commit -m "feat(#73): bind preserve_whitespace parameter for read_xml and read_html"
+```
+
+---
+
+### Task 4: Update SAX reader for dual-mode whitespace handling
+
+**Files:**
+- Modify: `src/include/xml_sax_reader.hpp:67-73` (add field to context)
+- Modify: `src/xml_sax_reader.cpp:105-118` (replace TrimWhitespace), `:282` (call site)
+- Modify: `src/xml_reader_functions.cpp:740-745` (thread option to SAX context)
+
+- [ ] **Step 1: Add preserve_whitespace to SAXCallbackContext**
+
+In `src/include/xml_sax_reader.hpp`, add to `SAXCallbackContext` (after line 72):
+
+```cpp
+struct SAXCallbackContext {
+	SAXRecordAccumulator *accumulator = nullptr;
+	idx_t max_rows = 0;                                             // Maximum records to accumulate (0 = unlimited)
+	idx_t rows_completed = 0;                                       // Number of completed records so far
+	bool stop_parsing = false;                                      // Signal to stop the push parser
+	std::vector<SAXRecordAccumulator> *completed_records = nullptr; // Where to store completed records
+	bool preserve_whitespace = true;                                // Whitespace handling mode
+};
+```
+
+- [ ] **Step 2: Replace TrimWhitespace with dual-mode ProcessTextContent**
+
+In `src/xml_sax_reader.cpp`, replace the `TrimWhitespace` function (lines 105-118) with:
+
+```cpp
+static std::string ProcessTextContent(const std::string &text, bool preserve_whitespace) {
+	auto is_ascii_space = [](unsigned char c) {
+		return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+	};
+	auto lstart = std::find_if_not(text.begin(), text.end(),
+	                               [&](char c) { return is_ascii_space(static_cast<unsigned char>(c)); });
+	auto rend = std::find_if_not(text.rbegin(), text.rend(), [&](char c) {
+		            return is_ascii_space(static_cast<unsigned char>(c));
+	            }).base();
+	if (lstart >= rend) {
+		return "";
+	}
+
+	if (preserve_whitespace) {
+		// Preserve internal whitespace, normalize CRLF/CR to LF (XML 1.0 §2.11)
+		std::string result;
+		result.reserve(static_cast<size_t>(rend - lstart));
+		for (auto it = lstart; it != rend; ++it) {
+			if (*it == '\r') {
+				result += '\n';
+				auto next = it + 1;
+				if (next != rend && *next == '\n') {
+					++it;
+				}
+			} else {
+				result += *it;
+			}
+		}
+		return result;
+	}
+
+	// Collapse whitespace (matches DOM CleanTextContent with preserve_whitespace=false)
+	std::string result;
+	result.reserve(static_cast<size_t>(rend - lstart));
+	bool in_space = false;
+	for (auto it = lstart; it != rend; ++it) {
+		if (is_ascii_space(static_cast<unsigned char>(*it))) {
+			if (!in_space) {
+				result += ' ';
+				in_space = true;
+			}
+		} else {
+			result += *it;
+			in_space = false;
+		}
+	}
+	return result;
+}
+```
+
+- [ ] **Step 3: Update the SAX call site**
+
+In `src/xml_sax_reader.cpp`, line 282, change:
+
+```cpp
+value = TrimWhitespace(acc->current_text);
+```
+
+to:
+
+```cpp
+value = ProcessTextContent(acc->current_text, sax_ctx->preserve_whitespace);
+```
+
+- [ ] **Step 4: Thread the option into SAXCallbackContext in xml_reader_functions.cpp**
+
+In `src/xml_reader_functions.cpp`, where the SAX context is initialized (around line 740-745), add the option:
+
+```cpp
+gstate.sax_ctx = make_uniq<SAXCallbackContext>();
+gstate.sax_ctx->accumulator = gstate.sax_accumulator.get();
+gstate.sax_ctx->max_rows = 0;
+gstate.sax_ctx->rows_completed = 0;
+gstate.sax_ctx->stop_parsing = false;
+gstate.sax_ctx->completed_records = &gstate.sax_pending_records;
+gstate.sax_ctx->preserve_whitespace = bind_data.schema_options.preserve_whitespace;
+```
+
+- [ ] **Step 5: Also thread it in SAXStreamReader::ReadRecords**
+
+In `src/xml_sax_reader.cpp`, in the `ReadRecords` function (around line 386-391), add:
+
+```cpp
+SAXCallbackContext ctx;
+ctx.accumulator = &accumulator;
+ctx.max_rows = max_rows;
+ctx.rows_completed = 0;
+ctx.stop_parsing = false;
+ctx.completed_records = &results;
+ctx.preserve_whitespace = options.preserve_whitespace;
+```
+
+- [ ] **Step 6: Build and run tests**
+
+Run: `blq run build && blq run test`
+Expected: OK — all existing tests pass, Task 2's test still passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/include/xml_sax_reader.hpp src/xml_sax_reader.cpp src/xml_reader_functions.cpp
+git commit -m "feat(#73): add dual-mode whitespace handling to SAX reader"
+```
+
+---
+
+### Task 5: Write comprehensive tests
+
+**Files:**
+- Modify: `test/sql/github_issue_73_preserve_whitespace.test`
+- Modify: `test/sql/read_function_parameters.test`
+
+- [ ] **Step 1: Add remaining tests to the test file**
+
+Append the following sections to `test/sql/github_issue_73_preserve_whitespace.test`:
+
+```
+# =============================================================================
+# SECTION 2: Explicit preserve_whitespace=false (old collapsing behavior)
+# =============================================================================
+
+# Explicit false: newlines are collapsed to spaces
+query I
+SELECT length(code) - length(replace(code, chr(10), '')) AS lf_count
+FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'},
+  preserve_whitespace=false);
+----
+0
+
+# Explicit false: content is collapsed to single-line
+query I
+SELECT code
+FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'},
+  preserve_whitespace=false);
+----
+Let ( [ a = 1 ; b = 2 ] ; a + b )
+
+# =============================================================================
+# SECTION 3: EOL normalization (CRLF/CR -> LF)
+# =============================================================================
+
+# Create test XML with mixed line endings using chr() to inject exact bytes
+statement ok
+COPY (SELECT '<?xml version="1.0" encoding="UTF-8"?><root><item>' || chr(13) || chr(10) || 'CRLF' || chr(13) || 'CR' || chr(10) || 'LF' || '</item></root>' AS xml) TO '__TEST_DIR__/whitespace_eol.xml' (FORMAT 'csv', HEADER false, QUOTE '');
+
+# Default (preserve): CRLF and CR are normalized to LF
+query I
+SELECT length(item) - length(replace(item, chr(10), '')) AS lf_count
+FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
+  record_element='root',
+  columns={'item': 'VARCHAR'});
+----
+3
+
+# Default (preserve): no CR bytes remain
+query I
+SELECT length(item) - length(replace(item, chr(13), '')) AS cr_count
+FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
+  record_element='root',
+  columns={'item': 'VARCHAR'});
+----
+0
+
+# =============================================================================
+# SECTION 4: DOM/SAX consistency
+# =============================================================================
+
+# DOM mode: preserve whitespace (default, small file stays DOM)
+query I
+SELECT length(code) - length(replace(code, chr(10), '')) AS lf_count
+FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'},
+  maximum_file_size=16777216);
+----
+6
+
+# SAX mode: preserve whitespace (force SAX via maximum_file_size=1)
+query I
+SELECT length(code) - length(replace(code, chr(10), '')) AS lf_count
+FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'},
+  maximum_file_size=1);
+----
+6
+
+# DOM mode: collapse whitespace
+query I
+SELECT code
+FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'},
+  preserve_whitespace=false,
+  maximum_file_size=16777216);
+----
+Let ( [ a = 1 ; b = 2 ] ; a + b )
+
+# SAX mode: collapse whitespace
+query I
+SELECT code
+FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'},
+  preserve_whitespace=false,
+  maximum_file_size=1);
+----
+Let ( [ a = 1 ; b = 2 ] ; a + b )
+
+# =============================================================================
+# SECTION 5: Edge cases
+# =============================================================================
+
+# Empty element — both modes return NULL
+query I
+SELECT item IS NULL FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
+  record_element='root',
+  columns={'missing': 'VARCHAR'});
+----
+true
+
+# Whitespace-only content becomes empty string -> NULL after trim
+statement ok
+COPY (SELECT '<?xml version="1.0" encoding="UTF-8"?><root><item>   </item></root>' AS xml) TO '__TEST_DIR__/whitespace_only.xml' (FORMAT 'csv', HEADER false, QUOTE '');
+
+query I
+SELECT item IS NULL FROM read_xml('__TEST_DIR__/whitespace_only.xml',
+  record_element='root',
+  columns={'item': 'VARCHAR'});
+----
+true
+
+# =============================================================================
+# SECTION 6: read_html also supports preserve_whitespace
+# =============================================================================
+
+statement ok
+COPY (SELECT '<html><body><table><tr><td>line1
+line2
+line3</td></tr></table></body></html>' AS html) TO '__TEST_DIR__/whitespace_html.html' (FORMAT 'csv', HEADER false, QUOTE '');
+
+# Default preserve: newlines are kept in HTML text
+query I
+SELECT length(td) - length(replace(td, chr(10), '')) AS lf_count
+FROM read_html('__TEST_DIR__/whitespace_html.html',
+  record_element='tr',
+  columns={'td': 'VARCHAR'});
+----
+2
+
+# Explicit false: newlines collapsed
+query I
+SELECT td
+FROM read_html('__TEST_DIR__/whitespace_html.html',
+  record_element='tr',
+  columns={'td': 'VARCHAR'},
+  preserve_whitespace=false);
+----
+line1 line2 line3
+```
+
+- [ ] **Step 2: Add parameter acceptance test**
+
+Append to `test/sql/read_function_parameters.test` in the `read_xml parameter acceptance` section (after the streaming parameter test, around line 71):
+
+```
+# Whitespace handling
+statement ok
+SELECT COUNT(*) FROM read_xml('test/data/employees.xml', preserve_whitespace := true);
+
+statement ok
+SELECT COUNT(*) FROM read_xml('test/data/employees.xml', preserve_whitespace := false);
+```
+
+Also find the `read_html parameter acceptance` section and add:
+
+```
+# Whitespace handling
+statement ok
+SELECT COUNT(*) FROM read_html('test/data/employees.html', preserve_whitespace := true);
+
+statement ok
+SELECT COUNT(*) FROM read_html('test/data/employees.html', preserve_whitespace := false);
+```
+
+- [ ] **Step 3: Run all tests**
+
+Run: `blq run test`
+Expected: All tests pass, including both new and existing tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/sql/github_issue_73_preserve_whitespace.test test/sql/read_function_parameters.test
+git commit -m "test(#73): add comprehensive tests for preserve_whitespace parameter"
+```
+
+---
+
+### Task 6: Update existing tests for new default behavior
+
+The default changed from collapsing whitespace to preserving it. Some existing tests may have expected values that assumed collapsing. This task identifies and updates them.
+
+**Files:**
+- Modify: any test files that fail due to the default change
+
+- [ ] **Step 1: Run the full test suite and capture failures**
+
+Run: `blq run test`
+Expected: Some existing tests may fail if they had multi-line XML text content whose expected output assumed collapsed whitespace. Capture the list of failures.
+
+- [ ] **Step 2: For each failing test, update the expected value OR add `preserve_whitespace=false`**
+
+For each failure:
+- If the test is explicitly testing whitespace collapsing behavior, add `preserve_whitespace=false` to the query.
+- If the test was incidentally affected (expected value changes due to preserved newlines), update the expected value to match the new default.
+- Do NOT change the `preserve_whitespace` default — the tests adapt to the new default.
+
+- [ ] **Step 3: Run full test suite again**
+
+Run: `blq run test`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -u test/
+git commit -m "test(#73): update existing tests for preserve_whitespace=true default"
+```
+
+---
+
+### Task 7: Final verification
+
+- [ ] **Step 1: Run full build from clean state**
+
+Run: `blq run build`
+Expected: OK, 0 errors, 0 warnings.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `blq run test`
+Expected: All tests pass.
+
+- [ ] **Step 3: Verify the exact reproduction case from issue #73**
+
+Run this SQL manually (or add as a final sanity check):
+
+```sql
+LOAD webbed;
+COPY (SELECT '<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <code><![CDATA[Let ( [
+  a = 1 ;
+  b = 2
+] ;
+  a + b
+)]]></code>
+</root>' AS xml) TO '/tmp/test_73.xml' (FORMAT 'csv', HEADER false, QUOTE '');
+
+SELECT
+  length(code) AS len,
+  length(code) - length(replace(code, chr(10), '')) AS lf_count,
+  code
+FROM read_xml('/tmp/test_73.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'});
+```
+
+Expected: `lf_count = 6`, `code` contains the original multi-line Let expression with newlines preserved.
+
+- [ ] **Step 4: Commit any final fixes if needed**
+
+If any issues were found in steps 1-3, fix and commit them individually.

--- a/docs/superpowers/specs/2026-05-08-preserve-whitespace-design.md
+++ b/docs/superpowers/specs/2026-05-08-preserve-whitespace-design.md
@@ -1,0 +1,133 @@
+# preserve_whitespace Parameter Design
+
+**Issue:** [#73 — Add option to preserve internal whitespace in text content](https://github.com/teaguesterling/duckdb_webbed/issues/73)
+**Date:** 2026-05-08
+**Branch:** feature/73-whitespace
+
+## Problem
+
+`read_xml` DOM mode collapses all internal whitespace (newlines, tabs, multi-space runs) in element text content into a single space character via `CleanTextContent()`. This is irreversible and destroys semantically meaningful structure — source code, configuration text, CDATA payloads, and any multi-line content.
+
+The current behavior violates XML 1.0 spec expectations: the spec requires CRLF/CR normalization to LF (§2.11) but does not mandate collapsing internal whitespace. CDATA sections in particular are explicitly intended to preserve literal content.
+
+The SAX reader uses `TrimWhitespace()` which only trims edges (preserving internal whitespace), creating an inconsistency between the two code paths.
+
+## Design
+
+### Parameter
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `preserve_whitespace` | `BOOLEAN` | `true` | Controls whitespace handling in text content |
+
+Default is `true` (breaking change for v2.0.0). Users who need the old collapsing behavior use `preserve_whitespace=false`.
+
+### Behavior Matrix
+
+| Mode | Leading/trailing WS | CRLF / bare CR | Internal WS runs |
+|------|---------------------|----------------|-------------------|
+| `preserve_whitespace=true` | Trimmed | Normalized to LF | Preserved as-is |
+| `preserve_whitespace=false` | Trimmed | Collapsed to space | Collapsed to single space |
+
+Both modes trim leading/trailing ASCII whitespace identically (existing behavior).
+
+EOL normalization (CRLF/CR → LF) applies only when `preserve_whitespace=true`. When `false`, all whitespace runs (including line endings) collapse to a single space as before, making explicit EOL normalization redundant.
+
+### Affected Code Paths
+
+#### 1. `XMLSchemaOptions` (`src/include/xml_schema_inference.hpp`)
+
+Add field:
+
+```cpp
+bool preserve_whitespace = true;  // near other boolean flags (~line 64)
+```
+
+#### 2. `CleanTextContent()` (`src/xml_schema_inference.cpp:1279-1313`)
+
+Change signature to accept the flag:
+
+```cpp
+std::string XMLSchemaInference::CleanTextContent(const std::string &text, bool preserve_whitespace)
+```
+
+When `preserve_whitespace=true`:
+- Trim leading/trailing ASCII whitespace (existing logic)
+- Normalize CRLF (`\r\n`) and bare CR (`\r`) to LF (`\n`)
+- Return result without collapsing internal whitespace
+
+When `preserve_whitespace=false`:
+- Existing behavior: trim + collapse all whitespace runs to single space
+
+#### 3. DOM Call Sites (8 locations in `xml_schema_inference.cpp`)
+
+Each call site passes `options.preserve_whitespace` (or the equivalent stored boolean):
+
+| Line | Function | Context |
+|------|----------|---------|
+| 385 | `InferColumnType()` | Text samples for type detection |
+| 468 | `InferColumnType()` | LIST instances with attributes |
+| 622 | `InferColumnType()` | Cross-record heterogeneous structures |
+| 859 | `AnalyzeElement()` | Element pattern analysis |
+| 1446 | `ExtractSingleRecord()` | Leaf element extraction |
+| 1558 | `ExtractSingleRecordWithSchema()` | Schema-guided extraction |
+| 1761 | `ExtractValueFromNode()` | Primitive type extraction |
+| 1791 | `ExtractStructFromNode()` | `#text` field from STRUCTs |
+
+Note: The inference call sites (385, 468, 622, 859) affect type detection. When whitespace is preserved, multi-line content is more likely to remain VARCHAR rather than being inferred as a numeric or temporal type. This is correct behavior — content with embedded newlines should not be coerced.
+
+#### 4. SAX Reader (`src/xml_sax_reader.cpp`)
+
+`TrimWhitespace()` (line 105-118) already preserves internal whitespace, which is the correct `preserve_whitespace=true` behavior. Changes needed:
+
+- Add EOL normalization (CRLF/CR → LF) for `preserve_whitespace=true`
+- Add whitespace collapsing for `preserve_whitespace=false` to match DOM behavior
+- The SAX handler needs access to the `preserve_whitespace` option (via `SAXCallbackContext` or similar)
+
+The function becomes mode-aware, matching `CleanTextContent()`'s dual behavior.
+
+#### 5. Parameter Binding (`src/xml_reader_functions.cpp`)
+
+In `ReadXMLBind()` (~line 1284), add parameter parsing:
+
+```cpp
+} else if (kv.first == "preserve_whitespace") {
+    schema_options.preserve_whitespace = kv.second.GetValue<bool>();
+}
+```
+
+Also register as a named parameter in the table function definitions for `read_xml` and `read_html`.
+
+### EOL Normalization Logic
+
+```
+Input        → Output
+\r\n         → \n     (CRLF → LF)
+\r (bare)    → \n     (CR → LF)
+\n           → \n     (LF unchanged)
+```
+
+This can be implemented as a single pass: scan for `\r`, replace with `\n`, skip next char if it's `\n` (CRLF pair).
+
+### Scope Boundaries
+
+**In scope:**
+- `preserve_whitespace` parameter for `read_xml` and `read_html`
+- Dual-mode `CleanTextContent()` and `TrimWhitespace()`
+- EOL normalization when preserving whitespace
+- Tests for both modes, CDATA, mixed content, EOL normalization
+
+**Out of scope:**
+- `xml:space="preserve"` attribute handling (per-element control — future enhancement)
+- Changes to `read_xml_objects` or other function variants beyond `read_xml`/`read_html`
+- Whitespace handling in attribute values (attributes are already handled correctly)
+
+## Testing Strategy
+
+1. **Basic preservation:** Multi-line CDATA content survives round-trip with `preserve_whitespace=true`
+2. **Basic collapsing:** Same content collapses with `preserve_whitespace=false`
+3. **Default behavior:** Verify default is `true` (no explicit parameter needed)
+4. **EOL normalization:** CRLF and bare CR become LF when preserving
+5. **DOM/SAX consistency:** Both code paths produce identical output for same input and options
+6. **Type inference impact:** Multi-line content stays VARCHAR, not coerced to numeric/temporal
+7. **Edge cases:** Empty elements, whitespace-only content, mixed content with nested elements

--- a/src/include/xml_sax_reader.hpp
+++ b/src/include/xml_sax_reader.hpp
@@ -70,6 +70,7 @@ struct SAXCallbackContext {
 	idx_t rows_completed = 0;                                       // Number of completed records so far
 	bool stop_parsing = false;                                      // Signal to stop the push parser
 	std::vector<SAXRecordAccumulator> *completed_records = nullptr; // Where to store completed records
+	bool preserve_whitespace = true;
 };
 
 // SAX2 callback functions (static, matching libxml2 signatures)

--- a/src/include/xml_schema_inference.hpp
+++ b/src/include/xml_schema_inference.hpp
@@ -227,6 +227,9 @@ public:
 	static Value ConvertToValuePublic(const std::string &text, const LogicalType &target_type,
 	                                  const XMLSchemaOptions &options, const std::string &datetime_format = "");
 
+	// Trim edges, optionally normalize EOL or collapse whitespace (used by both DOM and SAX paths)
+	static std::string CleanTextContent(const std::string &text, bool preserve_whitespace);
+
 private:
 	// 3-phase schema inference helpers
 	static std::unordered_map<std::string, ColumnAnalysis>
@@ -249,8 +252,6 @@ private:
 	                                 std::vector<xmlNodePtr> &result);
 
 	static LogicalType GetMostSpecificType(const std::vector<LogicalType> &types);
-
-	static std::string CleanTextContent(const std::string &text, bool preserve_whitespace);
 
 	static Value ConvertToValue(const std::string &text, const LogicalType &target_type,
 	                            const XMLSchemaOptions &options, const std::string &datetime_format = "");

--- a/src/include/xml_schema_inference.hpp
+++ b/src/include/xml_schema_inference.hpp
@@ -61,6 +61,9 @@ struct XMLSchemaOptions {
 	// SAX streaming controls
 	bool streaming = true; // Enable SAX mode for files exceeding maximum_file_size (default: true)
 
+	// Whitespace handling
+	bool preserve_whitespace = true; // Preserve internal whitespace in text content (default: true for v2.0.0)
+
 	// Type forcing
 	bool all_varchar = false;              // Force all scalar types to VARCHAR (nested structure preserved)
 	std::vector<std::string> null_strings; // Values to treat as NULL (empty = default behavior)
@@ -247,7 +250,7 @@ private:
 
 	static LogicalType GetMostSpecificType(const std::vector<LogicalType> &types);
 
-	static std::string CleanTextContent(const std::string &text);
+	static std::string CleanTextContent(const std::string &text, bool preserve_whitespace);
 
 	static Value ConvertToValue(const std::string &text, const LogicalType &target_type,
 	                            const XMLSchemaOptions &options, const std::string &datetime_format = "");

--- a/src/xml_reader_functions.cpp
+++ b/src/xml_reader_functions.cpp
@@ -387,6 +387,8 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 			ParseNullstrParameter(kv.second, function_name, schema_options.null_strings);
 		} else if (kv.first == "streaming") {
 			schema_options.streaming = kv.second.GetValue<bool>();
+		} else if (kv.first == "preserve_whitespace") {
+			schema_options.preserve_whitespace = kv.second.GetValue<bool>();
 		} else if (kv.first == "columns") {
 			// Handle explicit column schema specification (like JSON extension)
 			auto &child_type = kv.second.type();
@@ -1283,6 +1285,8 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context,
 			ParseNullstrParameter(kv.second, "read_xml", schema_options.null_strings);
 		} else if (kv.first == "streaming") {
 			schema_options.streaming = kv.second.GetValue<bool>();
+		} else if (kv.first == "preserve_whitespace") {
+			schema_options.preserve_whitespace = kv.second.GetValue<bool>();
 		} else if (kv.first == "columns") {
 			// Handle explicit column schema specification (like JSON extension)
 			auto &child_type = kv.second.type();
@@ -2000,6 +2004,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_xml_single.named_parameters["datetime_format"] = LogicalType::ANY; // VARCHAR or LIST(VARCHAR)
 	read_xml_single.named_parameters["nullstr"] = LogicalType::ANY;
 	read_xml_single.named_parameters["streaming"] = LogicalType::BOOLEAN;
+	read_xml_single.named_parameters["preserve_whitespace"] = LogicalType::BOOLEAN;
 	read_xml_set.AddFunction(read_xml_single);
 
 	// Variant 2: Array of strings parameter
@@ -2030,6 +2035,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_xml_array.named_parameters["datetime_format"] = LogicalType::ANY; // VARCHAR or LIST(VARCHAR)
 	read_xml_array.named_parameters["nullstr"] = LogicalType::ANY;
 	read_xml_array.named_parameters["streaming"] = LogicalType::BOOLEAN;
+	read_xml_array.named_parameters["preserve_whitespace"] = LogicalType::BOOLEAN;
 	read_xml_set.AddFunction(read_xml_array);
 
 	loader.RegisterFunction(read_xml_set);
@@ -2063,6 +2069,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_html_single.named_parameters["all_varchar"] = LogicalType::BOOLEAN;
 	read_html_single.named_parameters["datetime_format"] = LogicalType::ANY; // VARCHAR or LIST(VARCHAR)
 	read_html_single.named_parameters["nullstr"] = LogicalType::ANY;
+	read_html_single.named_parameters["preserve_whitespace"] = LogicalType::BOOLEAN;
 	read_html_set.AddFunction(read_html_single);
 
 	// Variant 2: Array of strings parameter
@@ -2092,6 +2099,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_html_array.named_parameters["all_varchar"] = LogicalType::BOOLEAN;
 	read_html_array.named_parameters["datetime_format"] = LogicalType::ANY; // VARCHAR or LIST(VARCHAR)
 	read_html_array.named_parameters["nullstr"] = LogicalType::ANY;
+	read_html_array.named_parameters["preserve_whitespace"] = LogicalType::BOOLEAN;
 	read_html_set.AddFunction(read_html_array);
 
 	loader.RegisterFunction(read_html_set);

--- a/src/xml_reader_functions.cpp
+++ b/src/xml_reader_functions.cpp
@@ -745,6 +745,7 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 					gstate.sax_ctx->rows_completed = 0;
 					gstate.sax_ctx->stop_parsing = false;
 					gstate.sax_ctx->completed_records = &gstate.sax_pending_records;
+					gstate.sax_ctx->preserve_whitespace = bind_data.schema_options.preserve_whitespace;
 
 					gstate.sax_handler = SAXStreamReader::CreateSAXHandler();
 					gstate.sax_parser_ctx = xmlCreatePushParserCtxt(&gstate.sax_handler, gstate.sax_ctx.get(), nullptr,

--- a/src/xml_sax_reader.cpp
+++ b/src/xml_sax_reader.cpp
@@ -100,9 +100,9 @@ static std::string XmlEscapeAttr(const std::string &text) {
 	return result;
 }
 
-// ─── Helper: UTF-8-safe whitespace trimming (matches CleanTextContent) ──────
+// ─── Helper: dual-mode text content processing (matches CleanTextContent) ────
 
-static std::string TrimWhitespace(const std::string &text) {
+static std::string ProcessTextContent(const std::string &text, bool preserve_whitespace) {
 	auto is_ascii_space = [](unsigned char c) {
 		return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
 	};
@@ -114,7 +114,41 @@ static std::string TrimWhitespace(const std::string &text) {
 	if (lstart >= rend) {
 		return "";
 	}
-	return std::string(lstart, rend);
+
+	if (preserve_whitespace) {
+		// Preserve internal whitespace, normalize CRLF/CR to LF (XML 1.0 §2.11)
+		std::string result;
+		result.reserve(static_cast<size_t>(rend - lstart));
+		for (auto it = lstart; it != rend; ++it) {
+			if (*it == '\r') {
+				result += '\n';
+				auto next = it + 1;
+				if (next != rend && *next == '\n') {
+					++it;
+				}
+			} else {
+				result += *it;
+			}
+		}
+		return result;
+	}
+
+	// Collapse whitespace (matches DOM CleanTextContent with preserve_whitespace=false)
+	std::string result;
+	result.reserve(static_cast<size_t>(rend - lstart));
+	bool in_space = false;
+	for (auto it = lstart; it != rend; ++it) {
+		if (is_ascii_space(static_cast<unsigned char>(*it))) {
+			if (!in_space) {
+				result += ' ';
+				in_space = true;
+			}
+		} else {
+			result += *it;
+			in_space = false;
+		}
+	}
+	return result;
 }
 
 // ─── Helper: resolve element name based on namespace mode ───────────────────
@@ -278,8 +312,8 @@ void SAXEndElementNs(void *ctx, const xmlChar *localname, const xmlChar *prefix,
 				value = acc->nested_xml;
 				acc->nested_xml.clear();
 			} else {
-				// Trim whitespace to match DOM's CleanTextContent behavior
-				value = TrimWhitespace(acc->current_text);
+				// Process whitespace to match DOM's CleanTextContent behavior
+				value = ProcessTextContent(acc->current_text, sax_ctx->preserve_whitespace);
 			}
 
 			// Check if this field already has a value (repeated element -> list)
@@ -389,6 +423,7 @@ std::vector<SAXRecordAccumulator> SAXStreamReader::ReadRecords(FileSystem &fs, c
 	ctx.rows_completed = 0;
 	ctx.stop_parsing = false;
 	ctx.completed_records = &results;
+	ctx.preserve_whitespace = options.preserve_whitespace;
 
 	xmlSAXHandler handler = CreateSAXHandler();
 

--- a/src/xml_sax_reader.cpp
+++ b/src/xml_sax_reader.cpp
@@ -100,57 +100,6 @@ static std::string XmlEscapeAttr(const std::string &text) {
 	return result;
 }
 
-// ─── Helper: dual-mode text content processing (matches CleanTextContent) ────
-
-static std::string ProcessTextContent(const std::string &text, bool preserve_whitespace) {
-	auto is_ascii_space = [](unsigned char c) {
-		return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
-	};
-	auto lstart = std::find_if_not(text.begin(), text.end(),
-	                               [&](char c) { return is_ascii_space(static_cast<unsigned char>(c)); });
-	auto rend = std::find_if_not(text.rbegin(), text.rend(), [&](char c) {
-		            return is_ascii_space(static_cast<unsigned char>(c));
-	            }).base();
-	if (lstart >= rend) {
-		return "";
-	}
-
-	if (preserve_whitespace) {
-		// Preserve internal whitespace, normalize CRLF/CR to LF (XML 1.0 §2.11)
-		std::string result;
-		result.reserve(static_cast<size_t>(rend - lstart));
-		for (auto it = lstart; it != rend; ++it) {
-			if (*it == '\r') {
-				result += '\n';
-				auto next = it + 1;
-				if (next != rend && *next == '\n') {
-					++it;
-				}
-			} else {
-				result += *it;
-			}
-		}
-		return result;
-	}
-
-	// Collapse whitespace (matches DOM CleanTextContent with preserve_whitespace=false)
-	std::string result;
-	result.reserve(static_cast<size_t>(rend - lstart));
-	bool in_space = false;
-	for (auto it = lstart; it != rend; ++it) {
-		if (is_ascii_space(static_cast<unsigned char>(*it))) {
-			if (!in_space) {
-				result += ' ';
-				in_space = true;
-			}
-		} else {
-			result += *it;
-			in_space = false;
-		}
-	}
-	return result;
-}
-
 // ─── Helper: resolve element name based on namespace mode ───────────────────
 
 static std::string ResolveElementName(const xmlChar *localname, const xmlChar *prefix,
@@ -313,7 +262,7 @@ void SAXEndElementNs(void *ctx, const xmlChar *localname, const xmlChar *prefix,
 				acc->nested_xml.clear();
 			} else {
 				// Process whitespace to match DOM's CleanTextContent behavior
-				value = ProcessTextContent(acc->current_text, sax_ctx->preserve_whitespace);
+				value = XMLSchemaInference::CleanTextContent(acc->current_text, sax_ctx->preserve_whitespace);
 			}
 
 			// Check if this field already has a value (repeated element -> list)

--- a/src/xml_schema_inference.cpp
+++ b/src/xml_schema_inference.cpp
@@ -382,7 +382,7 @@ LogicalType XMLSchemaInference::InferColumnType(const ColumnAnalysis &column, in
 		if (text_samples.size() < 20) {
 			xmlChar *content = xmlNodeGetContent(node);
 			if (content) {
-				std::string text = CleanTextContent((const char *)content);
+				std::string text = CleanTextContent((const char *)content, options.preserve_whitespace);
 				if (!text.empty() && !IsNullString(text, options)) {
 					text_samples.push_back(text);
 					if (!has_attributes) {
@@ -465,7 +465,7 @@ LogicalType XMLSchemaInference::InferColumnType(const ColumnAnalysis &column, in
 				}
 				xmlChar *content = xmlNodeGetContent(instance);
 				if (content) {
-					std::string text = CleanTextContent((const char *)content);
+					std::string text = CleanTextContent((const char *)content, options.preserve_whitespace);
 					if (!text.empty()) {
 						list_text_samples.push_back(text);
 					}
@@ -619,7 +619,7 @@ LogicalType XMLSchemaInference::InferColumnType(const ColumnAnalysis &column, in
 			if (cross_record_text_samples.size() < 20) {
 				xmlChar *content = xmlNodeGetContent(instance);
 				if (content) {
-					std::string text = CleanTextContent((const char *)content);
+					std::string text = CleanTextContent((const char *)content, options.preserve_whitespace);
 					if (!text.empty()) {
 						cross_record_text_samples.push_back(text);
 					}
@@ -856,7 +856,7 @@ void XMLSchemaInference::AnalyzeElement(xmlNodePtr node, std::unordered_map<std:
 	// Check for text content
 	xmlChar *content = xmlNodeGetContent(node);
 	if (content) {
-		std::string text_content = CleanTextContent((const char *)content);
+		std::string text_content = CleanTextContent((const char *)content, options.preserve_whitespace);
 		if (!text_content.empty()) {
 			pattern.has_text = true;
 			if (pattern.sample_values.size() < 20) { // Limit sample size
@@ -1276,7 +1276,7 @@ LogicalType XMLSchemaInference::GetMostSpecificType(const std::vector<LogicalTyp
 	return result;
 }
 
-std::string XMLSchemaInference::CleanTextContent(const std::string &text) {
+std::string XMLSchemaInference::CleanTextContent(const std::string &text, bool preserve_whitespace) {
 	// UTF-8-safe trim: only strip ASCII whitespace.
 	// We avoid StringUtil::Trim() because its RTrim has a `ch > 0` guard
 	// that treats UTF-8 continuation bytes (negative as signed char) as
@@ -1294,7 +1294,26 @@ std::string XMLSchemaInference::CleanTextContent(const std::string &text) {
 		return "";
 	}
 
-	// Collapse runs of ASCII whitespace to a single space
+	if (preserve_whitespace) {
+		// Preserve internal whitespace, normalize CRLF/CR to LF (XML 1.0 §2.11)
+		std::string result;
+		result.reserve(static_cast<size_t>(rend - lstart));
+		for (auto it = lstart; it != rend; ++it) {
+			if (*it == '\r') {
+				result += '\n';
+				// Skip LF after CR (CRLF pair)
+				auto next = it + 1;
+				if (next != rend && *next == '\n') {
+					++it;
+				}
+			} else {
+				result += *it;
+			}
+		}
+		return result;
+	}
+
+	// Collapse runs of ASCII whitespace to a single space (original behavior)
 	std::string result;
 	result.reserve(static_cast<size_t>(rend - lstart));
 	bool in_space = false;
@@ -1443,7 +1462,7 @@ std::vector<Value> XMLSchemaInference::ExtractSingleRecord(xmlNodePtr record, co
 						// Leaf element - return text content
 						xmlChar *text_content = xmlNodeGetContent(child);
 						if (text_content) {
-							element_text = CleanTextContent((const char *)text_content);
+							element_text = CleanTextContent((const char *)text_content, options.preserve_whitespace);
 							xmlFree(text_content);
 						}
 					}
@@ -1555,7 +1574,7 @@ std::vector<Value> XMLSchemaInference::ExtractSingleRecordWithSchema(
 						// Has a datetime format: extract raw text and convert with format
 						xmlChar *text_content = xmlNodeGetContent(child);
 						if (text_content) {
-							std::string text = CleanTextContent((const char *)text_content);
+							std::string text = CleanTextContent((const char *)text_content, options.preserve_whitespace);
 							xmlFree(text_content);
 							value = ConvertToValue(text, column_type, options, col_fmt);
 						}
@@ -1758,7 +1777,7 @@ Value XMLSchemaInference::ExtractValueFromNode(xmlNodePtr node, const LogicalTyp
 		// TODO(#38): No datetime_format passed here — nested primitives use default parsing.
 		xmlChar *text_content = xmlNodeGetContent(node);
 		if (text_content) {
-			std::string text = CleanTextContent((const char *)text_content);
+			std::string text = CleanTextContent((const char *)text_content, options.preserve_whitespace);
 			xmlFree(text_content);
 			return ConvertToValue(text, target_type, options);
 		}
@@ -1788,7 +1807,7 @@ Value XMLSchemaInference::ExtractStructFromNode(xmlNodePtr node, const LogicalTy
 		if (field_name == "#text") {
 			xmlChar *content = xmlNodeGetContent(node);
 			if (content) {
-				std::string text = CleanTextContent((const char *)content);
+				std::string text = CleanTextContent((const char *)content, options.preserve_whitespace);
 				if (!text.empty()) {
 					field_value = ConvertToValue(text, field_type, options);
 					found = true;

--- a/test/sql/github_issue_73_preserve_whitespace.test
+++ b/test/sql/github_issue_73_preserve_whitespace.test
@@ -31,7 +31,7 @@ FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
   record_element='root',
   columns={'code': 'VARCHAR'});
 ----
-6
+5
 
 # =============================================================================
 # SECTION 2: Explicit preserve_whitespace=false (old collapsing behavior)
@@ -95,7 +95,7 @@ FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
   columns={'code': 'VARCHAR'},
   maximum_file_size=16777216);
 ----
-6
+5
 
 # SAX mode: preserve whitespace (force SAX via maximum_file_size=1)
 query I
@@ -105,7 +105,7 @@ FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
   columns={'code': 'VARCHAR'},
   maximum_file_size=1);
 ----
-6
+5
 
 # DOM mode: collapse whitespace
 query I

--- a/test/sql/github_issue_73_preserve_whitespace.test
+++ b/test/sql/github_issue_73_preserve_whitespace.test
@@ -129,11 +129,31 @@ FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
 ----
 Let ( [ a = 1 ; b = 2 ] ; a + b )
 
+# SAX mode: CRLF normalization consistency
+query I
+SELECT length(item) - length(replace(item, chr(10), '')) AS lf_count
+FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
+  record_element='root',
+  columns={'item': 'VARCHAR'},
+  maximum_file_size=1);
+----
+3
+
+# SAX mode: no CR bytes remain
+query I
+SELECT length(item) - length(replace(item, chr(13), '')) AS cr_count
+FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
+  record_element='root',
+  columns={'item': 'VARCHAR'},
+  maximum_file_size=1);
+----
+0
+
 # =============================================================================
 # SECTION 5: Edge cases
 # =============================================================================
 
-# Empty element — both modes return NULL
+# Non-existent column returns NULL
 query I
 SELECT item IS NULL FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
   record_element='root',

--- a/test/sql/github_issue_73_preserve_whitespace.test
+++ b/test/sql/github_issue_73_preserve_whitespace.test
@@ -65,14 +65,14 @@ Let ( [ a = 1 ; b = 2 ] ; a + b )
 statement ok
 COPY (SELECT '<?xml version="1.0" encoding="UTF-8"?><root><item>' || chr(13) || chr(10) || 'CRLF' || chr(13) || 'CR' || chr(10) || 'LF' || '</item></root>' AS xml) TO '__TEST_DIR__/whitespace_eol.xml' (FORMAT 'csv', HEADER false, QUOTE '');
 
-# Default (preserve): CRLF and CR are normalized to LF
+# Default (preserve): CRLF and CR are normalized to LF (leading LF trimmed)
 query I
 SELECT length(item) - length(replace(item, chr(10), '')) AS lf_count
 FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
   record_element='root',
   columns={'item': 'VARCHAR'});
 ----
-3
+2
 
 # Default (preserve): no CR bytes remain
 query I
@@ -129,7 +129,7 @@ FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
 ----
 Let ( [ a = 1 ; b = 2 ] ; a + b )
 
-# SAX mode: CRLF normalization consistency
+# SAX mode: CRLF normalization consistency (leading LF trimmed)
 query I
 SELECT length(item) - length(replace(item, chr(10), '')) AS lf_count
 FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
@@ -137,7 +137,7 @@ FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
   columns={'item': 'VARCHAR'},
   maximum_file_size=1);
 ----
-3
+2
 
 # SAX mode: no CR bytes remain
 query I

--- a/test/sql/github_issue_73_preserve_whitespace.test
+++ b/test/sql/github_issue_73_preserve_whitespace.test
@@ -1,0 +1,181 @@
+# name: test/sql/github_issue_73_preserve_whitespace.test
+# description: Test preserve_whitespace parameter for read_xml/read_html (GitHub Issue #73)
+# group: [sql]
+
+require webbed
+
+# =============================================================================
+# Test fixture setup
+# =============================================================================
+
+# Create test XML with multi-line CDATA content (the exact reproduction from issue #73)
+statement ok
+COPY (SELECT '<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <code><![CDATA[Let ( [
+  a = 1 ;
+  b = 2
+] ;
+  a + b
+)]]></code>
+</root>' AS xml) TO '__TEST_DIR__/whitespace_cdata.xml' (FORMAT 'csv', HEADER false, QUOTE '');
+
+# =============================================================================
+# SECTION 1: Default behavior (preserve_whitespace=true)
+# =============================================================================
+
+# Default: newlines are preserved in CDATA content
+query I
+SELECT length(code) - length(replace(code, chr(10), '')) AS lf_count
+FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'});
+----
+6
+
+# =============================================================================
+# SECTION 2: Explicit preserve_whitespace=false (old collapsing behavior)
+# =============================================================================
+
+# Explicit false: newlines are collapsed to spaces
+query I
+SELECT length(code) - length(replace(code, chr(10), '')) AS lf_count
+FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'},
+  preserve_whitespace=false);
+----
+0
+
+# Explicit false: content is collapsed to single-line
+query I
+SELECT code
+FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'},
+  preserve_whitespace=false);
+----
+Let ( [ a = 1 ; b = 2 ] ; a + b )
+
+# =============================================================================
+# SECTION 3: EOL normalization (CRLF/CR -> LF)
+# =============================================================================
+
+# Create test XML with mixed line endings using chr() to inject exact bytes
+statement ok
+COPY (SELECT '<?xml version="1.0" encoding="UTF-8"?><root><item>' || chr(13) || chr(10) || 'CRLF' || chr(13) || 'CR' || chr(10) || 'LF' || '</item></root>' AS xml) TO '__TEST_DIR__/whitespace_eol.xml' (FORMAT 'csv', HEADER false, QUOTE '');
+
+# Default (preserve): CRLF and CR are normalized to LF
+query I
+SELECT length(item) - length(replace(item, chr(10), '')) AS lf_count
+FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
+  record_element='root',
+  columns={'item': 'VARCHAR'});
+----
+3
+
+# Default (preserve): no CR bytes remain
+query I
+SELECT length(item) - length(replace(item, chr(13), '')) AS cr_count
+FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
+  record_element='root',
+  columns={'item': 'VARCHAR'});
+----
+0
+
+# =============================================================================
+# SECTION 4: DOM/SAX consistency
+# =============================================================================
+
+# DOM mode: preserve whitespace (default, small file stays DOM)
+query I
+SELECT length(code) - length(replace(code, chr(10), '')) AS lf_count
+FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'},
+  maximum_file_size=16777216);
+----
+6
+
+# SAX mode: preserve whitespace (force SAX via maximum_file_size=1)
+query I
+SELECT length(code) - length(replace(code, chr(10), '')) AS lf_count
+FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'},
+  maximum_file_size=1);
+----
+6
+
+# DOM mode: collapse whitespace
+query I
+SELECT code
+FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'},
+  preserve_whitespace=false,
+  maximum_file_size=16777216);
+----
+Let ( [ a = 1 ; b = 2 ] ; a + b )
+
+# SAX mode: collapse whitespace
+query I
+SELECT code
+FROM read_xml('__TEST_DIR__/whitespace_cdata.xml',
+  record_element='root',
+  columns={'code': 'VARCHAR'},
+  preserve_whitespace=false,
+  maximum_file_size=1);
+----
+Let ( [ a = 1 ; b = 2 ] ; a + b )
+
+# =============================================================================
+# SECTION 5: Edge cases
+# =============================================================================
+
+# Empty element — both modes return NULL
+query I
+SELECT item IS NULL FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
+  record_element='root',
+  columns={'missing': 'VARCHAR'});
+----
+true
+
+# Whitespace-only content becomes empty string -> NULL after trim
+statement ok
+COPY (SELECT '<?xml version="1.0" encoding="UTF-8"?><root><item>   </item></root>' AS xml) TO '__TEST_DIR__/whitespace_only.xml' (FORMAT 'csv', HEADER false, QUOTE '');
+
+query I
+SELECT item IS NULL FROM read_xml('__TEST_DIR__/whitespace_only.xml',
+  record_element='root',
+  columns={'item': 'VARCHAR'});
+----
+true
+
+# =============================================================================
+# SECTION 6: read_html also supports preserve_whitespace
+# =============================================================================
+
+statement ok
+COPY (SELECT '<html><body><table><tr><td>line1
+line2
+line3</td></tr></table></body></html>' AS html) TO '__TEST_DIR__/whitespace_html.html' (FORMAT 'csv', HEADER false, QUOTE '');
+
+# Default preserve: newlines are kept in HTML text
+query I
+SELECT length(td) - length(replace(td, chr(10), '')) AS lf_count
+FROM read_html('__TEST_DIR__/whitespace_html.html',
+  record_element='tr',
+  columns={'td': 'VARCHAR'});
+----
+2
+
+# Explicit false: newlines collapsed
+query I
+SELECT td
+FROM read_html('__TEST_DIR__/whitespace_html.html',
+  record_element='tr',
+  columns={'td': 'VARCHAR'},
+  preserve_whitespace=false);
+----
+line1 line2 line3

--- a/test/sql/github_issue_73_preserve_whitespace.test
+++ b/test/sql/github_issue_73_preserve_whitespace.test
@@ -155,7 +155,7 @@ FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
 
 # Non-existent column returns NULL
 query I
-SELECT item IS NULL FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
+SELECT missing IS NULL FROM read_xml('__TEST_DIR__/whitespace_eol.xml',
   record_element='root',
   columns={'missing': 'VARCHAR'});
 ----

--- a/test/sql/read_function_parameters.test
+++ b/test/sql/read_function_parameters.test
@@ -69,6 +69,13 @@ SELECT COUNT(*) FROM read_xml('test/data/employees.xml', empty_elements := 'obje
 statement ok
 SELECT COUNT(*) FROM read_xml('test/data/employees.xml', union_by_name := false);
 
+# Whitespace handling
+statement ok
+SELECT COUNT(*) FROM read_xml('test/data/employees.xml', preserve_whitespace := true);
+
+statement ok
+SELECT COUNT(*) FROM read_xml('test/data/employees.xml', preserve_whitespace := false);
+
 # -----------------------------------------------------------------------------
 # read_xml_objects parameter acceptance
 # -----------------------------------------------------------------------------
@@ -103,6 +110,13 @@ SELECT COUNT(*) FROM read_html('test/html/complex.html', all_varchar := true);
 
 statement ok
 SELECT COUNT(*) FROM read_html('test/html/complex.html', union_by_name := false);
+
+# Whitespace handling
+statement ok
+SELECT COUNT(*) FROM read_html('test/html/complex.html', preserve_whitespace := true);
+
+statement ok
+SELECT COUNT(*) FROM read_html('test/html/complex.html', preserve_whitespace := false);
 
 # -----------------------------------------------------------------------------
 # read_html_objects parameter acceptance

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
         "name": "duckdb-webbed",
-        "version": "1.1.0",
+        "version": "2.0.1",
         "dependencies": [
                 {
                         "name": "libxml2",


### PR DESCRIPTION
## Summary

Closes #73

- Add `preserve_whitespace` parameter (default `true`) to `read_xml` and `read_html` that controls whitespace handling in text content
- When `true` (new default for v2.0.0): trims leading/trailing whitespace, normalizes CRLF/CR → LF per XML 1.0 §2.11, preserves internal whitespace (newlines, tabs, multi-space runs)
- When `false`: original behavior — collapses all internal whitespace runs to a single space
- Both DOM and SAX code paths share a single `CleanTextContent()` implementation

## Changes

- `XMLSchemaOptions`: new `bool preserve_whitespace = true` field
- `CleanTextContent()`: dual-mode function accepting a `preserve_whitespace` flag, all 8 DOM call sites updated
- SAX reader: calls shared `CleanTextContent()` instead of maintaining a separate `TrimWhitespace()` copy
- Parameter binding: registered on `read_xml` (single/array) and `read_html` (single/array) table functions
- Tests: 6 sections covering default behavior, explicit false, EOL normalization, DOM/SAX consistency, edge cases, and read_html support

## Test plan

- [x] All 2511 assertions in 68 test cases pass
- [x] New test file `github_issue_73_preserve_whitespace.test` covers all specified behavior
- [x] Parameter acceptance tests added to `read_function_parameters.test`
- [x] No existing tests broken by default change (existing XML test data is single-line)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)