### PR TITLE
fix: schema inference widening, attrs, order, output safety

### DIFF
--- a/src/include/xml_sax_reader.hpp
+++ b/src/include/xml_sax_reader.hpp
@@ -45,6 +45,11 @@ struct SAXRecordAccumulator {
 	std::unordered_map<std::string, std::vector<FieldOccurrence>> current_fields; // field_name -> ordered occurrences
 	std::unordered_map<std::string, std::string> current_attributes;              // attr_name -> value
 
+	// First-seen insertion order of current_fields / current_attributes keys, so synthetic XML
+	// built for schema inference reflects document order (deterministic column order).
+	std::vector<std::string> field_order;
+	std::vector<std::string> attribute_order;
+
 	// Namespace declarations (prefix -> URI) seen anywhere in the document, accumulated globally so
 	// reparsed nested-XML fragments can resolve prefixed names. Intentionally NOT cleared by Reset()
 	// since root-level xmlns: declarations appear before the first record.

--- a/src/include/xml_schema_inference.hpp
+++ b/src/include/xml_schema_inference.hpp
@@ -237,6 +237,11 @@ public:
 	// Trim edges, optionally normalize EOL or collapse whitespace (used by both DOM and SAX paths)
 	static std::string CleanTextContent(const std::string &text, bool preserve_whitespace);
 
+	// Map a column name back to the underlying XML attribute name. In attr_mode='prefixed' the
+	// inferred column name is attr_prefix + attribute name, so the prefix must be stripped before
+	// looking up the attribute on the node (used by both DOM and SAX extraction paths).
+	static std::string AttributeNameFromColumn(const std::string &column_name, const XMLSchemaOptions &options);
+
 	// Merge two column types from union_by_name inference across files.
 	// Recursively unions STRUCT fields, recurses into LIST element types, falls back to VARCHAR
 	// when a complex type collides with a non-matching kind. Scalar promotion uses
@@ -247,8 +252,9 @@ public:
 
 private:
 	// 3-phase schema inference helpers
-	static std::unordered_map<std::string, ColumnAnalysis>
-	IdentifyColumns(const std::vector<xmlNodePtr> &record_elements, const XMLSchemaOptions &options);
+	// Returns columns in first-seen document order so the inferred column order is deterministic.
+	static std::vector<ColumnAnalysis> IdentifyColumns(const std::vector<xmlNodePtr> &record_elements,
+	                                                   const XMLSchemaOptions &options);
 	static LogicalType InferColumnType(const ColumnAnalysis &column, int remaining_depth,
 	                                   const XMLSchemaOptions &options, std::string &winning_datetime_format);
 

--- a/src/xml_reader_functions.cpp
+++ b/src/xml_reader_functions.cpp
@@ -721,6 +721,24 @@ void XMLReaderFunctions::ReadDocumentObjectsFunction(ClientContext &context, Tab
 	CompatSetOutputCardinality(output, output_idx);
 }
 
+// Write one extracted row into the output chunk: optional filename column first, then the row's
+// values. Any output columns the row does not provide are NULL-filled so no vector slot is left
+// uninitialized (e.g. fallback schemas where extraction yields fewer values).
+static void EmitRow(DataChunk &output, idx_t output_idx, const std::vector<Value> &row, bool include_filename,
+                    const string &filename) {
+	idx_t output_col_idx = 0;
+	if (include_filename) {
+		output.data[output_col_idx++].SetValue(output_idx, Value(filename));
+	}
+	for (idx_t row_col_idx = 0; row_col_idx < row.size() && output_col_idx < output.ColumnCount();
+	     row_col_idx++, output_col_idx++) {
+		output.data[output_col_idx].SetValue(output_idx, row[row_col_idx]);
+	}
+	for (; output_col_idx < output.ColumnCount(); output_col_idx++) {
+		output.data[output_col_idx].SetValue(output_idx, Value(output.data[output_col_idx].GetType()));
+	}
+}
+
 void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &bind_data = data_p.bind_data->Cast<XMLReadFunctionData>();
 	auto &gstate = data_p.global_state->Cast<XMLReadGlobalState>();
@@ -870,14 +888,7 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 						    record, bind_data.column_names, bind_data.column_types, schema_options,
 						    bind_data.column_datetime_formats, bind_data.inferred_schema);
 
-						idx_t output_col_idx = 0;
-						if (bind_data.include_filename) {
-							output.data[output_col_idx++].SetValue(output_idx, Value(filename));
-						}
-						for (idx_t row_col_idx = 0; row_col_idx < row.size() && output_col_idx < output.ColumnCount();
-						     row_col_idx++, output_col_idx++) {
-							output.data[output_col_idx].SetValue(output_idx, row[row_col_idx]);
-						}
+						EmitRow(output, output_idx, row, bind_data.include_filename, filename);
 
 						output_idx++;
 						gstate.sax_pending_records.erase(gstate.sax_pending_records.begin());
@@ -911,14 +922,7 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 					                                             schema_options, bind_data.column_datetime_formats,
 					                                             bind_data.inferred_schema);
 
-					idx_t output_col_idx = 0;
-					if (bind_data.include_filename) {
-						output.data[output_col_idx++].SetValue(output_idx, Value(filename));
-					}
-					for (idx_t row_col_idx = 0; row_col_idx < row.size() && output_col_idx < output.ColumnCount();
-					     row_col_idx++, output_col_idx++) {
-						output.data[output_col_idx].SetValue(output_idx, row[row_col_idx]);
-					}
+					EmitRow(output, output_idx, row, bind_data.include_filename, filename);
 					output_idx++;
 					gstate.sax_pending_records.erase(gstate.sax_pending_records.begin());
 				}
@@ -951,14 +955,7 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 						                                              gstate.remaining_depth, schema_options);
 					}
 
-					idx_t output_col_idx = 0;
-					if (bind_data.include_filename) {
-						output.data[output_col_idx++].SetValue(output_idx, Value(filename));
-					}
-					for (idx_t row_col_idx = 0; row_col_idx < row.size() && output_col_idx < output.ColumnCount();
-					     row_col_idx++, output_col_idx++) {
-						output.data[output_col_idx].SetValue(output_idx, row[row_col_idx]);
-					}
+					EmitRow(output, output_idx, row, bind_data.include_filename, filename);
 
 					output_idx++;
 					gstate.current_record_index++;
@@ -1936,8 +1933,10 @@ void XMLReaderFunctions::ParseDocumentFunction(ClientContext &context, TableFunc
 	while (output_idx < STANDARD_VECTOR_SIZE && gstate.current_row < gstate.extracted_rows.size()) {
 		const auto &row = gstate.extracted_rows[gstate.current_row];
 
-		for (idx_t col_idx = 0; col_idx < row.size() && col_idx < output.ColumnCount(); col_idx++) {
-			output.data[col_idx].SetValue(output_idx, row[col_idx]);
+		for (idx_t col_idx = 0; col_idx < output.ColumnCount(); col_idx++) {
+			// NULL-fill columns the row did not provide so no vector slot is left uninitialized
+			Value value = col_idx < row.size() ? row[col_idx] : Value(output.data[col_idx].GetType());
+			output.data[col_idx].SetValue(output_idx, value);
 		}
 
 		output_idx++;

--- a/src/xml_sax_reader.cpp
+++ b/src/xml_sax_reader.cpp
@@ -13,6 +13,8 @@ void SAXRecordAccumulator::Reset() {
 	state = SAXAccumulatorState::SEEKING_RECORD;
 	current_fields.clear();
 	current_attributes.clear();
+	field_order.clear();
+	attribute_order.clear();
 	current_text.clear();
 	current_element_name.clear();
 	nested_xml.clear();
@@ -187,7 +189,9 @@ void SAXStartElementNs(void *ctx, const xmlChar *localname, const xmlChar *prefi
 				}
 
 				std::string attr_value(value_start, value_end);
-				acc->current_attributes[attr_name] = attr_value;
+				if (acc->current_attributes.emplace(attr_name, attr_value).second) {
+					acc->attribute_order.push_back(attr_name);
+				}
 			}
 		}
 	} else if (acc->state == SAXAccumulatorState::IN_RECORD) {
@@ -280,7 +284,12 @@ void SAXEndElementNs(void *ctx, const xmlChar *localname, const xmlChar *prefix,
 				value = XMLSchemaInference::CleanTextContent(acc->current_text, sax_ctx->preserve_whitespace);
 			}
 
-			acc->current_fields[name].push_back({is_xml, std::move(value)});
+			auto field_it = acc->current_fields.find(name);
+			if (field_it == acc->current_fields.end()) {
+				field_it = acc->current_fields.emplace(name, std::vector<FieldOccurrence>()).first;
+				acc->field_order.push_back(name);
+			}
+			field_it->second.push_back({is_xml, std::move(value)});
 
 			acc->current_text.clear();
 			acc->current_element_name.clear();
@@ -425,27 +434,28 @@ std::vector<XMLColumnInfo> SAXStreamReader::InferSchemaFromStream(FileSystem &fs
 	xml << "<root" << records.back().BuildNamespaceDeclarations() << ">";
 
 	for (const auto &record : records) {
-		xml << "<record>";
-
-		// Emit record-level attributes as elements for schema inference
+		// Emit record-level attributes as real attributes, in document order, so DOM inference
+		// applies the same attr_mode naming (e.g. 'prefixed') and typing as it does on real files
 		// (skip when attr_mode='discard' to match DOM behavior)
+		xml << "<record";
 		if (options.attr_mode != "discard") {
-			for (const auto &attr : record.current_attributes) {
+			for (const auto &attr_name : record.attribute_order) {
 				// Skip child element attributes (contain a dot)
-				if (attr.first.find('.') != std::string::npos) {
+				if (attr_name.find('.') != std::string::npos) {
 					continue;
 				}
-				xml << "<" << attr.first << ">" << XmlEscapeText(attr.second) << "</" << attr.first << ">";
+				xml << " " << attr_name << "=\"" << XmlEscapeAttr(record.GetAttribute(attr_name)) << "\"";
 			}
 		}
+		xml << ">";
 
 		// Emit each field's occurrences in document order: text payloads escaped, nested-XML
 		// fragments emitted structurally so DOM inference reconstructs the STRUCT / LIST shape.
-		for (const auto &field : record.current_fields) {
-			for (const auto &occ : field.second) {
-				xml << "<" << field.first << ">";
+		for (const auto &field_name : record.field_order) {
+			for (const auto &occ : record.GetOccurrences(field_name)) {
+				xml << "<" << field_name << ">";
 				xml << (occ.is_xml ? occ.payload : XmlEscapeText(occ.payload));
-				xml << "</" << field.first << ">";
+				xml << "</" << field_name << ">";
 			}
 		}
 
@@ -503,9 +513,12 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 			is_attribute = inferred_schema[i].is_attribute;
 		}
 
-		if (is_attribute || accumulator.HasAttribute(col_name)) {
+		// Attributes are accumulated under their bare XML names; in attr_mode='prefixed' the
+		// column name carries attr_prefix, so strip it before lookup.
+		const std::string attr_name = XMLSchemaInference::AttributeNameFromColumn(col_name, options);
+		if (is_attribute || accumulator.HasAttribute(attr_name)) {
 			// Attribute value
-			std::string attr_val = accumulator.GetAttribute(col_name);
+			std::string attr_val = accumulator.GetAttribute(attr_name);
 			if (attr_val.empty()) {
 				value = Value(); // NULL
 			} else if (IsNullString(attr_val, options)) {

--- a/src/xml_schema_inference.cpp
+++ b/src/xml_schema_inference.cpp
@@ -298,7 +298,10 @@ std::vector<ColumnAnalysis> XMLSchemaInference::IdentifyColumns(const std::vecto
 		// Check if any column appeared multiple times in this record
 		for (const auto &pair : columns_in_this_record) {
 			if (pair.second > 1) {
-				columns[column_index[pair.first]].repeats_in_record = true;
+				auto idx_it = column_index.find(pair.first);
+				if (idx_it != column_index.end()) {
+					columns[idx_it->second].repeats_in_record = true;
+				}
 			}
 		}
 	}

--- a/src/xml_schema_inference.cpp
+++ b/src/xml_schema_inference.cpp
@@ -3,10 +3,12 @@
 #include "duckdb_compat.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/exception/conversion_exception.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/cast_rules.hpp"
 #include "duckdb/function/scalar/strftime_format.hpp"
 #include <algorithm>
+#include <cmath>
 #include <regex>
 #include <unordered_set>
 #include <libxml/xpath.h>
@@ -132,12 +134,10 @@ std::vector<XMLColumnInfo> XMLSchemaInference::InferSchema(const std::string &xm
 	}
 
 	// Phase 2: Identify Columns (immediate children of records)
-	auto column_map = IdentifyColumns(record_elements, options);
+	auto column_list = IdentifyColumns(record_elements, options);
 
 	// Phase 3: Infer Type for each column
-	for (auto &pair : column_map) {
-		const auto &col_analysis = pair.second;
-
+	for (auto &col_analysis : column_list) {
 		std::string winning_fmt;
 		LogicalType col_type = InferColumnType(col_analysis, remaining_depth, options, winning_fmt);
 
@@ -233,9 +233,21 @@ std::vector<xmlNodePtr> XMLSchemaInference::IdentifyRecordElements(XMLDocRAII &d
 }
 
 // Phase 2: Identify Columns
-std::unordered_map<std::string, ColumnAnalysis>
-XMLSchemaInference::IdentifyColumns(const std::vector<xmlNodePtr> &record_elements, const XMLSchemaOptions &options) {
-	std::unordered_map<std::string, ColumnAnalysis> columns;
+// Columns are returned in first-seen document order (attributes of a record before its child
+// elements) so the inferred top-level column order is deterministic.
+std::vector<ColumnAnalysis> XMLSchemaInference::IdentifyColumns(const std::vector<xmlNodePtr> &record_elements,
+                                                                const XMLSchemaOptions &options) {
+	std::vector<ColumnAnalysis> columns;
+	std::unordered_map<std::string, size_t> column_index;
+
+	auto get_column = [&](const std::string &column_name, bool is_attribute) -> ColumnAnalysis & {
+		auto it = column_index.find(column_name);
+		if (it == column_index.end()) {
+			it = column_index.emplace(column_name, columns.size()).first;
+			columns.emplace_back(column_name, is_attribute);
+		}
+		return columns[it->second];
+	};
 
 	// Iterate through each record element
 	for (xmlNodePtr record : record_elements) {
@@ -257,11 +269,7 @@ XMLSchemaInference::IdentifyColumns(const std::vector<xmlNodePtr> &record_elemen
 						column_name = attr_name;
 					}
 
-					auto it = columns.find(column_name);
-					if (it == columns.end()) {
-						it = columns.emplace(column_name, ColumnAnalysis(column_name, true)).first;
-					}
-					auto &col = it->second;
+					auto &col = get_column(column_name, true);
 					col.instances.push_back(record); // Store record node for attribute access
 					col.occurrence_count++;
 					columns_in_this_record[column_name]++;
@@ -280,11 +288,7 @@ XMLSchemaInference::IdentifyColumns(const std::vector<xmlNodePtr> &record_elemen
 					element_name = StripNamespacePrefix(element_name);
 				}
 
-				auto it = columns.find(element_name);
-				if (it == columns.end()) {
-					it = columns.emplace(element_name, ColumnAnalysis(element_name, false)).first;
-				}
-				auto &col = it->second;
+				auto &col = get_column(element_name, false);
 				col.instances.push_back(child);
 				col.occurrence_count++;
 				columns_in_this_record[element_name]++;
@@ -294,10 +298,7 @@ XMLSchemaInference::IdentifyColumns(const std::vector<xmlNodePtr> &record_elemen
 		// Check if any column appeared multiple times in this record
 		for (const auto &pair : columns_in_this_record) {
 			if (pair.second > 1) {
-				auto col_it = columns.find(pair.first);
-				if (col_it != columns.end()) {
-					col_it->second.repeats_in_record = true;
-				}
+				columns[column_index[pair.first]].repeats_in_record = true;
 			}
 		}
 	}
@@ -1068,7 +1069,14 @@ LogicalType XMLSchemaInference::InferTypeFromSamples(const std::vector<std::stri
 		if (sample.empty())
 			continue;
 		if (options.numeric_detection && IsInteger(sample)) {
-			detected_types.push_back(LogicalType::INTEGER);
+			// Pick the narrowest integer type that can hold the value;
+			// GetMostSpecificType widens INTEGER to BIGINT when samples mix.
+			int32_t int32_result;
+			if (TryCast::Operation(string_t(sample), int32_result, true)) {
+				detected_types.push_back(LogicalType::INTEGER);
+			} else {
+				detected_types.push_back(LogicalType::BIGINT);
+			}
 		} else if (options.numeric_detection && IsDouble(sample)) {
 			detected_types.push_back(LogicalType::DOUBLE);
 		} else if (options.boolean_detection && IsBoolean(sample)) {
@@ -1156,26 +1164,20 @@ bool XMLSchemaInference::IsInteger(const std::string &value) {
 	if (value.empty())
 		return false;
 
-	try {
-		size_t pos;
-		std::stoll(value, &pos);
-		return pos == value.length(); // Entire string was converted
-	} catch (...) {
-		return false;
-	}
+	int64_t result;
+	return TryCast::Operation(string_t(value), result, true);
 }
 
 bool XMLSchemaInference::IsDouble(const std::string &value) {
 	if (value.empty())
 		return false;
 
-	try {
-		size_t pos;
-		std::stod(value, &pos);
-		return pos == value.length(); // Entire string was converted
-	} catch (...) {
+	double result;
+	if (!TryCast::Operation(string_t(value), result, true)) {
 		return false;
 	}
+	// Strings like "inf" and "nan" parse as DOUBLE but are not numeric data
+	return std::isfinite(result);
 }
 
 // IsDate, IsTime, IsTimestamp removed — replaced by StrpTimeFormat candidate elimination in InferTypeFromSamples.
@@ -1371,6 +1373,16 @@ LogicalType XMLSchemaInference::MergeXMLColumnType(const LogicalType &a, const L
 	return LogicalType::VARCHAR;
 }
 
+std::string XMLSchemaInference::AttributeNameFromColumn(const std::string &column_name,
+                                                        const XMLSchemaOptions &options) {
+	if (options.attr_mode == "prefixed" && !options.attr_prefix.empty() &&
+	    column_name.size() > options.attr_prefix.size() &&
+	    column_name.compare(0, options.attr_prefix.size(), options.attr_prefix) == 0) {
+		return column_name.substr(options.attr_prefix.size());
+	}
+	return column_name;
+}
+
 std::string XMLSchemaInference::CleanTextContent(const std::string &text, bool preserve_whitespace) {
 	// UTF-8-safe trim: only strip ASCII whitespace.
 	// We avoid StringUtil::Trim() because its RTrim has a `ch > 0` guard
@@ -1453,13 +1465,8 @@ std::vector<Value> XMLSchemaInference::ExtractSingleRecord(xmlNodePtr record, co
 		Value value;
 
 		if (column.is_attribute) {
-			// Extract attribute value
-			std::string attr_name = column.name;
-			// Remove element prefix if present (e.g., "employee_id" -> "id")
-			size_t underscore_pos = attr_name.find('_');
-			if (underscore_pos != std::string::npos) {
-				attr_name = attr_name.substr(underscore_pos + 1);
-			}
+			// Extract attribute value (strip attr_prefix in 'prefixed' mode)
+			std::string attr_name = AttributeNameFromColumn(column.name, options);
 
 			xmlChar *attr_value = xmlGetProp(record, (const xmlChar *)attr_name.c_str());
 			if (attr_value) {
@@ -1631,8 +1638,9 @@ std::vector<Value> XMLSchemaInference::ExtractSingleRecordWithSchema(
 
 		Value value;
 
-		// First check if it's an attribute
-		xmlChar *attr_value = xmlGetProp(record, (const xmlChar *)column_name.c_str());
+		// First check if it's an attribute (strip attr_prefix in 'prefixed' mode)
+		std::string attr_name = AttributeNameFromColumn(column_name, options);
+		xmlChar *attr_value = xmlGetProp(record, (const xmlChar *)attr_name.c_str());
 		if (attr_value) {
 			std::string str_value = (const char *)attr_value;
 			value = ConvertToValue(str_value, column_type, options, col_fmt);
@@ -1763,12 +1771,27 @@ Value XMLSchemaInference::ConvertToValue(const std::string &text, const LogicalT
 			}
 			return Value(); // NULL for unrecognized boolean
 		}
-		case LogicalTypeId::INTEGER:
-			return Value::INTEGER(std::stoi(text));
-		case LogicalTypeId::BIGINT:
-			return Value::BIGINT(std::stoll(text));
-		case LogicalTypeId::DOUBLE:
-			return Value::DOUBLE(std::stod(text));
+		case LogicalTypeId::INTEGER: {
+			int32_t int_result;
+			if (TryCast::Operation(string_t(text), int_result, false)) {
+				return Value::INTEGER(int_result);
+			}
+			return Value(text); // Fall back to VARCHAR value on conversion failure
+		}
+		case LogicalTypeId::BIGINT: {
+			int64_t bigint_result;
+			if (TryCast::Operation(string_t(text), bigint_result, false)) {
+				return Value::BIGINT(bigint_result);
+			}
+			return Value(text);
+		}
+		case LogicalTypeId::DOUBLE: {
+			double double_result;
+			if (TryCast::Operation(string_t(text), double_result, false)) {
+				return Value::DOUBLE(double_result);
+			}
+			return Value(text);
+		}
 		case LogicalTypeId::DATE: {
 			if (!datetime_format.empty()) {
 				StrpTimeFormat strp_format;

--- a/test/sql/xml_sax_dom_equivalence.test
+++ b/test/sql/xml_sax_dom_equivalence.test
@@ -216,13 +216,13 @@ priority	VARCHAR
 status	VARCHAR
 
 # SAX: schema includes all attributes from all records
-# Note: SAX emits attributes as elements in synthetic XML, so id gets type-inferred as INTEGER
-# (DOM keeps attributes as VARCHAR). This is a known difference.
+# SAX emits attributes as real attributes in the synthetic XML, so attribute typing and naming
+# match DOM (attributes stay VARCHAR).
 query II
 SELECT column_name, column_type FROM (DESCRIBE SELECT * FROM read_xml('test/xml/cross_record_attrs.xml', record_element:='item', maximum_file_size:=1)) ORDER BY column_name;
 ----
 data	VARCHAR
-id	INTEGER
+id	VARCHAR
 priority	VARCHAR
 status	VARCHAR
 

--- a/test/sql/xml_schema_inference_fixes.test
+++ b/test/sql/xml_schema_inference_fixes.test
@@ -1,0 +1,126 @@
+# name: test/sql/xml_schema_inference_fixes.test
+# description: Regression tests for schema inference fixes: integer widening, prefixed
+#              attributes, deterministic column order, inf/nan handling, and NULL-filling
+#              of fallback schema columns
+# group: [sql]
+
+require webbed
+
+# -----------------------------------------------------------------------------
+# Integer widening: values that do not fit INT32 must infer BIGINT, and values
+# beyond INT64 must infer DOUBLE
+# -----------------------------------------------------------------------------
+
+query IIIII
+SELECT typeof(small), typeof(big), typeof(mixed), typeof(neg), typeof(huge)
+FROM read_xml('test/xml/schema_inference/bigint_widening.xml') LIMIT 1;
+----
+INTEGER	BIGINT	BIGINT	BIGINT	DOUBLE
+
+query III
+SELECT small, big, mixed FROM read_xml('test/xml/schema_inference/bigint_widening.xml') ORDER BY small;
+----
+5	3000000000	7
+6	4000000001	3000000000
+
+query I
+SELECT neg FROM read_xml('test/xml/schema_inference/bigint_widening.xml') ORDER BY neg;
+----
+-4000000001
+-5
+
+# -----------------------------------------------------------------------------
+# attr_mode='prefixed': prefixed attribute columns must be populated
+# -----------------------------------------------------------------------------
+
+query II
+SELECT column_name, column_type
+FROM (DESCRIBE SELECT * FROM read_xml('test/xml/schema_inference/attr_prefixed.xml', attr_mode := 'prefixed'));
+----
+@id	VARCHAR
+v	INTEGER
+
+query II
+SELECT "@id", v FROM read_xml('test/xml/schema_inference/attr_prefixed.xml', attr_mode := 'prefixed') ORDER BY v;
+----
+1	1
+2	2
+
+# Custom prefix
+query II
+SELECT attr_id, v FROM read_xml('test/xml/schema_inference/attr_prefixed.xml', attr_mode := 'prefixed', attr_prefix := 'attr_') ORDER BY v;
+----
+1	1
+2	2
+
+# Default 'columns' mode still works
+query II
+SELECT id, v FROM read_xml('test/xml/schema_inference/attr_prefixed.xml') ORDER BY v;
+----
+1	1
+2	2
+
+# SAX streaming path (forced via maximum_file_size) must apply the same prefixed naming
+query II
+SELECT "@id", v FROM read_xml('test/xml/schema_inference/attr_prefixed.xml', attr_mode := 'prefixed', maximum_file_size := 1) ORDER BY v;
+----
+1	1
+2	2
+
+# -----------------------------------------------------------------------------
+# Deterministic column order: top-level columns must come out in document order
+# -----------------------------------------------------------------------------
+
+query I
+SELECT column_name FROM (DESCRIBE SELECT * FROM read_xml('test/xml/schema_inference/column_order.xml'));
+----
+delta
+alpha
+echo
+bravo
+zulu
+charlie
+yankee
+mike
+
+# SAX streaming inference must also preserve document order
+query I
+SELECT column_name FROM (DESCRIBE SELECT * FROM read_xml('test/xml/schema_inference/column_order.xml', maximum_file_size := 1));
+----
+delta
+alpha
+echo
+bravo
+zulu
+charlie
+yankee
+mike
+
+# -----------------------------------------------------------------------------
+# inf/nan strings must not be classified as DOUBLE
+# -----------------------------------------------------------------------------
+
+query IIII
+SELECT typeof(a), typeof(b), typeof(c), typeof(d)
+FROM read_xml('test/xml/schema_inference/inf_nan.xml') LIMIT 1;
+----
+VARCHAR	VARCHAR	VARCHAR	DOUBLE
+
+query II
+SELECT a, b FROM read_xml('test/xml/schema_inference/inf_nan.xml') ORDER BY b;
+----
+inf	NaN
+inf	nan
+
+# -----------------------------------------------------------------------------
+# Fallback schema must NULL-fill output columns instead of leaving them
+# uninitialized (invalid first file with ignore_errors yields the simple
+# 'xml' fallback schema, then rows from the valid file carry no values)
+# -----------------------------------------------------------------------------
+
+query I
+SELECT xml IS NULL
+FROM read_xml(['test/invalid/invalid.xml', 'test/xml/schema_inference/attr_prefixed.xml'], ignore_errors := true);
+----
+true
+true

--- a/test/xml/schema_inference/attr_prefixed.xml
+++ b/test/xml/schema_inference/attr_prefixed.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<root><r id="1"><v>1</v></r><r id="2"><v>2</v></r></root>

--- a/test/xml/schema_inference/bigint_widening.xml
+++ b/test/xml/schema_inference/bigint_widening.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<root>
+  <r><small>5</small><big>3000000000</big><mixed>7</mixed><neg>-4000000001</neg><huge>99999999999999999999</huge></r>
+  <r><small>6</small><big>4000000001</big><mixed>3000000000</mixed><neg>-5</neg><huge>1</huge></r>
+</root>

--- a/test/xml/schema_inference/column_order.xml
+++ b/test/xml/schema_inference/column_order.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<root>
+  <row><delta>1</delta><alpha>2</alpha><echo>3</echo><bravo>4</bravo><zulu>5</zulu><charlie>6</charlie><yankee>7</yankee><mike>8</mike></row>
+  <row><delta>9</delta><alpha>10</alpha><echo>11</echo><bravo>12</bravo><zulu>13</zulu><charlie>14</charlie><yankee>15</yankee><mike>16</mike></row>
+</root>

--- a/test/xml/schema_inference/inf_nan.xml
+++ b/test/xml/schema_inference/inf_nan.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<root>
+  <r><a>inf</a><b>nan</b><c>-inf</c><d>1.5</d></r>
+  <r><a>inf</a><b>NaN</b><c>Infinity</c><d>2.5</d></r>
+</root>


### PR DESCRIPTION
Fixes five `read_xml` schema-inference bugs in `xml_schema_inference.cpp` and the reader emit paths.

## Changes

- **Integer width**: inference pushed `INTEGER` for anything `std::stoll` could parse, so `<n>3000000000</n>` inferred INT32 and the scan threw `Could not convert string '3000000000' to INT32`. Samples now select INTEGER or BIGINT by value range and fall through to DOUBLE beyond INT64, widening across mixed samples like the CSV sniffer. `ConvertToValue` numeric cases use `TryCast` instead of `stoi`/`stoll`/`stod`.
- **`attr_mode := 'prefixed'`**: inference named columns `@id` but extraction called `xmlGetProp(record, "@id")`, so every attribute column was NULL. Extraction now strips the prefix when resolving the attribute name. I also removed a stale fallback that mangled names at the first `_`, and made SAX inference emit record attributes as real attributes so SAX and DOM agree (one pinned "known difference" expectation updated).
- **Column order**: `IdentifyColumns` returned an `unordered_map`, so DESCRIBE order varied run to run. It now returns columns in first-seen document order, for both DOM and SAX.
- **Locale and non-finite values**: `IsInteger`/`IsDouble` used locale-dependent `std::stod` and accepted `inf`/`nan` as DOUBLE. They now use strict `TryCast` and reject non-finite doubles, so such columns infer VARCHAR.
- **Uninitialized output**: with `ignore_errors := true` and the single-column fallback schema, emitted rows never wrote their slots and returned stale memory (reproduced as a 6653-character garbage string). A shared `EmitRow` helper NULL-fills any column a row does not provide.

One behavior change to note: `'12abc'` against an explicit INTEGER column now errors instead of silently truncating to 12, matching DuckDB cast semantics.

## Testing

New `test/sql/xml_schema_inference_fixes.test` with fixtures under `test/xml/schema_inference/`: BIGINT/DOUBLE widening, prefixed attributes (default and custom prefix, DOM and SAX), pinned document-order DESCRIBE (fails reliably pre-fix), `inf`/`nan` typing, and the NULL-fill fallback.
