### PR TITLE
fix: validate wrapper element name in xml_wrap_fragment

### DIFF
--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 
+#include <libxml/tree.h>
 #include <regex>
 #include <set>
 
@@ -314,6 +315,13 @@ void XMLScalarFunctions::XMLWrapFragmentFunction(DataChunk &args, ExpressionStat
 	    fragment_vector, wrapper_vector, result, args.size(), [&](string_t fragment_str, string_t wrapper_str) {
 		    std::string fragment = fragment_str.GetString();
 		    std::string wrapper = wrapper_str.GetString();
+
+		    // Reject wrapper names that are not valid XML element names to prevent markup injection.
+		    // The embedded NUL check guards against names that truncate during C-string validation.
+		    if (wrapper.find('\0') != std::string::npos ||
+		        xmlValidateName(reinterpret_cast<const xmlChar *>(wrapper.c_str()), 0) != 0) {
+			    throw InvalidInputException("xml_wrap_fragment: '%s' is not a valid XML element name", wrapper);
+		    }
 
 		    // Create wrapped XML: <wrapper>fragment</wrapper>
 		    std::string wrapped_xml = "<" + wrapper + ">" + fragment + "</" + wrapper + ">";

--- a/test/sql/xml_wrap_fragment_validation.test
+++ b/test/sql/xml_wrap_fragment_validation.test
@@ -1,0 +1,71 @@
+# name: test/sql/xml_wrap_fragment_validation.test
+# description: Test xml_wrap_fragment wrapper name validation (markup injection prevention)
+# group: [sql]
+
+require webbed
+
+# Valid simple wrapper name still works
+query I
+SELECT xml_wrap_fragment('<item>A</item>', 'items')::VARCHAR;
+----
+<items><item>A</item></items>
+
+# Valid namespace-prefixed wrapper name still works
+query I
+SELECT xml_wrap_fragment('<item>A</item>', 'ns:items')::VARCHAR;
+----
+<ns:items><item>A</item></ns:items>
+
+# Valid names with allowed punctuation (dash, dot, underscore)
+query I
+SELECT xml_wrap_fragment('x', 'my-wrapper._1')::VARCHAR;
+----
+<my-wrapper._1>x</my-wrapper._1>
+
+# Valid unicode wrapper name (XML Name allows non-ASCII letters)
+query I
+SELECT xml_wrap_fragment('x', 'über')::VARCHAR;
+----
+<über>x</über>
+
+# Injection attempt via '>' in wrapper name errors
+statement error
+SELECT xml_wrap_fragment('x', 'a><evil');
+----
+Invalid Input Error: xml_wrap_fragment: 'a><evil' is not a valid XML element name
+
+# Injection attempt via attribute in wrapper name errors
+statement error
+SELECT xml_wrap_fragment('x', 'a onload="evil"');
+----
+not a valid XML element name
+
+# Injection attempt via closing tag errors
+statement error
+SELECT xml_wrap_fragment('x', 'a></a><b');
+----
+not a valid XML element name
+
+# Empty wrapper name errors
+statement error
+SELECT xml_wrap_fragment('x', '');
+----
+not a valid XML element name
+
+# Name starting with a digit errors
+statement error
+SELECT xml_wrap_fragment('x', '1abc');
+----
+not a valid XML element name
+
+# Whitespace-only wrapper name errors
+statement error
+SELECT xml_wrap_fragment('x', ' ');
+----
+not a valid XML element name
+
+# NULL inputs still propagate as NULL
+query I
+SELECT xml_wrap_fragment('x', NULL) IS NULL;
+----
+true


### PR DESCRIPTION
Fixes markup injection in `xml_wrap_fragment`: the wrapper name was concatenated into markup unvalidated, so `xml_wrap_fragment('x', 'a><evil')` produced `<a><evil>x</a><evil>` typed as trusted `xml`.

## Changes

The wrapper name is now validated with libxml2's `xmlValidateName` before concatenation, and invalid names throw `InvalidInputException`. I chose Name over NCName so namespace-prefixed wrappers like `ns:items` keep working. An embedded-NUL check prevents a name that validates truncated (`'a\0><evil'`) from concatenating in full.

## Testing

New `test/sql/xml_wrap_fragment_validation.test`: injection variants error, while simple, prefixed, punctuated, and unicode names still work, and NULL propagates.
