### PR TITLE
fix: restore DuckDB main compatibility for the Identifier type

### DIFF
--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -19,7 +19,41 @@
 #include "duckdb/function/function_set.hpp"
 #endif
 
+// Detect the duckdb::Identifier type (newer DuckDB main), which replaced std::string as the key
+// of child_list_t (STRUCT/UNION field names) and several name-typed fields (e.g. table alias,
+// Expression::GetAlias). Identifier does not implicitly convert to/from std::string, so reads and
+// constructions at the boundary must go through the helpers below. Detected by header presence so
+// it stays orthogonal to DUCKDB_HAS_NEW_VECTOR_HEADERS.
+#if __has_include("duckdb/common/identifier.hpp")
+#define DUCKDB_HAS_IDENTIFIER 1
+#include "duckdb/common/identifier.hpp"
+#endif
+
 namespace duckdb {
+
+// --- Identifier <-> string boundary helpers ---
+// CompatIdentifierName: read the raw string name from a child_list_t key / aliased name.
+// CompatMakeIdentifier: build a child_list_t key (or name-typed field) from a runtime string.
+// On older DuckDB these are pass-throughs (the key already is a std::string).
+#ifdef DUCKDB_HAS_IDENTIFIER
+inline const string &CompatIdentifierName(const Identifier &id) {
+	return id.GetIdentifierName();
+}
+inline const string &CompatIdentifierName(const string &name) {
+	return name;
+}
+inline Identifier CompatMakeIdentifier(string name) {
+	return Identifier(std::move(name));
+}
+#else
+inline const string &CompatIdentifierName(const string &name) {
+	return name;
+}
+inline string CompatMakeIdentifier(string name) {
+	return name;
+}
+#endif
+
 
 #ifdef DUCKDB_HAS_NEW_VECTOR_HEADERS
 

--- a/src/xml_reader_functions.cpp
+++ b/src/xml_reader_functions.cpp
@@ -474,7 +474,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 				auto logical_type = TransformStringToLogicalType(StringValue::Get(val), context);
 
 				return_types.push_back(logical_type);
-				names.push_back(name);
+				names.push_back(CompatIdentifierName(name));
 			}
 
 			if (return_types.empty()) {
@@ -1351,7 +1351,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context,
 				auto logical_type = TransformStringToLogicalType(StringValue::Get(val), context);
 
 				return_types.push_back(logical_type);
-				names.push_back(name);
+				names.push_back(CompatIdentifierName(name));
 			}
 
 			if (return_types.empty()) {
@@ -1524,7 +1524,7 @@ unique_ptr<TableRef> XMLReaderFunctions::ReadXMLReplacement(ClientContext &conte
 	// Set alias for non-glob patterns
 	if (!FileSystem::HasGlob(table_name)) {
 		auto &fs = FileSystem::GetFileSystem(context);
-		table_function->alias = fs.ExtractBaseName(table_name);
+		table_function->alias = CompatMakeIdentifier(fs.ExtractBaseName(table_name));
 	}
 
 	return std::move(table_function);
@@ -1802,7 +1802,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ParseDocumentBind(ClientContext &co
 
 				auto logical_type = TransformStringToLogicalType(StringValue::Get(val), context);
 				return_types.push_back(logical_type);
-				names.push_back(name);
+				names.push_back(CompatIdentifierName(name));
 			}
 
 			if (return_types.empty()) {

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -864,7 +864,7 @@ unique_ptr<FunctionData> XMLScalarFunctions::XMLToJSONWithSchemaBind(DUCKDB_SCAL
 	// Process named parameters (if any)
 	for (idx_t i = 1; i < bind_args.size(); i++) {
 		auto &arg = bind_args[i];
-		std::string param_name = arg->GetAlias();
+		std::string param_name = CompatIdentifierName(arg->GetAlias());
 
 		if (param_name.empty()) {
 			throw BinderException(
@@ -1772,7 +1772,7 @@ void XMLScalarFunctions::HTMLExtractTablesJSONFunction(DataChunk &args, Expressi
 			for (const auto &row : rows) {
 				child_list_t<Value> row_obj;
 				for (size_t j = 0; j < headers.size() && j < row.size(); j++) {
-					row_obj.push_back({headers[j], Value(row[j])});
+					row_obj.push_back({CompatMakeIdentifier(headers[j]), Value(row[j])});
 				}
 				object_rows.push_back(Value::STRUCT(row_obj));
 			}

--- a/src/xml_schema_inference.cpp
+++ b/src/xml_schema_inference.cpp
@@ -473,7 +473,7 @@ LogicalType XMLSchemaInference::InferColumnType(const ColumnAnalysis &column, in
 						attr_name = StripNamespacePrefix(attr_name);
 					}
 					// Attributes are always VARCHAR
-					struct_fields.push_back(make_pair(attr_name, LogicalType::VARCHAR));
+					struct_fields.push_back(make_pair(CompatMakeIdentifier(attr_name), LogicalType::VARCHAR));
 				}
 			}
 		}
@@ -499,7 +499,7 @@ LogicalType XMLSchemaInference::InferColumnType(const ColumnAnalysis &column, in
 				std::string list_text_winning_fmt;
 				LogicalType text_type = InferTypeFromSamples(list_text_samples, options, list_text_winning_fmt);
 				// Insert #text as first field (before attribute fields)
-				struct_fields.insert(struct_fields.begin(), make_pair(options.text_key, text_type));
+				struct_fields.insert(struct_fields.begin(), make_pair(CompatMakeIdentifier(options.text_key), text_type));
 			}
 		}
 
@@ -527,7 +527,7 @@ LogicalType XMLSchemaInference::InferColumnType(const ColumnAnalysis &column, in
 				// Proper fix requires a format-per-field map threaded through extraction.
 				std::string nested_winning_fmt;
 				LogicalType child_type = InferColumnType(nested_col, remaining_depth - 1, options, nested_winning_fmt);
-				struct_fields.push_back(make_pair(child_name, child_type));
+				struct_fields.push_back(make_pair(CompatMakeIdentifier(child_name), child_type));
 			}
 		}
 
@@ -586,7 +586,7 @@ LogicalType XMLSchemaInference::InferColumnType(const ColumnAnalysis &column, in
 			// TODO(#38): nested_winning_fmt2 is computed but discarded (see nested format limitation above).
 			std::string nested_winning_fmt2;
 			LogicalType child_type = InferColumnType(nested_col, remaining_depth - 1, options, nested_winning_fmt2);
-			struct_fields.push_back(make_pair(child_name, child_type));
+			struct_fields.push_back(make_pair(CompatMakeIdentifier(child_name), child_type));
 		}
 
 		if (!struct_fields.empty()) {
@@ -635,13 +635,13 @@ LogicalType XMLSchemaInference::InferColumnType(const ColumnAnalysis &column, in
 			// Add text content field with inferred type
 			std::string text_winning_fmt;
 			LogicalType text_type = InferTypeFromSamples(cross_record_text_samples, options, text_winning_fmt);
-			struct_fields.push_back(make_pair(options.text_key, text_type));
+			struct_fields.push_back(make_pair(CompatMakeIdentifier(options.text_key), text_type));
 
 			// Add attribute fields (sorted for determinism)
 			std::vector<std::string> sorted_attrs(all_attrs.begin(), all_attrs.end());
 			std::sort(sorted_attrs.begin(), sorted_attrs.end());
 			for (const auto &attr_name : sorted_attrs) {
-				struct_fields.push_back(make_pair(attr_name, LogicalType::VARCHAR));
+				struct_fields.push_back(make_pair(CompatMakeIdentifier(attr_name), LogicalType::VARCHAR));
 			}
 
 			return LogicalType::STRUCT(struct_fields);
@@ -1133,7 +1133,7 @@ LogicalType XMLSchemaInference::InferNestedType(const ElementPattern &pattern,
 					child_type = InferNestedType(child_pattern, all_patterns, options);
 				}
 
-				struct_fields.push_back(make_pair(child_name, child_type));
+				struct_fields.push_back(make_pair(CompatMakeIdentifier(child_name), child_type));
 			}
 		}
 
@@ -1291,12 +1291,12 @@ LogicalType XMLSchemaInference::MergeXMLColumnType(const LogicalType &a, const L
 		// extraction consistent with this merge semantic.
 		case_insensitive_map_t<idx_t> b_index;
 		for (idx_t i = 0; i < b_children.size(); i++) {
-			b_index[b_children[i].first] = i;
+			b_index[CompatIdentifierName(b_children[i].first)] = i;
 		}
 
 		child_list_t<LogicalType> merged;
 		for (auto &ac : a_children) {
-			auto it = b_index.find(ac.first);
+			auto it = b_index.find(CompatIdentifierName(ac.first));
 			if (it == b_index.end()) {
 				merged.emplace_back(ac.first, ac.second);
 			} else {
@@ -1306,7 +1306,7 @@ LogicalType XMLSchemaInference::MergeXMLColumnType(const LogicalType &a, const L
 		}
 		// Append b-only fields in b's original order
 		for (auto &bc : b_children) {
-			auto it = b_index.find(bc.first);
+			auto it = b_index.find(CompatIdentifierName(bc.first));
 			if (it != b_index.end()) {
 				merged.emplace_back(bc.first, bc.second);
 				b_index.erase(it);

--- a/src/xml_utils.cpp
+++ b/src/xml_utils.cpp
@@ -2234,7 +2234,7 @@ void XMLUtils::ConvertStructToXML(Vector &input_vector, Vector &result, idx_t co
 
 		// Process each struct field
 		for (idx_t field_idx = 0; field_idx < child_types.size(); field_idx++) {
-			auto &field_name = child_types[field_idx].first;
+			const std::string &field_name = CompatIdentifierName(child_types[field_idx].first);
 			auto &field_type = child_types[field_idx].second;
 
 			// Get the child vector for this field
@@ -2335,7 +2335,7 @@ xmlNodePtr XMLUtils::ConvertValueToXMLNode(const Value &value, const LogicalType
 
 		// Add each struct field as a child node
 		for (size_t i = 0; i < child_types.size(); i++) {
-			auto &field_name = child_types[i].first;
+			const std::string &field_name = CompatIdentifierName(child_types[i].first);
 			auto &field_type = child_types[i].second;
 			auto &field_value = struct_value[i];
 


### PR DESCRIPTION
DuckDB `main` introduced `duckdb::Identifier`, replacing `std::string` as the key of `child_list_t` (STRUCT/UNION field names) and several name-typed fields (table alias, `Expression::GetAlias`). It doesn't implicitly convert to/from `std::string`, so the `duckdb-next` (main) CI broke across ~17 sites in `xml_schema_inference`, `xml_scalar_functions`, `xml_reader_functions`, and `xml_utils`.

## Fix
- `duckdb_compat.hpp`: add `CompatIdentifierName` (read raw name) + `CompatMakeIdentifier` (build a key from a runtime string), gated on `__has_include("duckdb/common/identifier.hpp")` — orthogonal to the vector-headers gate. Pass-throughs on older DuckDB.
- Apply at each boundary: `child_list_t` construction, struct-name `case_insensitive_map` lookups, `names` vectors, the `read_xml` table alias, and the `to_xml` field-name path.
- String-literal keys are left untouched (`Identifier` constructs implicitly from `const char*`).

## Verification
No-op against pinned v1.5.3 (helpers are pass-throughs): local build + full suite green (2674 assertions). The NEW branch only compiles against DuckDB `main`, so **CI here is the authoritative check**.

**This unblocks the whole open-PR batch** — every PR's earlier green CI went stale when this drift landed on DuckDB `main`; this needs to merge to `main` first, then the others rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)