### PR TITLE
fix: preserve significant inline whitespace in parse_html

### DIFF
--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -3,6 +3,7 @@
 #include "xml_types.hpp"
 #include "duckdb_compat.hpp"
 #include "duckdb/function/scalar_function.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/execution/expression_executor.hpp"
@@ -1833,6 +1834,66 @@ void XMLScalarFunctions::HTMLExtractTablesJSONFunction(DataChunk &args, Expressi
 	}
 }
 
+// Serialize a parsed HTML document without the XML declaration or DOCTYPE,
+// collapsing each run of whitespace outside tags to a single space. Runs are
+// collapsed rather than deleted because whitespace adjacent to tags can be
+// significant (e.g. between inline elements). Uses StringUtil::CharacterIsSpace
+// so UTF-8 continuation bytes are never misclassified as whitespace.
+// Returns false if the document could not be serialized.
+static bool SerializeMinifiedHTML(xmlDocPtr doc, std::string &minified_html) {
+	xmlChar *html_output = nullptr;
+	int output_size = 0;
+	xmlDocDumpMemory(doc, &html_output, &output_size);
+	if (!html_output) {
+		return false;
+	}
+	XMLCharPtr html_ptr(html_output);
+	std::string normalized_html(reinterpret_cast<const char *>(html_ptr.get()));
+
+	// Remove the leading XML declaration if present
+	if (normalized_html.compare(0, 2, "<?") == 0) {
+		size_t xml_decl_end = normalized_html.find("?>");
+		if (xml_decl_end != std::string::npos) {
+			normalized_html.erase(0, xml_decl_end + 2);
+		}
+	}
+
+	// Remove the leading DOCTYPE if present
+	size_t content_start = normalized_html.find_first_not_of(" \t\n\r");
+	if (content_start != std::string::npos && normalized_html.compare(content_start, 9, "<!DOCTYPE") == 0) {
+		size_t doctype_end = normalized_html.find('>', content_start);
+		if (doctype_end != std::string::npos) {
+			normalized_html.erase(content_start, doctype_end - content_start + 1);
+		}
+	}
+
+	minified_html.clear();
+	minified_html.reserve(normalized_html.length());
+	bool inside_tag = false;
+	bool pending_space = false;
+	for (char c : normalized_html) {
+		if (!inside_tag && StringUtil::CharacterIsSpace(c)) {
+			pending_space = true;
+			continue;
+		}
+		if (pending_space) {
+			// Collapse the run to one space; drop it at the document start
+			if (!minified_html.empty()) {
+				minified_html += ' ';
+			}
+			pending_space = false;
+		}
+		if (c == '<') {
+			inside_tag = true;
+		} else if (c == '>') {
+			inside_tag = false;
+		}
+		minified_html += c;
+	}
+	// A pending run at the document end is dropped, trimming trailing whitespace
+	return true;
+}
+
 void XMLScalarFunctions::ParseHTMLFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &file_path_vector = args.data[0];
 
@@ -1858,64 +1919,8 @@ void XMLScalarFunctions::ParseHTMLFunction(DataChunk &args, ExpressionState &sta
 			// Parse the HTML using the HTML parser to normalize it (removes DOCTYPE)
 			XMLDocRAII html_doc(content, true); // Use HTML parser
 			if (html_doc.IsValid()) {
-				// Serialize the document back to string (without DOCTYPE)
-				xmlChar *html_output = nullptr;
-				int output_size = 0;
-				xmlDocDumpMemory(html_doc.doc, &html_output, &output_size);
-
-				if (html_output) {
-					XMLCharPtr html_ptr(html_output);
-					std::string normalized_html = std::string(reinterpret_cast<const char *>(html_ptr.get()));
-
-					// Remove XML declaration if present
-					size_t xml_decl_end = normalized_html.find("?>");
-					if (xml_decl_end != std::string::npos) {
-						normalized_html = normalized_html.substr(xml_decl_end + 2);
-						// Remove leading whitespace/newlines
-						normalized_html.erase(0, normalized_html.find_first_not_of(" \t\n\r"));
-					}
-
-					// Remove DOCTYPE if present
-					size_t doctype_start = normalized_html.find("<!DOCTYPE");
-					if (doctype_start != std::string::npos) {
-						size_t doctype_end = normalized_html.find(">", doctype_start);
-						if (doctype_end != std::string::npos) {
-							normalized_html.erase(doctype_start, doctype_end - doctype_start + 1);
-							// Remove leading whitespace/newlines after DOCTYPE removal
-							normalized_html.erase(0, normalized_html.find_first_not_of(" \t\n\r"));
-						}
-					}
-
-					// Minify HTML: remove whitespace between tags
-					std::string minified_html;
-					bool in_tag = false;
-					bool in_content = false;
-					for (size_t i = 0; i < normalized_html.length(); i++) {
-						char c = normalized_html[i];
-
-						if (c == '<') {
-							in_tag = true;
-							in_content = false;
-							minified_html += c;
-						} else if (c == '>') {
-							in_tag = false;
-							in_content = true;
-							minified_html += c;
-						} else if (in_tag) {
-							// Inside tag: keep all characters
-							minified_html += c;
-						} else if (in_content) {
-							// Between tags: trim whitespace but keep content
-							if (!std::isspace(c)) {
-								minified_html += c;
-							} else if (!minified_html.empty() && minified_html.back() != '>' &&
-							           i + 1 < normalized_html.length() && normalized_html[i + 1] != '<') {
-								// Keep single space between words, but not between tags
-								minified_html += ' ';
-							}
-						}
-					}
-
+				std::string minified_html;
+				if (SerializeMinifiedHTML(html_doc.doc, minified_html)) {
 					return StringVector::AddString(result, minified_html);
 				}
 			}
@@ -1945,79 +1950,8 @@ void XMLScalarFunctions::ReadHTMLFunction(DataChunk &args, ExpressionState &stat
 			    // Parse the HTML using the HTML parser to normalize it
 			    XMLDocRAII html_doc(html_content, true); // Use HTML parser
 			    if (html_doc.IsValid()) {
-				    // Serialize the document back to string
-				    xmlChar *html_output = nullptr;
-				    int output_size = 0;
-				    xmlDocDumpMemory(html_doc.doc, &html_output, &output_size);
-
-				    if (html_output) {
-					    XMLCharPtr html_ptr(html_output);
-					    std::string normalized_html = std::string(reinterpret_cast<const char *>(html_ptr.get()));
-
-					    // Remove XML declaration if present
-					    size_t xml_decl_end = normalized_html.find("?>");
-					    if (xml_decl_end != std::string::npos) {
-						    normalized_html = normalized_html.substr(xml_decl_end + 2);
-						    // Remove leading whitespace/newlines
-						    normalized_html.erase(0, normalized_html.find_first_not_of(" \t\n\r"));
-					    }
-
-					    // Remove DOCTYPE if present
-					    size_t doctype_start = normalized_html.find("<!DOCTYPE");
-					    if (doctype_start != std::string::npos) {
-						    size_t doctype_end = normalized_html.find(">", doctype_start);
-						    if (doctype_end != std::string::npos) {
-							    normalized_html.erase(doctype_start, doctype_end - doctype_start + 1);
-							    // Remove leading whitespace/newlines after DOCTYPE removal
-							    normalized_html.erase(0, normalized_html.find_first_not_of(" \t\n\r"));
-						    }
-					    }
-
-					    // Minify HTML: remove whitespace between tags
-					    std::string minified_html;
-					    bool inside_tag = false;
-					    bool last_was_space = false;
-					    bool between_tags = true; // Start assuming we're between tags
-
-					    for (size_t i = 0; i < normalized_html.length(); i++) {
-						    char c = normalized_html[i];
-
-						    if (c == '<') {
-							    inside_tag = true;
-							    between_tags = false;
-							    minified_html += c;
-							    last_was_space = false;
-						    } else if (c == '>') {
-							    inside_tag = false;
-							    between_tags = true;
-							    minified_html += c;
-							    last_was_space = false;
-						    } else if (inside_tag) {
-							    minified_html += c;
-							    last_was_space = false;
-						    } else {
-							    if (std::isspace(c)) {
-								    if (between_tags) {
-									    // Skip all whitespace between tags
-									    continue;
-								    } else if (!last_was_space) {
-									    // Keep single space between words within text content
-									    minified_html += ' ';
-								    }
-								    last_was_space = true;
-							    } else {
-								    between_tags = false;
-								    minified_html += c;
-								    last_was_space = false;
-							    }
-						    }
-					    }
-
-					    // Trim trailing whitespace
-					    if (!minified_html.empty() && std::isspace(minified_html.back())) {
-						    minified_html.erase(minified_html.find_last_not_of(" \t\n\r") + 1);
-					    }
-
+				    std::string minified_html;
+				    if (SerializeMinifiedHTML(html_doc.doc, minified_html)) {
 					    return StringVector::AddString(result, minified_html);
 				    }
 			    }

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1848,7 +1848,7 @@ static bool SerializeMinifiedHTML(xmlDocPtr doc, std::string &minified_html) {
 		return false;
 	}
 	XMLCharPtr html_ptr(html_output);
-	std::string normalized_html(reinterpret_cast<const char *>(html_ptr.get()));
+	std::string normalized_html(reinterpret_cast<const char *>(html_ptr.get()), static_cast<size_t>(output_size));
 
 	// Remove the leading XML declaration if present
 	if (normalized_html.compare(0, 2, "<?") == 0) {

--- a/test/sql/parse_html_whitespace.test
+++ b/test/sql/parse_html_whitespace.test
@@ -1,0 +1,50 @@
+# name: test/sql/parse_html_whitespace.test
+# description: parse_html must preserve significant inline whitespace and handle non-ASCII bytes
+# group: [sql]
+
+require webbed
+
+# Space between an inline element and following text must be preserved
+query I
+SELECT parse_html('<p>Hello <b>world</b> again</p>') AS html_content;
+----
+<html><body><p>Hello <b>world</b> again</p></body></html>
+
+# Space separating two inline elements must be preserved
+query I
+SELECT parse_html('<p><b>bold</b> <i>italic</i></p>') AS html_content;
+----
+<html><body><p><b>bold</b> <i>italic</i></p></body></html>
+
+# Runs of whitespace inside text collapse to a single space
+query I
+SELECT parse_html('<p>Hello   	  world</p>') AS html_content;
+----
+<html><body><p>Hello world</p></body></html>
+
+# Newlines around inline elements collapse to a single separating space
+query I
+SELECT parse_html('<p>Hello
+<b>world</b>
+again</p>') AS html_content;
+----
+<html><body><p>Hello <b>world</b> again</p></body></html>
+
+# Non-ASCII text survives minification (UTF-8 continuation bytes such as 0xA0
+# in 'à' must not be treated as whitespace)
+query I
+SELECT parse_html('<p>voilà café naïve</p>') AS html_content;
+----
+<html><body><p>voilà café naïve</p></body></html>
+
+# Non-ASCII text around inline elements keeps separating spaces
+query I
+SELECT parse_html('<p>héllo <b>wörld</b> ągain</p>') AS html_content;
+----
+<html><body><p>héllo <b>wörld</b> ągain</p></body></html>
+
+# A DOCTYPE literal inside a comment survives DOCTYPE stripping
+query I
+SELECT parse_html('<html><body><!-- keep <!DOCTYPE html> inside --><p>x</p></body></html>') AS html_content;
+----
+<html><body><!-- keep <!DOCTYPE html> inside --><p>x</p></body></html>

--- a/test/sql/parse_html_whitespace.test
+++ b/test/sql/parse_html_whitespace.test
@@ -48,3 +48,24 @@ query I
 SELECT parse_html('<html><body><!-- keep <!DOCTYPE html> inside --><p>x</p></body></html>') AS html_content;
 ----
 <html><body><!-- keep <!DOCTYPE html> inside --><p>x</p></body></html>
+
+# Literal angle brackets in text are entity-escaped by the serializer, so the
+# whitespace scanner never mistakes them for tag boundaries
+query I
+SELECT parse_html('<html><body><p>a &lt; b   &gt;   c</p></body></html>') AS html_content;
+----
+<html><body><p>a &lt; b &gt; c</p></body></html>
+
+# Whitespace inside <pre> collapses to single spaces under the minification
+# policy (collapsed, never deleted); content is otherwise untouched
+query I
+SELECT parse_html('<html><body><pre>line1' || chr(10) || '  line2' || chr(10) || chr(9) || 'line3</pre></body></html>') AS html_content;
+----
+<html><body><pre>line1 line2 line3</pre></body></html>
+
+# Script content is wrapped in CDATA by the serializer; whitespace runs in it
+# collapse to single spaces but tokens are never fused together
+query I
+SELECT parse_html('<html><body><script>if (a > 0)  {  a  =  1;  }</script></body></html>') AS html_content;
+----
+<html><body><script><![CDATA[if (a > 0) { a = 1; }]]></script></body></html>

--- a/test/sql/read_html_content.test
+++ b/test/sql/read_html_content.test
@@ -28,7 +28,7 @@ SELECT parse_html('') AS html_content;
 ----
 <html></html>
 
-# Test HTML with extra whitespace (should be minified)
+# Test HTML with extra whitespace (runs collapse to a single space)
 query I
 SELECT parse_html('<html>
     <body>
@@ -37,7 +37,7 @@ SELECT parse_html('<html>
     </body>
 </html>') AS html_content;
 ----
-<html><body><h1>Title</h1><p>Some text with multiple spaces</p></body></html>
+<html> <body> <h1>Title</h1> <p>Some text with multiple spaces</p> </body> </html>
 
 # Test HTML with self-closing tags
 query I


### PR DESCRIPTION
Fixes `parse_html` deleting significant whitespace: `parse_html('<p>Hello <b>world</b> again</p>')` returned `<b>world</b>again`, dropping the space before "again". The hand-rolled minifier skipped every whitespace run adjacent to a tag boundary, and a serializer cannot know whether the surrounding elements are inline, so deletion is never safe.

## Changes

- Replaces the two duplicated minifier loops (`ReadHTMLFunction` and its file-based twin) with one shared `SerializeMinifiedHTML` helper
- Collapses each whitespace run to a single space instead of deleting it, trimming only at document start and end. Pretty-printed inter-tag newlines become single spaces, which renders identically
- Fixes undefined behavior from calling `std::isspace` on raw `char` (UTF-8 continuation bytes are negative) by using `StringUtil::CharacterIsSpace`
- Anchors the XML-declaration and DOCTYPE strips to the document start. The previous unanchored `find` could erase content when `<!DOCTYPE` appeared inside a comment

## Testing

New `test/sql/parse_html_whitespace.test`: the original repro, inline-element separators, run collapsing, non-ASCII inputs that exercise the `isspace` fix, and DOCTYPE-in-comment. One expectation in `read_html_content.test` updated to the collapse-to-one-space policy.
