### PR TITLE
fix: reject markup-injecting element names in to_xml (security)

### DIFF
--- a/src/include/xml_utils.hpp
+++ b/src/include/xml_utils.hpp
@@ -217,6 +217,10 @@ public:
 	static bool IsValidXML(const std::string &xml_str);
 	static bool IsWellFormedXML(const std::string &xml_str);
 	static bool ValidateXMLSchema(const std::string &xml_str, const std::string &xsd_schema);
+	// Throw InvalidInputException unless `name` is a usable XML element name. Used to prevent markup
+	// injection through user-controlled names (to_xml's node_name argument and STRUCT field names),
+	// which are otherwise concatenated/emitted into trusted `xml`-typed output unvalidated.
+	static void ValidateXMLElementName(const std::string &name);
 
 	// Extraction functions
 	static std::vector<XMLElement> ExtractByXPath(const std::string &xml_str, const std::string &xpath);

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1022,6 +1022,9 @@ void XMLScalarFunctions::ValueToXMLFunction(DataChunk &args, ExpressionState &st
 			}
 		}
 	}
+	// The node name becomes an element name; reject any that would inject markup into the
+	// trusted xml-typed output (e.g. to_xml(v, 'a><evil')).
+	XMLUtils::ValidateXMLElementName(default_node_name);
 
 	// Apply our type hierarchy
 	if (XMLTypes::IsXMLFragmentType(input_type)) {

--- a/src/xml_utils.cpp
+++ b/src/xml_utils.cpp
@@ -7,6 +7,7 @@
 #include <libxml/HTMLparser.h>
 #include <libxml/entities.h>
 #include <libxml/xpathInternals.h>
+#include <libxml/valid.h>
 #include <algorithm>
 #include <cctype>
 #include <iostream>
@@ -2115,6 +2116,17 @@ std::vector<std::string> XMLUtils::ExtractXMLFragmentList(const std::string &xml
 	return results;
 }
 
+void XMLUtils::ValidateXMLElementName(const std::string &name) {
+	// An embedded NUL would let the name validate as a truncated prefix (C-string APIs stop at the
+	// NUL) while the full std::string still concatenates into markup, so reject it explicitly.
+	// xmlValidateName(name, 0) accepts the XML Name production, including namespace-prefixed names
+	// like "ns:item", and rejects anything containing '<', '>', '"', '/', whitespace, etc.
+	if (name.find('\0') != std::string::npos ||
+	    xmlValidateName(reinterpret_cast<const xmlChar *>(name.c_str()), 0) != 0) {
+		throw InvalidInputException("Invalid XML element name '%s': cannot be used to construct XML output", name);
+	}
+}
+
 std::string XMLUtils::ScalarToXML(const std::string &value, const std::string &node_name) {
 	// Use RAII-safe libxml2 document creation
 	XMLDocPtr doc(xmlNewDoc(BAD_CAST "1.0"));
@@ -2235,6 +2247,8 @@ void XMLUtils::ConvertStructToXML(Vector &input_vector, Vector &result, idx_t co
 		// Process each struct field
 		for (idx_t field_idx = 0; field_idx < child_types.size(); field_idx++) {
 			const std::string &field_name = CompatIdentifierName(child_types[field_idx].first);
+			// STRUCT field names become element names; reject any that would inject markup.
+			ValidateXMLElementName(field_name);
 			auto &field_type = child_types[field_idx].second;
 
 			// Get the child vector for this field
@@ -2336,6 +2350,8 @@ xmlNodePtr XMLUtils::ConvertValueToXMLNode(const Value &value, const LogicalType
 		// Add each struct field as a child node
 		for (size_t i = 0; i < child_types.size(); i++) {
 			const std::string &field_name = CompatIdentifierName(child_types[i].first);
+			// STRUCT field names become element names; reject any that would inject markup.
+			ValidateXMLElementName(field_name);
 			auto &field_type = child_types[i].second;
 			auto &field_value = struct_value[i];
 

--- a/test/sql/to_xml_name_injection.test
+++ b/test/sql/to_xml_name_injection.test
@@ -1,0 +1,98 @@
+# name: test/sql/to_xml_name_injection.test
+# description: to_xml must reject element names (node_name arg and STRUCT field names) that would inject markup
+# group: [sql]
+
+require webbed
+
+# =============================================================================
+# Injection via the node_name argument is rejected
+# =============================================================================
+
+statement error
+SELECT to_xml(42, 'a><injected');
+----
+Invalid XML element name
+
+statement error
+SELECT to_xml('v', 'x></x><script>evil</script><x');
+----
+Invalid XML element name
+
+statement error
+SELECT to_xml([1, 2], 'r><evil');
+----
+Invalid XML element name
+
+# Attribute injection via the name
+statement error
+SELECT to_xml(42, 'a onload="evil"');
+----
+Invalid XML element name
+
+# =============================================================================
+# Injection via STRUCT field names is rejected
+# =============================================================================
+
+statement error
+SELECT to_xml({'a><evil x="1"': 42});
+----
+Invalid XML element name
+
+# Nested struct field name
+statement error
+SELECT to_xml({'ok': {'b><evil': 1}});
+----
+Invalid XML element name
+
+# =============================================================================
+# Names that are invalid XML are rejected (empty, leading digit, whitespace)
+# =============================================================================
+
+statement error
+SELECT to_xml(42, '');
+----
+Invalid XML element name
+
+statement error
+SELECT to_xml(42, '1abc');
+----
+Invalid XML element name
+
+statement error
+SELECT to_xml(42, 'a b');
+----
+Invalid XML element name
+
+# =============================================================================
+# Legitimate names still work
+# =============================================================================
+
+# Simple node name
+query I
+SELECT REPLACE(to_xml(42, 'count')::VARCHAR, chr(10), '');
+----
+<?xml version="1.0"?><count>42</count>
+
+# Namespace-prefixed name (XML Name allows ':')
+query I
+SELECT REPLACE(to_xml(42, 'ns:count')::VARCHAR, chr(10), '');
+----
+<?xml version="1.0"?><ns:count>42</ns:count>
+
+# Struct with valid field names
+query I
+SELECT REPLACE(to_xml({'name': 'Joe', 'age': 30})::VARCHAR, chr(10), '');
+----
+<?xml version="1.0"?><xml><name>Joe</name><age>30</age></xml>
+
+# Default node name (no second argument) is unaffected
+query I
+SELECT to_xml(42) IS NOT NULL;
+----
+true
+
+# Punctuated valid name (dash, dot, underscore)
+query I
+SELECT REPLACE(to_xml('x', 'my-node._1')::VARCHAR, chr(10), '');
+----
+<?xml version="1.0"?><my-node._1>x</my-node._1>


### PR DESCRIPTION
Found during the security pass. `to_xml` builds `xml`-typed output from a user-controlled `node_name` argument **and** STRUCT field names, both concatenated/emitted **unvalidated** — the same injection class #89 fixes for `xml_wrap_fragment`, but wide open and producing *trusted* `xml`:

```
to_xml(42, 'a><injected attr="x"')   -> <a><injected attr="x">42</a>…
to_xml({'a><evil x="1"': 42})        -> <xml><a><evil x="1">42</a>…   (struct field name)
to_xml([1,2], 'r><evil')             -> <r><evil_list>…
```

## Fix
Add `XMLUtils::ValidateXMLElementName` (libxml2 `xmlValidateName` for the XML Name production + an embedded-NUL guard, throwing `InvalidInputException`) and apply it to:
- `to_xml`'s `node_name` argument (`ValueToXMLFunction`)
- STRUCT field names in `ConvertStructToXML` and the recursive `ConvertValueToXMLNode`

Namespace-prefixed names (`ns:item`) still work; `<`, `>`, `"`, `/`, whitespace, leading-digit, and empty names are rejected.

## Behavior change (note for release notes)
`to_xml` on a struct whose field names — or an explicit `node_name` — are not valid XML element names now **errors** instead of producing malformed/injected output.

## Tests
`test/sql/to_xml_name_injection.test`: injection via node_name / struct field / nested struct / list all rejected; empty / leading-digit / whitespace names rejected; valid simple, prefixed, and punctuated names still work. Full suite green (2688 assertions).

Based on `main` (post #92), so it builds against current DuckDB `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)