### PR TITLE
fix: parse_html whitespace — proper CDATA/raw-text/preformatted handling (supersedes #88)

### DIFF
--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1834,13 +1834,61 @@ void XMLScalarFunctions::HTMLExtractTablesJSONFunction(DataChunk &args, Expressi
 	}
 }
 
-// Serialize a parsed HTML document without the XML declaration or DOCTYPE,
-// collapsing each run of whitespace outside tags to a single space. Runs are
-// collapsed rather than deleted because whitespace adjacent to tags can be
-// significant (e.g. between inline elements). Uses StringUtil::CharacterIsSpace
-// so UTF-8 continuation bytes are never misclassified as whitespace.
-// Returns false if the document could not be serialized.
+// Elements whose descendant text is whitespace-significant and must be preserved verbatim:
+// raw-text elements (script, style) and preformatted elements (pre, textarea).
+static bool IsWhitespacePreservingElement(const xmlChar *name) {
+	if (!name) {
+		return false;
+	}
+	std::string n(reinterpret_cast<const char *>(name));
+	return StringUtil::CIEquals(n, "pre") || StringUtil::CIEquals(n, "textarea") ||
+	       StringUtil::CIEquals(n, "script") || StringUtil::CIEquals(n, "style");
+}
+
+// Collapse each run of ASCII whitespace in TEXT nodes to a single space, recursively, operating
+// on the parse tree before serialization. CDATA and comment nodes are left untouched, and text
+// inside whitespace-preserving elements (pre/textarea/script/style) is left verbatim. Working on
+// the tree (rather than the serialized string) means a literal '>' or '&' in raw content is never
+// mistaken for a tag boundary, and libxml2 still handles escaping, CDATA wrapping and self-closing
+// on dump. The rewrite is done in place because the collapsed text is never longer than the
+// original, so no reallocation or entity round-trip is required. StringUtil::CharacterIsSpace is
+// used so UTF-8 continuation bytes are never misclassified as whitespace.
+static void CollapseTextWhitespace(xmlNodePtr node, bool preserve) {
+	for (xmlNodePtr child = node->children; child; child = child->next) {
+		if (child->type == XML_ELEMENT_NODE) {
+			CollapseTextWhitespace(child, preserve || IsWhitespacePreservingElement(child->name));
+		} else if (child->type == XML_TEXT_NODE && !preserve && child->content) {
+			xmlChar *content = child->content;
+			size_t w = 0;
+			bool pending_space = false;
+			for (size_t r = 0; content[r] != '\0'; r++) {
+				if (StringUtil::CharacterIsSpace(static_cast<char>(content[r]))) {
+					pending_space = true;
+					continue;
+				}
+				if (pending_space) {
+					// Keep a single separating space (significant between inline elements)
+					content[w++] = ' ';
+					pending_space = false;
+				}
+				content[w++] = content[r];
+			}
+			if (pending_space) {
+				content[w++] = ' ';
+			}
+			content[w] = '\0';
+		}
+		// CDATA_SECTION_NODE, COMMENT_NODE, etc. are intentionally left untouched
+	}
+}
+
+// Serialize a parsed HTML document without the XML declaration or DOCTYPE, collapsing each run of
+// whitespace to a single space except inside CDATA sections, comments, and whitespace-preserving
+// elements (see CollapseTextWhitespace). Returns false if the document could not be serialized.
 static bool SerializeMinifiedHTML(xmlDocPtr doc, std::string &minified_html) {
+	// Normalize whitespace on the parse tree first, then let libxml2 serialize.
+	CollapseTextWhitespace(reinterpret_cast<xmlNodePtr>(doc), false);
+
 	xmlChar *html_output = nullptr;
 	int output_size = 0;
 	xmlDocDumpMemory(doc, &html_output, &output_size);
@@ -1848,49 +1896,33 @@ static bool SerializeMinifiedHTML(xmlDocPtr doc, std::string &minified_html) {
 		return false;
 	}
 	XMLCharPtr html_ptr(html_output);
-	std::string normalized_html(reinterpret_cast<const char *>(html_ptr.get()), static_cast<size_t>(output_size));
+	std::string result(reinterpret_cast<const char *>(html_ptr.get()), static_cast<size_t>(output_size));
 
 	// Remove the leading XML declaration if present
-	if (normalized_html.compare(0, 2, "<?") == 0) {
-		size_t xml_decl_end = normalized_html.find("?>");
+	if (result.compare(0, 2, "<?") == 0) {
+		size_t xml_decl_end = result.find("?>");
 		if (xml_decl_end != std::string::npos) {
-			normalized_html.erase(0, xml_decl_end + 2);
+			result.erase(0, xml_decl_end + 2);
 		}
 	}
 
 	// Remove the leading DOCTYPE if present
-	size_t content_start = normalized_html.find_first_not_of(" \t\n\r");
-	if (content_start != std::string::npos && normalized_html.compare(content_start, 9, "<!DOCTYPE") == 0) {
-		size_t doctype_end = normalized_html.find('>', content_start);
+	size_t content_start = result.find_first_not_of(" \t\n\r");
+	if (content_start != std::string::npos && result.compare(content_start, 9, "<!DOCTYPE") == 0) {
+		size_t doctype_end = result.find('>', content_start);
 		if (doctype_end != std::string::npos) {
-			normalized_html.erase(content_start, doctype_end - content_start + 1);
+			result.erase(content_start, doctype_end - content_start + 1);
 		}
 	}
 
-	minified_html.clear();
-	minified_html.reserve(normalized_html.length());
-	bool inside_tag = false;
-	bool pending_space = false;
-	for (char c : normalized_html) {
-		if (!inside_tag && StringUtil::CharacterIsSpace(c)) {
-			pending_space = true;
-			continue;
-		}
-		if (pending_space) {
-			// Collapse the run to one space; drop it at the document start
-			if (!minified_html.empty()) {
-				minified_html += ' ';
-			}
-			pending_space = false;
-		}
-		if (c == '<') {
-			inside_tag = true;
-		} else if (c == '>') {
-			inside_tag = false;
-		}
-		minified_html += c;
+	// Trim whitespace introduced at the document edges (e.g. the serializer's trailing newline)
+	size_t first = result.find_first_not_of(" \t\n\r");
+	if (first == std::string::npos) {
+		minified_html.clear();
+		return true;
 	}
-	// A pending run at the document end is dropped, trimming trailing whitespace
+	size_t last = result.find_last_not_of(" \t\n\r");
+	minified_html.assign(result, first, last - first + 1);
 	return true;
 }
 

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -3,6 +3,7 @@
 #include "xml_types.hpp"
 #include "duckdb_compat.hpp"
 #include "duckdb/function/scalar_function.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/execution/expression_executor.hpp"
@@ -1833,6 +1834,66 @@ void XMLScalarFunctions::HTMLExtractTablesJSONFunction(DataChunk &args, Expressi
 	}
 }
 
+// Serialize a parsed HTML document without the XML declaration or DOCTYPE,
+// collapsing each run of whitespace outside tags to a single space. Runs are
+// collapsed rather than deleted because whitespace adjacent to tags can be
+// significant (e.g. between inline elements). Uses StringUtil::CharacterIsSpace
+// so UTF-8 continuation bytes are never misclassified as whitespace.
+// Returns false if the document could not be serialized.
+static bool SerializeMinifiedHTML(xmlDocPtr doc, std::string &minified_html) {
+	xmlChar *html_output = nullptr;
+	int output_size = 0;
+	xmlDocDumpMemory(doc, &html_output, &output_size);
+	if (!html_output) {
+		return false;
+	}
+	XMLCharPtr html_ptr(html_output);
+	std::string normalized_html(reinterpret_cast<const char *>(html_ptr.get()));
+
+	// Remove the leading XML declaration if present
+	if (normalized_html.compare(0, 2, "<?") == 0) {
+		size_t xml_decl_end = normalized_html.find("?>");
+		if (xml_decl_end != std::string::npos) {
+			normalized_html.erase(0, xml_decl_end + 2);
+		}
+	}
+
+	// Remove the leading DOCTYPE if present
+	size_t content_start = normalized_html.find_first_not_of(" \t\n\r");
+	if (content_start != std::string::npos && normalized_html.compare(content_start, 9, "<!DOCTYPE") == 0) {
+		size_t doctype_end = normalized_html.find('>', content_start);
+		if (doctype_end != std::string::npos) {
+			normalized_html.erase(content_start, doctype_end - content_start + 1);
+		}
+	}
+
+	minified_html.clear();
+	minified_html.reserve(normalized_html.length());
+	bool inside_tag = false;
+	bool pending_space = false;
+	for (char c : normalized_html) {
+		if (!inside_tag && StringUtil::CharacterIsSpace(c)) {
+			pending_space = true;
+			continue;
+		}
+		if (pending_space) {
+			// Collapse the run to one space; drop it at the document start
+			if (!minified_html.empty()) {
+				minified_html += ' ';
+			}
+			pending_space = false;
+		}
+		if (c == '<') {
+			inside_tag = true;
+		} else if (c == '>') {
+			inside_tag = false;
+		}
+		minified_html += c;
+	}
+	// A pending run at the document end is dropped, trimming trailing whitespace
+	return true;
+}
+
 void XMLScalarFunctions::ParseHTMLFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &file_path_vector = args.data[0];
 
@@ -1858,64 +1919,8 @@ void XMLScalarFunctions::ParseHTMLFunction(DataChunk &args, ExpressionState &sta
 			// Parse the HTML using the HTML parser to normalize it (removes DOCTYPE)
 			XMLDocRAII html_doc(content, true); // Use HTML parser
 			if (html_doc.IsValid()) {
-				// Serialize the document back to string (without DOCTYPE)
-				xmlChar *html_output = nullptr;
-				int output_size = 0;
-				xmlDocDumpMemory(html_doc.doc, &html_output, &output_size);
-
-				if (html_output) {
-					XMLCharPtr html_ptr(html_output);
-					std::string normalized_html = std::string(reinterpret_cast<const char *>(html_ptr.get()));
-
-					// Remove XML declaration if present
-					size_t xml_decl_end = normalized_html.find("?>");
-					if (xml_decl_end != std::string::npos) {
-						normalized_html = normalized_html.substr(xml_decl_end + 2);
-						// Remove leading whitespace/newlines
-						normalized_html.erase(0, normalized_html.find_first_not_of(" \t\n\r"));
-					}
-
-					// Remove DOCTYPE if present
-					size_t doctype_start = normalized_html.find("<!DOCTYPE");
-					if (doctype_start != std::string::npos) {
-						size_t doctype_end = normalized_html.find(">", doctype_start);
-						if (doctype_end != std::string::npos) {
-							normalized_html.erase(doctype_start, doctype_end - doctype_start + 1);
-							// Remove leading whitespace/newlines after DOCTYPE removal
-							normalized_html.erase(0, normalized_html.find_first_not_of(" \t\n\r"));
-						}
-					}
-
-					// Minify HTML: remove whitespace between tags
-					std::string minified_html;
-					bool in_tag = false;
-					bool in_content = false;
-					for (size_t i = 0; i < normalized_html.length(); i++) {
-						char c = normalized_html[i];
-
-						if (c == '<') {
-							in_tag = true;
-							in_content = false;
-							minified_html += c;
-						} else if (c == '>') {
-							in_tag = false;
-							in_content = true;
-							minified_html += c;
-						} else if (in_tag) {
-							// Inside tag: keep all characters
-							minified_html += c;
-						} else if (in_content) {
-							// Between tags: trim whitespace but keep content
-							if (!std::isspace(c)) {
-								minified_html += c;
-							} else if (!minified_html.empty() && minified_html.back() != '>' &&
-							           i + 1 < normalized_html.length() && normalized_html[i + 1] != '<') {
-								// Keep single space between words, but not between tags
-								minified_html += ' ';
-							}
-						}
-					}
-
+				std::string minified_html;
+				if (SerializeMinifiedHTML(html_doc.doc, minified_html)) {
 					return StringVector::AddString(result, minified_html);
 				}
 			}
@@ -1945,79 +1950,8 @@ void XMLScalarFunctions::ReadHTMLFunction(DataChunk &args, ExpressionState &stat
 			    // Parse the HTML using the HTML parser to normalize it
 			    XMLDocRAII html_doc(html_content, true); // Use HTML parser
 			    if (html_doc.IsValid()) {
-				    // Serialize the document back to string
-				    xmlChar *html_output = nullptr;
-				    int output_size = 0;
-				    xmlDocDumpMemory(html_doc.doc, &html_output, &output_size);
-
-				    if (html_output) {
-					    XMLCharPtr html_ptr(html_output);
-					    std::string normalized_html = std::string(reinterpret_cast<const char *>(html_ptr.get()));
-
-					    // Remove XML declaration if present
-					    size_t xml_decl_end = normalized_html.find("?>");
-					    if (xml_decl_end != std::string::npos) {
-						    normalized_html = normalized_html.substr(xml_decl_end + 2);
-						    // Remove leading whitespace/newlines
-						    normalized_html.erase(0, normalized_html.find_first_not_of(" \t\n\r"));
-					    }
-
-					    // Remove DOCTYPE if present
-					    size_t doctype_start = normalized_html.find("<!DOCTYPE");
-					    if (doctype_start != std::string::npos) {
-						    size_t doctype_end = normalized_html.find(">", doctype_start);
-						    if (doctype_end != std::string::npos) {
-							    normalized_html.erase(doctype_start, doctype_end - doctype_start + 1);
-							    // Remove leading whitespace/newlines after DOCTYPE removal
-							    normalized_html.erase(0, normalized_html.find_first_not_of(" \t\n\r"));
-						    }
-					    }
-
-					    // Minify HTML: remove whitespace between tags
-					    std::string minified_html;
-					    bool inside_tag = false;
-					    bool last_was_space = false;
-					    bool between_tags = true; // Start assuming we're between tags
-
-					    for (size_t i = 0; i < normalized_html.length(); i++) {
-						    char c = normalized_html[i];
-
-						    if (c == '<') {
-							    inside_tag = true;
-							    between_tags = false;
-							    minified_html += c;
-							    last_was_space = false;
-						    } else if (c == '>') {
-							    inside_tag = false;
-							    between_tags = true;
-							    minified_html += c;
-							    last_was_space = false;
-						    } else if (inside_tag) {
-							    minified_html += c;
-							    last_was_space = false;
-						    } else {
-							    if (std::isspace(c)) {
-								    if (between_tags) {
-									    // Skip all whitespace between tags
-									    continue;
-								    } else if (!last_was_space) {
-									    // Keep single space between words within text content
-									    minified_html += ' ';
-								    }
-								    last_was_space = true;
-							    } else {
-								    between_tags = false;
-								    minified_html += c;
-								    last_was_space = false;
-							    }
-						    }
-					    }
-
-					    // Trim trailing whitespace
-					    if (!minified_html.empty() && std::isspace(minified_html.back())) {
-						    minified_html.erase(minified_html.find_last_not_of(" \t\n\r") + 1);
-					    }
-
+				    std::string minified_html;
+				    if (SerializeMinifiedHTML(html_doc.doc, minified_html)) {
 					    return StringVector::AddString(result, minified_html);
 				    }
 			    }

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1848,7 +1848,7 @@ static bool SerializeMinifiedHTML(xmlDocPtr doc, std::string &minified_html) {
 		return false;
 	}
 	XMLCharPtr html_ptr(html_output);
-	std::string normalized_html(reinterpret_cast<const char *>(html_ptr.get()));
+	std::string normalized_html(reinterpret_cast<const char *>(html_ptr.get()), static_cast<size_t>(output_size));
 
 	// Remove the leading XML declaration if present
 	if (normalized_html.compare(0, 2, "<?") == 0) {

--- a/test/sql/parse_html_whitespace.test
+++ b/test/sql/parse_html_whitespace.test
@@ -1,0 +1,50 @@
+# name: test/sql/parse_html_whitespace.test
+# description: parse_html must preserve significant inline whitespace and handle non-ASCII bytes
+# group: [sql]
+
+require webbed
+
+# Space between an inline element and following text must be preserved
+query I
+SELECT parse_html('<p>Hello <b>world</b> again</p>') AS html_content;
+----
+<html><body><p>Hello <b>world</b> again</p></body></html>
+
+# Space separating two inline elements must be preserved
+query I
+SELECT parse_html('<p><b>bold</b> <i>italic</i></p>') AS html_content;
+----
+<html><body><p><b>bold</b> <i>italic</i></p></body></html>
+
+# Runs of whitespace inside text collapse to a single space
+query I
+SELECT parse_html('<p>Hello   	  world</p>') AS html_content;
+----
+<html><body><p>Hello world</p></body></html>
+
+# Newlines around inline elements collapse to a single separating space
+query I
+SELECT parse_html('<p>Hello
+<b>world</b>
+again</p>') AS html_content;
+----
+<html><body><p>Hello <b>world</b> again</p></body></html>
+
+# Non-ASCII text survives minification (UTF-8 continuation bytes such as 0xA0
+# in 'à' must not be treated as whitespace)
+query I
+SELECT parse_html('<p>voilà café naïve</p>') AS html_content;
+----
+<html><body><p>voilà café naïve</p></body></html>
+
+# Non-ASCII text around inline elements keeps separating spaces
+query I
+SELECT parse_html('<p>héllo <b>wörld</b> ągain</p>') AS html_content;
+----
+<html><body><p>héllo <b>wörld</b> ągain</p></body></html>
+
+# A DOCTYPE literal inside a comment survives DOCTYPE stripping
+query I
+SELECT parse_html('<html><body><!-- keep <!DOCTYPE html> inside --><p>x</p></body></html>') AS html_content;
+----
+<html><body><!-- keep <!DOCTYPE html> inside --><p>x</p></body></html>

--- a/test/sql/parse_html_whitespace.test
+++ b/test/sql/parse_html_whitespace.test
@@ -56,16 +56,38 @@ SELECT parse_html('<html><body><p>a &lt; b   &gt;   c</p></body></html>') AS htm
 ----
 <html><body><p>a &lt; b &gt; c</p></body></html>
 
-# Whitespace inside <pre> collapses to single spaces under the minification
-# policy (collapsed, never deleted); content is otherwise untouched
+# Whitespace inside <pre> is preserved verbatim: preformatted content is
+# whitespace-significant, so newlines and runs are NOT collapsed. Compared as a
+# boolean because the value contains newlines.
 query I
-SELECT parse_html('<html><body><pre>line1' || chr(10) || '  line2' || chr(10) || chr(9) || 'line3</pre></body></html>') AS html_content;
+SELECT parse_html('<html><body><pre>line1' || chr(10) || '  line2' || chr(10) || chr(9) || 'line3</pre></body></html>')
+       = '<html><body><pre>line1' || chr(10) || '  line2' || chr(10) || chr(9) || 'line3</pre></body></html>';
 ----
-<html><body><pre>line1 line2 line3</pre></body></html>
+true
 
-# Script content is wrapped in CDATA by the serializer; whitespace runs in it
-# collapse to single spaces but tokens are never fused together
+# Script content is raw text (wrapped in CDATA by the serializer) and preserved
+# verbatim: whitespace runs are NOT collapsed and a literal '>' inside it is never
+# treated as a tag boundary
 query I
 SELECT parse_html('<html><body><script>if (a > 0)  {  a  =  1;  }</script></body></html>') AS html_content;
 ----
-<html><body><script><![CDATA[if (a > 0) { a = 1; }]]></script></body></html>
+<html><body><script><![CDATA[if (a > 0)  {  a  =  1;  }]]></script></body></html>
+
+# Style content (also raw text) is preserved verbatim
+query I
+SELECT parse_html('<html><head><style>a {  color :  red ;  }</style></head></html>') AS html_content;
+----
+<html><head><style><![CDATA[a {  color :  red ;  }]]></style></head></html>
+
+# A comment containing a literal '>' and internal whitespace is preserved verbatim
+query I
+SELECT parse_html('<html><body><p>x<!-- a > b   c --></p></body></html>') AS html_content;
+----
+<html><body><p>x<!-- a > b   c --></p></body></html>
+
+# Non-breaking spaces (U+00A0) are NOT whitespace and must be preserved, not collapsed.
+# Compared as a boolean since the value contains non-ASCII bytes.
+query I
+SELECT parse_html('<p>a&nbsp;&nbsp;b</p>') = '<html><body><p>a' || chr(160) || chr(160) || 'b</p></body></html>';
+----
+true

--- a/test/sql/parse_html_whitespace.test
+++ b/test/sql/parse_html_whitespace.test
@@ -48,3 +48,24 @@ query I
 SELECT parse_html('<html><body><!-- keep <!DOCTYPE html> inside --><p>x</p></body></html>') AS html_content;
 ----
 <html><body><!-- keep <!DOCTYPE html> inside --><p>x</p></body></html>
+
+# Literal angle brackets in text are entity-escaped by the serializer, so the
+# whitespace scanner never mistakes them for tag boundaries
+query I
+SELECT parse_html('<html><body><p>a &lt; b   &gt;   c</p></body></html>') AS html_content;
+----
+<html><body><p>a &lt; b &gt; c</p></body></html>
+
+# Whitespace inside <pre> collapses to single spaces under the minification
+# policy (collapsed, never deleted); content is otherwise untouched
+query I
+SELECT parse_html('<html><body><pre>line1' || chr(10) || '  line2' || chr(10) || chr(9) || 'line3</pre></body></html>') AS html_content;
+----
+<html><body><pre>line1 line2 line3</pre></body></html>
+
+# Script content is wrapped in CDATA by the serializer; whitespace runs in it
+# collapse to single spaces but tokens are never fused together
+query I
+SELECT parse_html('<html><body><script>if (a > 0)  {  a  =  1;  }</script></body></html>') AS html_content;
+----
+<html><body><script><![CDATA[if (a > 0) { a = 1; }]]></script></body></html>

--- a/test/sql/read_html_content.test
+++ b/test/sql/read_html_content.test
@@ -28,7 +28,7 @@ SELECT parse_html('') AS html_content;
 ----
 <html></html>
 
-# Test HTML with extra whitespace (should be minified)
+# Test HTML with extra whitespace (runs collapse to a single space)
 query I
 SELECT parse_html('<html>
     <body>
@@ -37,7 +37,7 @@ SELECT parse_html('<html>
     </body>
 </html>') AS html_content;
 ----
-<html><body><h1>Title</h1><p>Some text with multiple spaces</p></body></html>
+<html> <body> <h1>Title</h1> <p>Some text with multiple spaces</p> </body> </html>
 
 # Test HTML with self-closing tags
 query I


### PR DESCRIPTION
Builds on @bendrucker's #88 and finishes the whitespace story so it's correct for CDATA, raw-text, and preformatted content.

## Why this supersedes #88
#88 changed the HTML minifier from deleting inter-tag whitespace to collapsing it (plus an `isspace`-UB fix and anchored DOCTYPE/decl stripping — all kept here). But it still minified by walking the **serialized string** and naively tracking `<`/`>`, so raw content was treated as markup:

- `<script>if (a > 0) {...}</script>` → the `>` in `a > 0` was read as a tag-close, **deleting** the following space (`a >0`).
- `<style>…</style>` with no `>` in it → the whole `<![CDATA[…]]>` was seen as one "tag" → whitespace **fully preserved**.

So whether script/style/CDATA survived intact depended on whether it happened to contain a `>`.

## Fix
Stop string-walking serialized output. Normalize whitespace on the **parse tree** instead: collapse whitespace runs in `XML_TEXT_NODE`s only, skipping `XML_CDATA_SECTION_NODE`, `XML_COMMENT_NODE`, and whitespace-preserving elements (`pre`/`textarea`/`script`/`style`); then let libxml2 serialize (it handles escaping, CDATA wrapping, self-closing). The text rewrite is in place — collapsed text is never longer than the original — so no reallocation or entity round-trip.

Result: general inline whitespace still collapses (#88's fix), while `<pre>`/`<script>`/`<style>`/CDATA/comments are now verbatim, a literal `>`/`&` in content is never mistaken for markup, and `&nbsp;` (U+00A0) is preserved (not ASCII whitespace).

## Tests
Extends `test/sql/parse_html_whitespace.test`: `<pre>` (verbatim, boolean-compared due to newlines), `<script>`/`<style>` verbatim, comment with literal `>`, and `&nbsp;` preservation. Full suite green (2687 assertions / 75 cases) locally against pinned v1.5.3.

## Merge note
Please **merge with a merge commit (not squash)** so @bendrucker's two commits (the inline-whitespace + explicit-length fixes) retain their authorship. Closes #88 in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)