### PR TITLE
fix: close #77 SAX rich-typing edge cases (FieldOccurrence refactor + ns-decl injection)

### DIFF
--- a/src/include/xml_sax_reader.hpp
+++ b/src/include/xml_sax_reader.hpp
@@ -17,6 +17,13 @@ enum class SAXAccumulatorState {
 	RECORD_COMPLETE // A complete record has been accumulated
 };
 
+// A single occurrence of a record field, tagged by payload kind. Occurrences are stored in
+// document order so a field mixing bare-text and nested-XML siblings keeps its original sequence.
+struct FieldOccurrence {
+	bool is_xml;         // true = nested-XML fragment, false = text payload
+	std::string payload; // serialized XML fragment (is_xml) or cleaned text (!is_xml)
+};
+
 // Accumulates field data from SAX events for a single XML record
 struct SAXRecordAccumulator {
 	// Current state
@@ -31,13 +38,11 @@ struct SAXRecordAccumulator {
 	std::vector<std::string> element_stack; // Stack of element names
 	int current_depth = 0;                  // Current nesting depth
 
-	// Accumulated data for current record. Scalar/text values and nested-XML values are tracked
-	// in parallel maps so the rich-typing path (STRUCT, LIST<STRUCT>) can re-parse the inner XML.
-	std::unordered_map<std::string, std::string> current_values;                 // field_name -> scalar value
-	std::unordered_map<std::string, std::vector<std::string>> current_lists;     // field_name -> repeated values
-	std::unordered_map<std::string, std::string> current_xml_values;             // field_name -> inner XML fragment
-	std::unordered_map<std::string, std::vector<std::string>> current_xml_lists; // field_name -> repeated inner XML
-	std::unordered_map<std::string, std::string> current_attributes;             // attr_name -> value
+	// Accumulated data for current record. Each field maps to its occurrences in document order,
+	// each tagged as text or nested-XML so the rich-typing path (STRUCT, LIST<STRUCT>) can re-parse
+	// the inner XML while preserving the original sequence of mixed text/XML siblings.
+	std::unordered_map<std::string, std::vector<FieldOccurrence>> current_fields; // field_name -> ordered occurrences
+	std::unordered_map<std::string, std::string> current_attributes;              // attr_name -> value
 
 	// Text accumulation (SAX may split text across multiple characters() callbacks)
 	std::string current_text;
@@ -53,17 +58,8 @@ struct SAXRecordAccumulator {
 	// Reset accumulator for next record
 	void Reset();
 
-	// Get a scalar value by field name (empty string if not found)
-	std::string GetValue(const std::string &name) const;
-
-	// Get list values by field name (empty vector if not found)
-	const std::vector<std::string> &GetListValues(const std::string &name) const;
-
-	// Get an inner-XML fragment by field name (empty string if the field carried only text)
-	std::string GetXmlValue(const std::string &name) const;
-
-	// Get inner-XML fragments for a repeated field (empty vector if not present)
-	const std::vector<std::string> &GetXmlListValues(const std::string &name) const;
+	// Get a field's occurrences in document order (empty vector if the field is absent)
+	const std::vector<FieldOccurrence> &GetOccurrences(const std::string &name) const;
 
 	// Check if an attribute exists
 	bool HasAttribute(const std::string &name) const;

--- a/src/include/xml_sax_reader.hpp
+++ b/src/include/xml_sax_reader.hpp
@@ -4,6 +4,7 @@
 #include "xml_schema_inference.hpp"
 #include <libxml/parser.h>
 #include <libxml/xmlstring.h>
+#include <map>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -44,6 +45,11 @@ struct SAXRecordAccumulator {
 	std::unordered_map<std::string, std::vector<FieldOccurrence>> current_fields; // field_name -> ordered occurrences
 	std::unordered_map<std::string, std::string> current_attributes;              // attr_name -> value
 
+	// Namespace declarations (prefix -> URI) seen anywhere in the document, accumulated globally so
+	// reparsed nested-XML fragments can resolve prefixed names. Intentionally NOT cleared by Reset()
+	// since root-level xmlns: declarations appear before the first record.
+	std::map<std::string, std::string> namespace_declarations;
+
 	// Text accumulation (SAX may split text across multiple characters() callbacks)
 	std::string current_text;
 	std::string current_element_name; // Name of the element whose text we're accumulating
@@ -60,6 +66,10 @@ struct SAXRecordAccumulator {
 
 	// Get a field's occurrences in document order (empty vector if the field is absent)
 	const std::vector<FieldOccurrence> &GetOccurrences(const std::string &name) const;
+
+	// Serialize accumulated namespace declarations as ` xmlns:prefix="uri"...` (empty if none),
+	// ready to splice into a synthetic wrapper element's open tag.
+	std::string BuildNamespaceDeclarations() const;
 
 	// Check if an attribute exists
 	bool HasAttribute(const std::string &name) const;

--- a/src/include/xml_schema_inference.hpp
+++ b/src/include/xml_schema_inference.hpp
@@ -231,7 +231,8 @@ public:
 	// given target type. Used by the SAX reader to materialize STRUCT / LIST<STRUCT> columns whose
 	// inner content was captured as raw XML during streaming.
 	static Value ExtractValueFromXmlFragment(const std::string &wrapper_name, const std::string &inner_xml,
-	                                         const LogicalType &target_type, const XMLSchemaOptions &options);
+	                                         const LogicalType &target_type, const XMLSchemaOptions &options,
+	                                         const std::string &extra_ns_decls = "");
 
 	// Trim edges, optionally normalize EOL or collapse whitespace (used by both DOM and SAX paths)
 	static std::string CleanTextContent(const std::string &text, bool preserve_whitespace);

--- a/src/xml_sax_reader.cpp
+++ b/src/xml_sax_reader.cpp
@@ -18,8 +18,8 @@ void SAXRecordAccumulator::Reset() {
 	nested_xml.clear();
 	nested_depth = 0;
 	row_ready = false;
-	// Note: element_stack, current_depth, record_depth, record_tag, namespace_mode
-	// are NOT reset — they persist across records
+	// Note: element_stack, current_depth, record_depth, record_tag, namespace_mode,
+	// namespace_declarations are NOT reset — they persist across records
 }
 
 const std::vector<FieldOccurrence> &SAXRecordAccumulator::GetOccurrences(const std::string &name) const {
@@ -91,6 +91,14 @@ static std::string XmlEscapeAttr(const std::string &text) {
 	return result;
 }
 
+std::string SAXRecordAccumulator::BuildNamespaceDeclarations() const {
+	std::string result;
+	for (const auto &ns : namespace_declarations) {
+		result += " xmlns:" + ns.first + "=\"" + XmlEscapeAttr(ns.second) + "\"";
+	}
+	return result;
+}
+
 // ─── Helper: resolve element name based on namespace mode ───────────────────
 
 static std::string ResolveElementName(const xmlChar *localname, const xmlChar *prefix,
@@ -131,6 +139,20 @@ void SAXStartElementNs(void *ctx, const xmlChar *localname, const xmlChar *prefi
 	std::string name = ResolveElementName(localname, prefix, acc->namespace_mode);
 	acc->current_depth++;
 	acc->element_stack.push_back(name);
+
+	// In keep mode, record each prefixed namespace declaration so reparsed nested-XML fragments can
+	// resolve their prefixes. Skip the default namespace (null prefix): extraction matches by local
+	// name, so only prefixes need resolving.
+	if (acc->namespace_mode == "keep") {
+		for (int i = 0; i < nb_namespaces; i++) {
+			const xmlChar *ns_prefix = namespaces[i * 2];
+			const xmlChar *ns_uri = namespaces[i * 2 + 1];
+			if (ns_prefix != nullptr && ns_uri != nullptr) {
+				acc->namespace_declarations[reinterpret_cast<const char *>(ns_prefix)] =
+				    reinterpret_cast<const char *>(ns_uri);
+			}
+		}
+	}
 
 	if (acc->state == SAXAccumulatorState::SEEKING_RECORD) {
 		// Determine if this element is a record element
@@ -395,9 +417,12 @@ std::vector<XMLColumnInfo> SAXStreamReader::InferSchemaFromStream(FileSystem &fs
 	}
 
 	// Build a synthetic XML document from accumulated records
-	// This lets us reuse the existing DOM-based InferSchema
+	// This lets us reuse the existing DOM-based InferSchema. Declare any prefixed namespaces on the
+	// synthetic root so prefixed nested elements parse under strict (non-recovery) inference.
+	// namespace_declarations accumulates monotonically across the parse and is never reset, so the
+	// last record's snapshot is the union of every declaration seen while sampling.
 	std::ostringstream xml;
-	xml << "<root>";
+	xml << "<root" << records.back().BuildNamespaceDeclarations() << ">";
 
 	for (const auto &record : records) {
 		xml << "<record>";
@@ -456,6 +481,10 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 	std::vector<Value> row;
 	row.reserve(column_names.size());
 
+	// Namespace declarations to splice into reparsed fragments so prefixed names resolve (empty
+	// unless namespaces:='keep'). Built once and reused across columns.
+	const std::string ns_decls = accumulator.BuildNamespaceDeclarations();
+
 	for (idx_t i = 0; i < column_names.size(); i++) {
 		const auto &col_name = column_names[i];
 		const auto &col_type = column_types[i];
@@ -491,8 +520,8 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 			if (occs.empty()) {
 				value = Value(col_type); // typed NULL
 			} else if (occs.front().is_xml) {
-				value =
-				    XMLSchemaInference::ExtractValueFromXmlFragment(col_name, occs.front().payload, col_type, options);
+				value = XMLSchemaInference::ExtractValueFromXmlFragment(col_name, occs.front().payload, col_type,
+				                                                        options, ns_decls);
 			} else {
 				// Text-only occurrence: wrap escaped text so the extractor yields a non-NULL struct
 				// shell (fields NULL), matching DOM, rather than a fully-NULL struct.
@@ -501,7 +530,7 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 					value = Value(col_type); // typed NULL
 				} else {
 					value = XMLSchemaInference::ExtractValueFromXmlFragment(col_name, XmlEscapeText(text), col_type,
-					                                                        options);
+					                                                        options, ns_decls);
 				}
 			}
 		} else if (col_type.id() == LogicalTypeId::LIST) {
@@ -522,7 +551,7 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 					// surface it as a #text-bearing struct (NULL for missing fields). Escape XML
 					// special chars first so '&', '<', '>' do not break the synthetic wrapper.
 					list_vals.push_back(XMLSchemaInference::ExtractValueFromXmlFragment(col_name, XmlEscapeText(item),
-					                                                                    child_type, options));
+					                                                                    child_type, options, ns_decls));
 				} else {
 					list_vals.push_back(
 					    XMLSchemaInference::ConvertToValuePublic(item, child_type, options, datetime_fmt));
@@ -531,7 +560,7 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 			auto append_xml = [&](const std::string &frag) {
 				if (child_is_complex) {
 					list_vals.push_back(
-					    XMLSchemaInference::ExtractValueFromXmlFragment(col_name, frag, child_type, options));
+					    XMLSchemaInference::ExtractValueFromXmlFragment(col_name, frag, child_type, options, ns_decls));
 				} else if (child_type.id() == LogicalTypeId::VARCHAR) {
 					// Scalar-typed list with an XML item: surface the serialized fragment.
 					list_vals.push_back(Value(frag));

--- a/src/xml_sax_reader.cpp
+++ b/src/xml_sax_reader.cpp
@@ -7,14 +7,11 @@ namespace duckdb {
 
 // ─── SAXRecordAccumulator ───────────────────────────────────────────────────
 
-static const std::vector<std::string> EMPTY_LIST;
+static const std::vector<FieldOccurrence> EMPTY_OCCURRENCES;
 
 void SAXRecordAccumulator::Reset() {
 	state = SAXAccumulatorState::SEEKING_RECORD;
-	current_values.clear();
-	current_lists.clear();
-	current_xml_values.clear();
-	current_xml_lists.clear();
+	current_fields.clear();
 	current_attributes.clear();
 	current_text.clear();
 	current_element_name.clear();
@@ -25,36 +22,12 @@ void SAXRecordAccumulator::Reset() {
 	// are NOT reset — they persist across records
 }
 
-std::string SAXRecordAccumulator::GetValue(const std::string &name) const {
-	auto it = current_values.find(name);
-	if (it != current_values.end()) {
+const std::vector<FieldOccurrence> &SAXRecordAccumulator::GetOccurrences(const std::string &name) const {
+	auto it = current_fields.find(name);
+	if (it != current_fields.end()) {
 		return it->second;
 	}
-	return "";
-}
-
-const std::vector<std::string> &SAXRecordAccumulator::GetListValues(const std::string &name) const {
-	auto it = current_lists.find(name);
-	if (it != current_lists.end()) {
-		return it->second;
-	}
-	return EMPTY_LIST;
-}
-
-std::string SAXRecordAccumulator::GetXmlValue(const std::string &name) const {
-	auto it = current_xml_values.find(name);
-	if (it != current_xml_values.end()) {
-		return it->second;
-	}
-	return "";
-}
-
-const std::vector<std::string> &SAXRecordAccumulator::GetXmlListValues(const std::string &name) const {
-	auto it = current_xml_lists.find(name);
-	if (it != current_xml_lists.end()) {
-		return it->second;
-	}
-	return EMPTY_LIST;
+	return EMPTY_OCCURRENCES;
 }
 
 bool SAXRecordAccumulator::HasAttribute(const std::string &name) const {
@@ -273,8 +246,9 @@ void SAXEndElementNs(void *ctx, const xmlChar *localname, const xmlChar *prefix,
 			}
 		} else if (relative_depth == 1) {
 			// Closing a direct child of the record. If we accumulated nested XML (the child has
-			// element children), store it in the XML-value map so rich-typing can re-parse it.
-			// Otherwise treat the value as text.
+			// element children), the payload is the raw fragment so rich-typing can re-parse it;
+			// otherwise it is text. Append in close order, capturing document order across a field's
+			// text and XML occurrences.
 			bool is_xml = !acc->nested_xml.empty();
 			std::string value;
 			if (is_xml) {
@@ -284,26 +258,7 @@ void SAXEndElementNs(void *ctx, const xmlChar *localname, const xmlChar *prefix,
 				value = XMLSchemaInference::CleanTextContent(acc->current_text, sax_ctx->preserve_whitespace);
 			}
 
-			auto &scalar_map = is_xml ? acc->current_xml_values : acc->current_values;
-			auto &list_map = is_xml ? acc->current_xml_lists : acc->current_lists;
-
-			// Repeated element -> list. Promote existing scalar to a list, or append to existing list.
-			auto it = scalar_map.find(name);
-			if (it != scalar_map.end()) {
-				auto &list = list_map[name];
-				if (list.empty()) {
-					list.push_back(it->second);
-				}
-				list.push_back(value);
-				scalar_map.erase(it);
-			} else {
-				auto list_it = list_map.find(name);
-				if (list_it != list_map.end()) {
-					list_it->second.push_back(value);
-				} else {
-					scalar_map[name] = value;
-				}
-			}
+			acc->current_fields[name].push_back({is_xml, std::move(value)});
 
 			acc->current_text.clear();
 			acc->current_element_name.clear();
@@ -459,27 +414,13 @@ std::vector<XMLColumnInfo> SAXStreamReader::InferSchemaFromStream(FileSystem &fs
 			}
 		}
 
-		// Emit scalar values (escape text to produce valid XML)
-		for (const auto &val : record.current_values) {
-			xml << "<" << val.first << ">" << XmlEscapeText(val.second) << "</" << val.first << ">";
-		}
-
-		// Emit list values as repeated elements
-		for (const auto &list : record.current_lists) {
-			for (const auto &item : list.second) {
-				xml << "<" << list.first << ">" << XmlEscapeText(item) << "</" << list.first << ">";
-			}
-		}
-
-		// Emit nested-XML values structurally so DOM inference reconstructs STRUCT shape.
-		for (const auto &val : record.current_xml_values) {
-			xml << "<" << val.first << ">" << val.second << "</" << val.first << ">";
-		}
-
-		// Emit nested-XML lists structurally as repeated elements.
-		for (const auto &list : record.current_xml_lists) {
-			for (const auto &item : list.second) {
-				xml << "<" << list.first << ">" << item << "</" << list.first << ">";
+		// Emit each field's occurrences in document order: text payloads escaped, nested-XML
+		// fragments emitted structurally so DOM inference reconstructs the STRUCT / LIST shape.
+		for (const auto &field : record.current_fields) {
+			for (const auto &occ : field.second) {
+				xml << "<" << field.first << ">";
+				xml << (occ.is_xml ? occ.payload : XmlEscapeText(occ.payload));
+				xml << "</" << field.first << ">";
 			}
 		}
 
@@ -544,15 +485,18 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 				value = XMLSchemaInference::ConvertToValuePublic(attr_val, col_type, options, datetime_fmt);
 			}
 		} else if (col_type.id() == LogicalTypeId::STRUCT) {
-			// STRUCT column: the child element had element children, captured as inner XML during
-			// streaming. Re-parse and dispatch through the DOM extractor.
-			std::string inner_xml = accumulator.GetXmlValue(col_name);
-			if (!inner_xml.empty()) {
-				value = XMLSchemaInference::ExtractValueFromXmlFragment(col_name, inner_xml, col_type, options);
+			// STRUCT column: a non-LIST struct implies a single occurrence. If it carried element
+			// children it was captured as inner XML; re-parse and dispatch through the DOM extractor.
+			const auto &occs = accumulator.GetOccurrences(col_name);
+			if (occs.empty()) {
+				value = Value(col_type); // typed NULL
+			} else if (occs.front().is_xml) {
+				value =
+				    XMLSchemaInference::ExtractValueFromXmlFragment(col_name, occs.front().payload, col_type, options);
 			} else {
 				// Text-only occurrence: wrap escaped text so the extractor yields a non-NULL struct
 				// shell (fields NULL), matching DOM, rather than a fully-NULL struct.
-				std::string text = accumulator.GetValue(col_name);
+				const std::string &text = occs.front().payload;
 				if (text.empty() || IsNullString(text, options)) {
 					value = Value(col_type); // typed NULL
 				} else {
@@ -561,18 +505,12 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 				}
 			}
 		} else if (col_type.id() == LogicalTypeId::LIST) {
-			// LIST column. Combine text-shaped items (current_lists / current_values) and
-			// nested-XML items (current_xml_lists / current_xml_values). Document order between
-			// text and XML items is not preserved (the accumulator stores them in parallel maps);
-			// items within a single map keep their relative order.
+			// LIST column. Iterate the field's occurrences in document order, dispatching each to the
+			// text or XML appender by its kind, so a list mixing bare-text and nested-XML siblings
+			// keeps its original sequence.
 			auto child_type = ListType::GetChildType(col_type);
 			const bool child_is_complex =
 			    (child_type.id() == LogicalTypeId::STRUCT || child_type.id() == LogicalTypeId::LIST);
-
-			const auto &text_items = accumulator.GetListValues(col_name);
-			std::string text_single = accumulator.GetValue(col_name);
-			const auto &xml_items = accumulator.GetXmlListValues(col_name);
-			std::string xml_single = accumulator.GetXmlValue(col_name);
 
 			std::vector<Value> list_vals;
 
@@ -602,19 +540,12 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 				}
 			};
 
-			if (!text_items.empty()) {
-				for (const auto &item : text_items) {
-					append_text(item);
+			for (const auto &occ : accumulator.GetOccurrences(col_name)) {
+				if (occ.is_xml) {
+					append_xml(occ.payload);
+				} else {
+					append_text(occ.payload);
 				}
-			} else if (!text_single.empty()) {
-				append_text(text_single);
-			}
-			if (!xml_items.empty()) {
-				for (const auto &frag : xml_items) {
-					append_xml(frag);
-				}
-			} else if (!xml_single.empty()) {
-				append_xml(xml_single);
 			}
 
 			if (list_vals.empty()) {
@@ -623,32 +554,39 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 				value = Value::LIST(child_type, std::move(list_vals));
 			}
 		} else {
-			// Scalar value. If the column was widened to VARCHAR but the source element had element
-			// children, the data is in the XML map; surface it as the serialized fragment.
-			std::string text = accumulator.GetValue(col_name);
-			if (text.empty()) {
-				std::string inner_xml = accumulator.GetXmlValue(col_name);
-				if (!inner_xml.empty() && col_type.id() == LogicalTypeId::VARCHAR) {
-					value = Value(inner_xml);
+			// Scalar value (possibly widened to VARCHAR).
+			const auto &occs = accumulator.GetOccurrences(col_name);
+			if (occs.empty()) {
+				value = Value(); // NULL
+			} else if (occs.size() == 1) {
+				const auto &occ = occs.front();
+				if (!occ.is_xml) {
+					if (occ.payload.empty() || IsNullString(occ.payload, options)) {
+						value = Value(); // NULL
+					} else {
+						value = XMLSchemaInference::ConvertToValuePublic(occ.payload, col_type, options, datetime_fmt);
+					}
 				} else if (col_type.id() == LogicalTypeId::VARCHAR) {
-					// Widened to VARCHAR but the element repeated: concatenate the list-map items so they
-					// are not dropped. Text items get wrapped in their element tag (mirroring the LIST
-					// branch); XML items are already serialized fragments. Order across maps is not kept.
-					std::string serialized;
-					for (const auto &item : accumulator.GetListValues(col_name)) {
-						serialized += "<" + col_name + ">" + XmlEscapeText(item) + "</" + col_name + ">";
-					}
-					for (const auto &frag : accumulator.GetXmlListValues(col_name)) {
-						serialized += frag;
-					}
-					value = serialized.empty() ? Value() : Value(serialized);
+					// Widened to VARCHAR but the source element had element children: surface the fragment.
+					value = Value(occ.payload);
 				} else {
 					value = Value(); // NULL
 				}
-			} else if (IsNullString(text, options)) {
-				value = Value(); // NULL
+			} else if (col_type.id() == LogicalTypeId::VARCHAR) {
+				// Widened to VARCHAR but the element repeated: concatenate occurrences in document
+				// order so none are dropped. Text items get wrapped in their element tag; XML items
+				// are already serialized fragments.
+				std::string serialized;
+				for (const auto &occ : occs) {
+					if (occ.is_xml) {
+						serialized += occ.payload;
+					} else {
+						serialized += "<" + col_name + ">" + XmlEscapeText(occ.payload) + "</" + col_name + ">";
+					}
+				}
+				value = serialized.empty() ? Value() : Value(serialized);
 			} else {
-				value = XMLSchemaInference::ConvertToValuePublic(text, col_type, options, datetime_fmt);
+				value = Value(); // NULL
 			}
 		}
 

--- a/src/xml_schema_inference.cpp
+++ b/src/xml_schema_inference.cpp
@@ -1854,16 +1854,20 @@ Value XMLSchemaInference::ConvertToValuePublic(const std::string &text, const Lo
 }
 
 Value XMLSchemaInference::ExtractValueFromXmlFragment(const std::string &wrapper_name, const std::string &inner_xml,
-                                                      const LogicalType &target_type, const XMLSchemaOptions &options) {
+                                                      const LogicalType &target_type, const XMLSchemaOptions &options,
+                                                      const std::string &extra_ns_decls) {
 	if (inner_xml.empty()) {
 		return Value(target_type);
 	}
 	// Wrap the fragment in its element so the parser sees a single root and so ExtractValueFromNode
-	// receives a node whose ->children are the original siblings.
+	// receives a node whose ->children are the original siblings. extra_ns_decls injects any xmlns:
+	// declarations the fragment's prefixed names depend on (the originating decls are not part of the
+	// captured fragment), without which strict parsing would fail and the value would be lost.
 	std::string wrapped;
-	wrapped.reserve(inner_xml.size() + wrapper_name.size() * 2 + 5);
+	wrapped.reserve(inner_xml.size() + wrapper_name.size() * 2 + extra_ns_decls.size() + 5);
 	wrapped.append("<")
 	    .append(wrapper_name)
+	    .append(extra_ns_decls)
 	    .append(">")
 	    .append(inner_xml)
 	    .append("</")

--- a/test/sql/github_issue_77_sax_edge_cases.test
+++ b/test/sql/github_issue_77_sax_edge_cases.test
@@ -1,0 +1,39 @@
+# name: test/sql/github_issue_77_sax_edge_cases.test
+# description: SAX rich-typing edge cases (issue #77): mixed text/XML list order, namespace decls
+# group: [sql]
+
+require webbed
+
+statement ok
+PRAGMA enable_verification
+
+# =============================================================================
+# Fix 2: document order preserved for mixed bare-text / nested-XML occurrences
+# =============================================================================
+#
+# sax_mixed_order.xml has a repeated <item>: text, nested-XML, text (in that
+# order). The list child unifies to STRUCT(nested), so the distinguishing
+# occurrence is the middle one ({nested: deep}). Before the fix the SAX reader
+# emitted all text occurrences first then all XML, pushing {nested: deep} to the
+# end; document order keeps it in the middle.
+
+# DOM reference: nested-XML occurrence stays in the middle
+query IIII
+SELECT len(item), item[1].nested IS NULL, item[2].nested, item[3].nested IS NULL
+FROM read_xml('test/xml/sax_mixed_order.xml', record_element:='record');
+----
+3	true	deep	true
+
+# SAX: same document order (was text-then-XML before the fix)
+query IIII
+SELECT len(item), item[1].nested IS NULL, item[2].nested, item[3].nested IS NULL
+FROM read_xml('test/xml/sax_mixed_order.xml', record_element:='record', maximum_file_size:=1);
+----
+3	true	deep	true
+
+# SAX <-> DOM equivalence on the full ordered list
+query I
+SELECT (SELECT item FROM read_xml('test/xml/sax_mixed_order.xml', record_element:='record', maximum_file_size:=1))
+     = (SELECT item FROM read_xml('test/xml/sax_mixed_order.xml', record_element:='record'));
+----
+true

--- a/test/sql/github_issue_77_sax_edge_cases.test
+++ b/test/sql/github_issue_77_sax_edge_cases.test
@@ -37,3 +37,62 @@ SELECT (SELECT item FROM read_xml('test/xml/sax_mixed_order.xml', record_element
      = (SELECT item FROM read_xml('test/xml/sax_mixed_order.xml', record_element:='record'));
 ----
 true
+
+# =============================================================================
+# Fix 1: namespace declarations injected into reparsed SAX fragments
+# =============================================================================
+#
+# sax_ns_keep.xml declares xmlns:ns on the root and uses <ns:tag> inside a
+# nested element. With namespaces:='keep' the SAX reader captures the prefixed
+# name into the fragment; reparsing it requires the xmlns:ns declaration, which
+# is injected from the accumulated document declarations. Without the fix the
+# strict reparse failed and the value collapsed to a typed NULL.
+
+# DOM reference: keep mode surfaces the nested value
+query II
+SELECT typeof(data), data.tag
+FROM read_xml('test/xml/sax_ns_keep.xml', record_element:='record', namespaces:='keep');
+----
+STRUCT(tag VARCHAR)	value
+
+# SAX: keep mode must also surface the value, not a typed NULL
+query II
+SELECT typeof(data), data.tag
+FROM read_xml('test/xml/sax_ns_keep.xml', record_element:='record', namespaces:='keep', maximum_file_size:=1);
+----
+STRUCT(tag VARCHAR)	value
+
+# strip-mode control: default strips the prefix before capture; behavior unchanged
+query II
+SELECT typeof(data), data.tag
+FROM read_xml('test/xml/sax_ns_keep.xml', record_element:='record');
+----
+STRUCT(tag VARCHAR)	value
+
+query II
+SELECT typeof(data), data.tag
+FROM read_xml('test/xml/sax_ns_keep.xml', record_element:='record', maximum_file_size:=1);
+----
+STRUCT(tag VARCHAR)	value
+
+# Namespace first declared on a later record (not the document root). Schema
+# inference must declare the cumulative set of prefixes on the synthetic root,
+# so the prefix resolves (field named 'b', not 'ns:b') and the value surfaces.
+
+# DOM reference
+query III
+SELECT typeof(item), item.a, item.b
+FROM read_xml('test/xml/sax_ns_later_record.xml', record_element:='record', namespaces:='keep')
+ORDER BY item.a NULLS LAST;
+----
+STRUCT(a INTEGER, b INTEGER)	1	NULL
+STRUCT(a INTEGER, b INTEGER)	NULL	2
+
+# SAX: must match DOM (was field 'ns:b' with value lost before the back() fix)
+query III
+SELECT typeof(item), item.a, item.b
+FROM read_xml('test/xml/sax_ns_later_record.xml', record_element:='record', namespaces:='keep', maximum_file_size:=1)
+ORDER BY item.a NULLS LAST;
+----
+STRUCT(a INTEGER, b INTEGER)	1	NULL
+STRUCT(a INTEGER, b INTEGER)	NULL	2

--- a/test/sql/xml_sax_accumulator_parity.test
+++ b/test/sql/xml_sax_accumulator_parity.test
@@ -33,8 +33,8 @@ ORDER BY id;
 # List-shaped column widened to VARCHAR by union_by_name. File A (read via SAX,
 # exceeds maximum_file_size) repeats <t> as text (LIST<VARCHAR>) and <s> as
 # nested XML (LIST<STRUCT(k)>). File B (DOM) collides each so both widen to
-# VARCHAR: <t> is a STRUCT, <s> is scalar text. <t> covers GetListValues, <s>
-# covers GetXmlListValues, so both columns are checked.
+# VARCHAR: <t> is a STRUCT, <s> is scalar text. <t> covers text-shaped
+# occurrences, <s> covers nested-XML occurrences, so both columns are checked.
 # =============================================================================
 
 # Both colliding columns widen to VARCHAR.

--- a/test/xml/sax_mixed_order.xml
+++ b/test/xml/sax_mixed_order.xml
@@ -1,0 +1,7 @@
+<root>
+  <record>
+    <item>text1</item>
+    <item><nested>deep</nested></item>
+    <item>text2</item>
+  </record>
+</root>

--- a/test/xml/sax_ns_keep.xml
+++ b/test/xml/sax_ns_keep.xml
@@ -1,0 +1,5 @@
+<root xmlns:ns="http://example.com/ns">
+  <record>
+    <data><ns:tag>value</ns:tag></data>
+  </record>
+</root>

--- a/test/xml/sax_ns_later_record.xml
+++ b/test/xml/sax_ns_later_record.xml
@@ -1,0 +1,4 @@
+<root>
+  <record><item><a>1</a></item></record>
+  <record xmlns:ns="http://example.com/ns"><item><ns:b>2</ns:b></item></record>
+</root>


### PR DESCRIPTION
Brings in @bendrucker's `sax-ns-order` follow-up to PR #75, closing both edge cases tracked in #77. Opening on his behalf to keep release-prep moving — his offer from #75: *"feel free to merge that branch into this PR if you want, or merge this as-is and I'll open a follow up to close #77."* All commits authored by him (verbatim from `bendrucker:sax-ns-order`); branch hosted on origin only because GitHub blocks cross-fork PRs from the upstream owner.

## Commit 1 — `20b92c3` preserve document order for mixed text/XML SAX occurrences

Replaces the four parallel accumulator maps (`current_values` / `current_xml_values` / `current_lists` / `current_xml_lists`) with a single `current_fields → vector<FieldOccurrence>` ordered sequence per field, each occurrence tagged `{is_xml, payload}` and appended in element-close order.

This is the *"cleaner shape ... one map of (name) → Variant<Text, XmlFragment> that preserves document order"* Ben himself flagged as out-of-scope in PR #75's body. Without this, the prior release would publish the parallel-maps shape that the author had already replaced.

- `SAXEndElementNs`: the 3-branch "promote scalar → list / append / new scalar" dance collapses to `current_fields[name].push_back({is_xml, std::move(value)})`. Singleton-vs-list semantics become consumer-derived from `occs.size()`.
- `InferSchemaFromStream`: 4 separate emit loops → 1 with a ternary on `occ.is_xml`. Closes the synthetic-doc-order leak.
- `AccumulatorToRow` LIST + VARCHAR branches: one ordered loop per field replaces the parallel-list dispatch. **This is the actual #77 case-2 fix** — the prior "Document order between text and XML items is not preserved" comment retires.
- STRUCT branch: now reads `occs.front()` explicitly, making the implicit "XML wins over text" semantics visible.

**Net −62 lines.**

## Commit 2 — `3520d3b` inject namespace declarations into reparsed SAX fragments

Closes the second #77 edge case: with `namespaces:='keep'`, SAX captures a prefixed nested element (`ns:tag`) into a raw fragment but not the originating `xmlns:ns` declaration. `ExtractValueFromXmlFragment` then reparses under strict (non-recovery) mode and the unresolved prefix collapses the value to typed NULL.

- `SAXStartElementNs` accumulates prefixed namespace declarations into a `std::map<string,string>` on the accumulator (skips default namespace — only prefixes need resolving; extraction matches by local name).
- Persistent across records (NOT cleared by `Reset()`) since root-level `xmlns:` decls appear before the first record.
- `BuildNamespaceDeclarations()` serializes as ` xmlns:prefix="uri"...` with `XmlEscapeAttr` on URIs (legitimately needed for `&` in query strings).
- `InferSchemaFromStream` declares accumulated namespaces on the synthetic `<root>` (uses `records.back()` — monotonic accumulation means it's the union of every decl seen while sampling).
- `AccumulatorToRow` builds `ns_decls` once per row, threads through 4 `ExtractValueFromXmlFragment` callsites via a defaulted `extra_ns_decls=""` parameter on the function added in #75 itself. **Fully backwards-compatible.**
- Default `namespaces:='strip'` is untouched — extra cost paid only when needed.

## Tests

- `test/sql/github_issue_77_sax_edge_cases.test`: ns-decl injection (DOM-ref + SAX-via-`maximum_file_size:=1` × keep mode + strip-mode control), mixed-order assertions for the FieldOccurrence refactor, and a `sax_ns_later_record.xml` case exercising the cumulative-across-records inference path (prefix first declared on a non-root record).
- `test/sql/xml_sax_accumulator_parity.test`: minor adjustments for the new internal API.
- Fixtures: `sax_mixed_order.xml`, `sax_ns_keep.xml`, `sax_ns_later_record.xml`.

## Closes

Closes #77.

cc @bendrucker — happy to amend the PR description if anything misrepresents the change.