### PR TITLE
fix: vector memory safety in scalar functions

### DIFF
--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -24,7 +24,7 @@ static void ExecuteNullSafeString(Vector &input, Vector &result, idx_t count, PR
 	for (idx_t i = 0; i < count; i++) {
 		auto input_idx = input_data.sel->get_index(i);
 		if (!input_data.validity.RowIsValid(input_idx)) {
-			result.SetValue(i, Value(result.GetType()));
+			FlatVector::SetNull(result, i, true);
 			continue;
 		}
 		process_row(i, input_strings[input_idx].GetString());

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -12,6 +12,25 @@
 
 namespace duckdb {
 
+// Iterates a string input vector via UnifiedVectorFormat (handles FLAT, DICTIONARY and CONSTANT
+// vectors) and propagates NULL inputs to NULL results. The callback receives the row index and
+// the row's string value, and stores its result via result.SetValue.
+template <class PROCESS_ROW>
+static void ExecuteNullSafeString(Vector &input, Vector &result, idx_t count, PROCESS_ROW process_row) {
+	UnifiedVectorFormat input_data;
+	CompatToUnifiedFormat(input, count, input_data);
+	auto input_strings = UnifiedVectorFormat::GetData<string_t>(input_data);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto input_idx = input_data.sel->get_index(i);
+		if (!input_data.validity.RowIsValid(input_idx)) {
+			result.SetValue(i, Value(result.GetType()));
+			continue;
+		}
+		process_row(i, input_strings[input_idx].GetString());
+	}
+}
+
 void XMLScalarFunctions::XMLValidFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
 
@@ -484,10 +503,7 @@ void XMLScalarFunctions::XMLExtractCommentsFunction(DataChunk &args, ExpressionS
 	auto &xml_vector = args.data[0];
 	auto count = args.size();
 
-	for (idx_t i = 0; i < count; i++) {
-		auto xml_str = FlatVector::GetData<string_t>(xml_vector)[i];
-		std::string xml_string = xml_str.GetString();
-
+	ExecuteNullSafeString(xml_vector, result, count, [&](idx_t i, const std::string &xml_string) {
 		auto comments = XMLUtils::ExtractComments(xml_string);
 
 		// Create list of comment structs
@@ -507,17 +523,14 @@ void XMLScalarFunctions::XMLExtractCommentsFunction(DataChunk &args, ExpressionS
 
 		Value list_value = Value::LIST(comment_struct_type, comment_values);
 		result.SetValue(i, list_value);
-	}
+	});
 }
 
 void XMLScalarFunctions::XMLExtractCDataFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
 	auto count = args.size();
 
-	for (idx_t i = 0; i < count; i++) {
-		auto xml_str = FlatVector::GetData<string_t>(xml_vector)[i];
-		std::string xml_string = xml_str.GetString();
-
+	ExecuteNullSafeString(xml_vector, result, count, [&](idx_t i, const std::string &xml_string) {
 		auto cdata_sections = XMLUtils::ExtractCData(xml_string);
 
 		// Create list of CDATA structs
@@ -537,17 +550,14 @@ void XMLScalarFunctions::XMLExtractCDataFunction(DataChunk &args, ExpressionStat
 
 		Value list_value = Value::LIST(cdata_struct_type, cdata_values);
 		result.SetValue(i, list_value);
-	}
+	});
 }
 
 void XMLScalarFunctions::XMLStatsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
 	auto count = args.size();
 
-	for (idx_t i = 0; i < count; i++) {
-		auto xml_str = FlatVector::GetData<string_t>(xml_vector)[i];
-		std::string xml_string = xml_str.GetString();
-
+	ExecuteNullSafeString(xml_vector, result, count, [&](idx_t i, const std::string &xml_string) {
 		auto stats = XMLUtils::GetXMLStats(xml_string);
 
 		// Create stats struct
@@ -560,17 +570,14 @@ void XMLScalarFunctions::XMLStatsFunction(DataChunk &args, ExpressionState &stat
 
 		Value stats_value = Value::STRUCT(stats_children);
 		result.SetValue(i, stats_value);
-	}
+	});
 }
 
 void XMLScalarFunctions::XMLNamespacesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &xml_vector = args.data[0];
 	auto count = args.size();
 
-	for (idx_t i = 0; i < count; i++) {
-		auto xml_str = FlatVector::GetData<string_t>(xml_vector)[i];
-		std::string xml_string = xml_str.GetString();
-
+	ExecuteNullSafeString(xml_vector, result, count, [&](idx_t i, const std::string &xml_string) {
 		auto namespaces = XMLUtils::ExtractNamespaces(xml_string);
 
 		// Create MAP(VARCHAR, VARCHAR) with prefix -> uri mappings
@@ -586,7 +593,7 @@ void XMLScalarFunctions::XMLNamespacesFunction(DataChunk &args, ExpressionState 
 		// Create MAP value
 		Value map_value = Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, keys, values);
 		result.SetValue(i, map_value);
-	}
+	});
 }
 
 void XMLScalarFunctions::XMLCommonNamespacesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -686,10 +693,7 @@ void XMLScalarFunctions::XMLDetectPrefixesFunction(DataChunk &args, ExpressionSt
 	    "following", "following-sibling", "namespace", "parent", "preceding",  "preceding-sibling",
 	    "self"};
 
-	for (idx_t i = 0; i < count; i++) {
-		auto xpath_str = FlatVector::GetData<string_t>(xpath_vector)[i];
-		std::string xpath = xpath_str.GetString();
-
+	ExecuteNullSafeString(xpath_vector, result, count, [&](idx_t i, const std::string &xpath) {
 		// Find all prefixes
 		std::set<std::string> prefixes;
 		std::sregex_iterator iter(xpath.begin(), xpath.end(), prefix_pattern);
@@ -712,7 +716,7 @@ void XMLScalarFunctions::XMLDetectPrefixesFunction(DataChunk &args, ExpressionSt
 
 		Value list_value = Value::LIST(LogicalType::VARCHAR, prefix_values);
 		result.SetValue(i, list_value);
-	}
+	});
 }
 
 void XMLScalarFunctions::XMLMockNamespacesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -752,12 +756,25 @@ void XMLScalarFunctions::XMLFindUndefinedPrefixesFunction(DataChunk &args, Expre
 	auto &xpath_vector = args.data[1];
 	auto count = args.size();
 
-	for (idx_t i = 0; i < count; i++) {
-		auto xml_str = FlatVector::GetData<string_t>(xml_vector)[i];
-		auto xpath_str = FlatVector::GetData<string_t>(xpath_vector)[i];
+	UnifiedVectorFormat xml_data;
+	UnifiedVectorFormat xpath_data;
+	CompatToUnifiedFormat(xml_vector, count, xml_data);
+	CompatToUnifiedFormat(xpath_vector, count, xpath_data);
 
-		std::string xml_string = xml_str.GetString();
-		std::string xpath = xpath_str.GetString();
+	auto xml_strings = UnifiedVectorFormat::GetData<string_t>(xml_data);
+	auto xpath_strings = UnifiedVectorFormat::GetData<string_t>(xpath_data);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto xml_idx = xml_data.sel->get_index(i);
+		auto xpath_idx = xpath_data.sel->get_index(i);
+
+		if (!xml_data.validity.RowIsValid(xml_idx) || !xpath_data.validity.RowIsValid(xpath_idx)) {
+			result.SetValue(i, Value(result.GetType()));
+			continue;
+		}
+
+		std::string xml_string = xml_strings[xml_idx].GetString();
+		std::string xpath = xpath_strings[xpath_idx].GetString();
 
 		// Get prefixes used in XPath
 		auto xpath_prefixes = DetectXPathPrefixes(xpath);
@@ -792,11 +809,8 @@ void XMLScalarFunctions::XMLAddNamespaceDeclarationsFunction(DataChunk &args, Ex
 	auto &ns_map_vector = args.data[1];
 	auto count = args.size();
 
-	for (idx_t i = 0; i < count; i++) {
-		auto xml_str = FlatVector::GetData<string_t>(xml_vector)[i];
+	ExecuteNullSafeString(xml_vector, result, count, [&](idx_t i, const std::string &xml_string) {
 		auto ns_map_value = ns_map_vector.GetValue(i);
-
-		std::string xml_string = xml_str.GetString();
 
 		// Parse the MAP value into case_insensitive_map
 		case_insensitive_map_t<string> namespaces_to_inject;
@@ -815,7 +829,7 @@ void XMLScalarFunctions::XMLAddNamespaceDeclarationsFunction(DataChunk &args, Ex
 		// Inject the namespaces
 		std::string modified_xml = InjectNamespaceDeclarations(xml_string, namespaces_to_inject);
 		result.SetValue(i, StringVector::AddString(result, modified_xml));
-	}
+	});
 }
 
 void XMLScalarFunctions::XMLLookupNamespaceFunction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -825,17 +839,14 @@ void XMLScalarFunctions::XMLLookupNamespaceFunction(DataChunk &args, ExpressionS
 	auto &prefix_vector = args.data[0];
 	auto count = args.size();
 
-	for (idx_t i = 0; i < count; i++) {
-		auto prefix_str = FlatVector::GetData<string_t>(prefix_vector)[i];
-		std::string prefix = prefix_str.GetString();
-
+	ExecuteNullSafeString(prefix_vector, result, count, [&](idx_t i, const std::string &prefix) {
 		std::string uri = GetCommonNamespaceURI(prefix);
 		if (uri.empty()) {
 			FlatVector::SetNull(result, i, true);
 		} else {
 			result.SetValue(i, Value(uri));
 		}
-	}
+	});
 }
 
 void XMLScalarFunctions::XMLToJSONFunction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1067,7 +1078,9 @@ void XMLScalarFunctions::ValueToXMLFunction(DataChunk &args, ExpressionState &st
 				std::string input_str;
 
 				if (input_value.IsNull()) {
-					input_str = "";
+					// NULL in -> NULL out
+					result.SetValue(i, Value(result.GetType()));
+					continue;
 				} else if (input_type.id() == LogicalTypeId::VARCHAR) {
 					input_str = input_value.GetValue<string>();
 				} else {
@@ -1606,10 +1619,7 @@ void XMLScalarFunctions::HTMLExtractLinksFunction(DataChunk &args, ExpressionSta
 	auto &html_vector = args.data[0];
 	auto count = args.size();
 
-	for (idx_t i = 0; i < count; i++) {
-		auto html_str = FlatVector::GetData<string_t>(html_vector)[i];
-		std::string html_string = html_str.GetString();
-
+	ExecuteNullSafeString(html_vector, result, count, [&](idx_t i, const std::string &html_string) {
 		auto links = XMLUtils::ExtractHTMLLinks(html_string);
 
 		vector<Value> link_values;
@@ -1629,17 +1639,14 @@ void XMLScalarFunctions::HTMLExtractLinksFunction(DataChunk &args, ExpressionSta
 
 		Value list_value = Value::LIST(link_struct_type, link_values);
 		result.SetValue(i, list_value);
-	}
+	});
 }
 
 void XMLScalarFunctions::HTMLExtractImagesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &html_vector = args.data[0];
 	auto count = args.size();
 
-	for (idx_t i = 0; i < count; i++) {
-		auto html_str = FlatVector::GetData<string_t>(html_vector)[i];
-		std::string html_string = html_str.GetString();
-
+	ExecuteNullSafeString(html_vector, result, count, [&](idx_t i, const std::string &html_string) {
 		auto images = XMLUtils::ExtractHTMLImages(html_string);
 
 		vector<Value> image_values;
@@ -1662,17 +1669,14 @@ void XMLScalarFunctions::HTMLExtractImagesFunction(DataChunk &args, ExpressionSt
 
 		Value list_value = Value::LIST(image_struct_type, image_values);
 		result.SetValue(i, list_value);
-	}
+	});
 }
 
 void XMLScalarFunctions::HTMLExtractTableRowsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &html_vector = args.data[0];
 	auto count = args.size();
 
-	for (idx_t i = 0; i < count; i++) {
-		auto html_str = FlatVector::GetData<string_t>(html_vector)[i];
-		std::string html_string = html_str.GetString();
-
+	ExecuteNullSafeString(html_vector, result, count, [&](idx_t i, const std::string &html_string) {
 		auto tables = XMLUtils::ExtractHTMLTables(html_string);
 
 		vector<Value> row_values;
@@ -1721,17 +1725,14 @@ void XMLScalarFunctions::HTMLExtractTableRowsFunction(DataChunk &args, Expressio
 
 		Value list_value = Value::LIST(table_row_struct_type, row_values);
 		result.SetValue(i, list_value);
-	}
+	});
 }
 
 void XMLScalarFunctions::HTMLExtractTablesJSONFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &html_vector = args.data[0];
 	auto count = args.size();
 
-	for (idx_t i = 0; i < count; i++) {
-		auto html_str = FlatVector::GetData<string_t>(html_vector)[i];
-		std::string html_string = html_str.GetString();
-
+	ExecuteNullSafeString(html_vector, result, count, [&](idx_t i, const std::string &html_string) {
 		auto tables = XMLUtils::ExtractHTMLTables(html_string);
 
 		vector<Value> table_values;
@@ -1830,7 +1831,7 @@ void XMLScalarFunctions::HTMLExtractTablesJSONFunction(DataChunk &args, Expressi
 
 		Value list_value = Value::LIST(table_json_struct_type, table_values);
 		result.SetValue(i, list_value);
-	}
+	});
 }
 
 void XMLScalarFunctions::ParseHTMLFunction(DataChunk &args, ExpressionState &state, Vector &result) {

--- a/src/xml_utils.cpp
+++ b/src/xml_utils.cpp
@@ -2154,11 +2154,16 @@ std::string XMLUtils::ScalarToXML(const std::string &value, const std::string &n
 void XMLUtils::ConvertListToXML(Vector &input_vector, Vector &result, idx_t count, const std::string &node_name) {
 	auto list_suffix = "_list";
 	auto element_name = node_name;
+	auto child_type = ListType::GetChildType(input_vector.GetType());
 
 	for (idx_t i = 0; i < count; i++) {
-		auto list_value = FlatVector::GetData<list_entry_t>(input_vector)[i];
-		auto &child_vector = CompatListGetChild(input_vector);
-		auto child_type = ListType::GetChildType(input_vector.GetType());
+		// Vector::GetValue handles FLAT, CONSTANT and DICTIONARY input vectors safely
+		Value list_value = input_vector.GetValue(i);
+		if (list_value.IsNull()) {
+			// NULL in -> NULL out
+			result.SetValue(i, Value(result.GetType()));
+			continue;
+		}
 
 		XMLDocPtr doc(xmlNewDoc(BAD_CAST "1.0"));
 		if (!doc) {
@@ -2171,23 +2176,22 @@ void XMLUtils::ConvertListToXML(Vector &input_vector, Vector &result, idx_t coun
 		xmlDocSetRootElement(doc.get(), root_node);
 
 		// Process each list element
-		for (idx_t j = 0; j < list_value.length; j++) {
-			idx_t child_idx = list_value.offset + j;
-
+		for (const auto &child_value : ListValue::GetChildren(list_value)) {
 			// Create element node for each list item
 			xmlNodePtr item_node = xmlNewNode(nullptr, BAD_CAST element_name.c_str());
 			xmlAddChild(root_node, item_node);
 
 			// Convert the child value based on its type
 			if (child_type.id() == LogicalTypeId::VARCHAR) {
-				auto child_data = FlatVector::GetData<string_t>(child_vector);
-				std::string child_str = child_data[child_idx].GetString();
-				xmlNodePtr text_node = xmlNewText(BAD_CAST child_str.c_str());
-				if (text_node)
-					xmlAddChild(item_node, text_node);
+				// Plain text content (NULL list elements stay as empty nodes)
+				if (!child_value.IsNull()) {
+					std::string child_str = StringValue::Get(child_value);
+					xmlNodePtr text_node = xmlNewText(BAD_CAST child_str.c_str());
+					if (text_node)
+						xmlAddChild(item_node, text_node);
+				}
 			} else {
 				// For other types, convert recursively
-				Value child_value = child_vector.GetValue(child_idx);
 				xmlNodePtr child_node = ConvertValueToXMLNode(child_value, child_type, element_name, doc.get());
 				if (child_node) {
 					// Add the child node's children to the item node
@@ -2222,6 +2226,15 @@ void XMLUtils::ConvertStructToXML(Vector &input_vector, Vector &result, idx_t co
 	auto &child_types = StructType::GetChildTypes(struct_type);
 
 	for (idx_t i = 0; i < count; i++) {
+		// Vector::GetValue handles FLAT, CONSTANT and DICTIONARY input vectors safely
+		Value struct_value = input_vector.GetValue(i);
+		if (struct_value.IsNull()) {
+			// NULL in -> NULL out
+			result.SetValue(i, Value(result.GetType()));
+			continue;
+		}
+		auto &field_values = StructValue::GetChildren(struct_value);
+
 		XMLDocPtr doc(xmlNewDoc(BAD_CAST "1.0"));
 		if (!doc) {
 			result.SetValue(i, Value("<" + node_name + "></" + node_name + ">"));
@@ -2237,15 +2250,12 @@ void XMLUtils::ConvertStructToXML(Vector &input_vector, Vector &result, idx_t co
 			auto &field_name = child_types[field_idx].first;
 			auto &field_type = child_types[field_idx].second;
 
-			// Get the child vector for this field
-			auto &field_vector = CompatStructGetField(input_vector, field_idx);
-
 			// Create field element
 			xmlNodePtr field_node = xmlNewNode(nullptr, BAD_CAST field_name.c_str());
 			xmlAddChild(root_node, field_node);
 
-			// Get field value and convert recursively using new node-based function
-			Value field_value = field_vector.GetValue(i);
+			// Convert recursively using the node-based function
+			auto &field_value = field_values[field_idx];
 			if (!field_value.IsNull()) {
 				xmlNodePtr child_node = ConvertValueToXMLNode(field_value, field_type, field_name, doc.get());
 				if (child_node) {

--- a/test/sql/vector_safety.test
+++ b/test/sql/vector_safety.test
@@ -1,0 +1,219 @@
+# name: test/sql/vector_safety.test
+# description: Regression tests for vector memory safety (NULL rows, constant vectors, multi-row inputs)
+# group: [sql]
+
+require webbed
+
+# --- xml_stats ---
+
+# Constant input replicated over multiple rows
+query I
+SELECT (xml_stats('<a/>')).element_count FROM range(3);
+----
+1
+1
+1
+
+# NULL in -> NULL out
+query I
+SELECT xml_stats(x) IS NULL FROM (VALUES ('<a/>'), (NULL), ('<b><c/></b>')) t(x);
+----
+false
+true
+false
+
+# --- xml_namespaces ---
+
+query I
+SELECT xml_namespaces('<r xmlns:p="urn:a"/>')['p'] FROM range(3);
+----
+urn:a
+urn:a
+urn:a
+
+query I
+SELECT xml_namespaces(x) IS NULL FROM (VALUES ('<r xmlns:p="urn:a"/>'), (NULL)) t(x);
+----
+false
+true
+
+# --- xml_extract_comments / xml_extract_cdata ---
+
+query I
+SELECT len(xml_extract_comments(x::XML)) FROM (VALUES ('<a><!--hi--></a>'), (NULL), ('<a/>')) t(x);
+----
+1
+NULL
+0
+
+query I
+SELECT len(xml_extract_cdata(x::XML)) FROM (VALUES ('<a><![CDATA[hi]]></a>'), (NULL), ('<a/>')) t(x);
+----
+1
+NULL
+0
+
+query I
+SELECT len(xml_extract_comments('<a><!--hi--></a>')) FROM range(3);
+----
+1
+1
+1
+
+# --- xml_detect_prefixes ---
+
+query I
+SELECT xml_detect_prefixes(x) FROM (VALUES ('//svg:circle'), (NULL)) t(x);
+----
+[svg]
+NULL
+
+# --- xml_find_undefined_prefixes ---
+
+query I
+SELECT xml_find_undefined_prefixes(x, p) FROM (VALUES ('<r/>', '//svg:circle'), (NULL, '//svg:circle'), ('<r/>', NULL)) t(x, p);
+----
+[svg]
+NULL
+NULL
+
+# --- xml_add_namespace_declarations ---
+
+query I
+SELECT xml_add_namespace_declarations(x, MAP {'p': 'urn:a'}) FROM (VALUES ('<r/>'), (NULL)) t(x);
+----
+<r xmlns:p="urn:a"/>
+NULL
+
+# --- xml_lookup_namespace ---
+
+query I
+SELECT xml_lookup_namespace(NULL);
+----
+NULL
+
+query I
+SELECT xml_lookup_namespace(p) FROM (VALUES ('svg'), (NULL), ('nosuchprefix')) t(p);
+----
+http://www.w3.org/2000/svg
+NULL
+NULL
+
+query I
+SELECT xml_lookup_namespace('svg') FROM range(3);
+----
+http://www.w3.org/2000/svg
+http://www.w3.org/2000/svg
+http://www.w3.org/2000/svg
+
+# --- to_xml: NULL propagation for scalars, lists and structs ---
+
+query II
+SELECT x, to_xml(x) IS NULL FROM (VALUES (1), (NULL)) t(x) ORDER BY x NULLS LAST;
+----
+1	false
+NULL	true
+
+query I
+SELECT to_xml(x) IS NULL FROM (VALUES (['a', 'b']), (NULL)) t(x);
+----
+false
+true
+
+query I
+SELECT to_xml(x) IS NULL FROM (VALUES ({'a': 1}), (NULL)) t(x);
+----
+false
+true
+
+# Constant list input replicated over many rows
+query I
+SELECT count(*) FROM (SELECT to_xml([1, 2, 3]) AS x FROM range(5000)) t WHERE x IS NOT NULL;
+----
+5000
+
+query I
+SELECT REPLACE(to_xml(['a', 'b'])::VARCHAR, chr(10), '') FROM range(2);
+----
+<?xml version="1.0"?><xml_list><xml>a</xml><xml>b</xml></xml_list>
+<?xml version="1.0"?><xml_list><xml>a</xml><xml>b</xml></xml_list>
+
+# Constant struct input replicated over multiple rows
+query I
+SELECT REPLACE(to_xml({'a': 1})::VARCHAR, chr(10), '') FROM range(2);
+----
+<?xml version="1.0"?><xml><a>1</a></xml>
+<?xml version="1.0"?><xml><a>1</a></xml>
+
+# NULL list elements become empty item nodes
+query I
+SELECT REPLACE(to_xml(['a', NULL, 'b'])::VARCHAR, chr(10), '');
+----
+<?xml version="1.0"?><xml_list><xml>a</xml><xml/><xml>b</xml></xml_list>
+
+# --- HTML extraction functions ---
+
+query I
+SELECT len(html_extract_links('<a href="https://example.com">x</a>')) FROM range(3);
+----
+1
+1
+1
+
+query I
+SELECT html_extract_links(h::HTML) IS NULL FROM (VALUES ('<a href="https://example.com">x</a>'), (NULL)) t(h);
+----
+false
+true
+
+query I
+SELECT html_extract_images(h::HTML) IS NULL FROM (VALUES ('<img src="a.png"/>'), (NULL)) t(h);
+----
+false
+true
+
+query I
+SELECT html_extract_table_rows(h::HTML) IS NULL FROM (VALUES ('<table><tr><td>1</td></tr></table>'), (NULL)) t(h);
+----
+false
+true
+
+# (documents without tables only: returning actual table data trips a pre-existing
+#  type mismatch between the declared STRUCT({}) fields and the produced values)
+query I
+SELECT html_extract_tables_json(h::HTML) IS NULL FROM (VALUES ('<p>x</p>'), (NULL)) t(h);
+----
+false
+true
+
+query I
+SELECT len(html_extract_images('<img src="a.png"/>')) FROM range(3);
+----
+1
+1
+1
+
+# --- multi-row mixed validity over a larger table ---
+
+statement ok
+CREATE TABLE vs_docs AS
+SELECT CASE WHEN i % 3 = 0 THEN NULL ELSE '<r xmlns:p="urn:a"><!--c--><![CDATA[d]]></r>' END AS doc
+FROM range(100) t(i);
+
+query III
+SELECT count(*) FILTER (s IS NULL), count(*) FILTER (s IS NOT NULL), max((s).element_count)
+FROM (SELECT xml_stats(doc) AS s FROM vs_docs) t;
+----
+34
+66
+1
+
+query II
+SELECT count(*) FILTER (c IS NULL), max(len(c))
+FROM (SELECT xml_extract_comments(doc::XML) AS c FROM vs_docs) t;
+----
+34
+1
+
+statement ok
+DROP TABLE vs_docs;


### PR DESCRIPTION
Fixes reproducible heap corruption (`SIGABRT: pointer being freed was not allocated`) when scalar functions run over NULL, constant, or dictionary-encoded inputs. Twelve scalar execute functions plus the `ConvertListToXML`/`ConvertStructToXML` helpers indexed raw `FlatVector::GetData` with the row index. NULL rows read uninitialized `string_t`s, constant vectors were indexed past their single element, and dictionary vectors were mis-indexed.

## Changes

- Adds an `ExecuteNullSafeString` helper (`UnifiedVectorFormat` + validity check + NULL propagation) and converts the eleven single-input VARCHAR functions to it (`xml_extract_comments`, `xml_extract_cdata`, `xml_stats`, `xml_namespaces`, `xml_detect_prefixes`, `xml_add_namespace_declarations`, `xml_lookup_namespace`, `html_extract_links`, `html_extract_images`, `html_extract_table_rows`, `html_extract_tables_json`)
- `xml_find_undefined_prefixes`: handles both inputs through `UnifiedVectorFormat`
- `ConvertListToXML`/`ConvertStructToXML`: row access via `Vector::GetValue`, which is safe for all vector classes, with NULL propagation at the list/struct level
- `to_xml`: a NULL row now returns NULL instead of `<xml></xml>`

The affected functions now follow NULL in, NULL out. No existing tests encoded the old NULL behavior, since it read garbage memory.

## Testing

New `test/sql/vector_safety.test` covers NULL rows, constant inputs replicated over `range(n)`, `to_xml` over lists and structs, and a 100-row mixed-validity scan across the affected functions.

Two follow-up fixes (per-row `node_name` in `to_xml`, namespace MAP dedup) are stacked on this branch. I'll submit them after this merges.
