### PR TITLE
test: regression guard for the libxml2 OOM path (#84/#94)

### DIFF
--- a/src/include/xml_scalar_functions.hpp
+++ b/src/include/xml_scalar_functions.hpp
@@ -14,6 +14,10 @@ private:
 	static void XMLValidFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void XMLWellFormedFunction(DataChunk &args, ExpressionState &state, Vector &result);
 	static void XMLValidateSchemaFunction(DataChunk &args, ExpressionState &state, Vector &result);
+	// Internal regression self-test for the libxml2 out-of-memory path (xml_oom_selftest()): verifies
+	// CheckXML reports ResourceError (not Malformed) under an injected allocation failure and that the
+	// resource-failure flag survives XMLDocRAII moves. The OOM path cannot be reached from SQL otherwise.
+	static void OOMSelfTestFunction(DataChunk &args, ExpressionState &state, Vector &result);
 
 	// Text extraction functions
 	static void XMLExtractTextFunction(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 
 #include <libxml/tree.h>
+#include <libxml/xmlmemory.h>
 #include <regex>
 #include <set>
 
@@ -603,6 +604,76 @@ void XMLScalarFunctions::XMLNamespacesFunction(DataChunk &args, ExpressionState 
 		Value map_value = Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, keys, values);
 		result.SetValue(i, map_value);
 	});
+}
+
+// --- Internal OOM-path regression self-test (xml_oom_selftest) ---
+// The libxml2 out-of-memory path cannot be reached from a SQL test, so this exercises it directly:
+// an always-failing allocator makes xmlNewParserCtxt return NULL, which must surface as
+// XMLValidity::ResourceError (not Malformed), and the resource-failure flag must survive XMLDocRAII
+// moves (the read_xml DOM path relies on `gstate.current_doc = XMLDocRAII(...)`). Allocator setup is
+// process-global, so it is installed and restored within this single call. On platforms where
+// xmlMemSetup is a no-op (e.g. macOS system libxml2) the injected failure has no effect and the
+// allocation-failure half is reported as skipped rather than failing.
+namespace {
+void *OOMFailMalloc(size_t) {
+	return nullptr;
+}
+void *OOMFailRealloc(void *, size_t) {
+	return nullptr;
+}
+char *OOMFailStrdup(const char *) {
+	return nullptr;
+}
+void OOMNoopFree(void *) {
+}
+
+std::string RunOOMSelfTest() {
+	// Part 1: move operations must carry resource_error (pure, no allocator involved).
+	{
+		XMLDocRAII a;
+		a.resource_error = true;
+		XMLDocRAII moved_ctor(std::move(a));
+		if (!moved_ctor.HadResourceError()) {
+			return "FAIL: move constructor dropped resource_error";
+		}
+		XMLDocRAII moved_assign;
+		moved_assign = std::move(moved_ctor);
+		if (!moved_assign.HadResourceError()) {
+			return "FAIL: move assignment dropped resource_error";
+		}
+	}
+
+	// Part 2: an allocation failure must be reported as ResourceError, not Malformed.
+	xmlFreeFunc saved_free = nullptr;
+	xmlMallocFunc saved_malloc = nullptr;
+	xmlReallocFunc saved_realloc = nullptr;
+	xmlStrdupFunc saved_strdup = nullptr;
+	xmlMemGet(&saved_free, &saved_malloc, &saved_realloc, &saved_strdup);
+
+	if (xmlMemSetup(OOMNoopFree, OOMFailMalloc, OOMFailRealloc, OOMFailStrdup) != 0) {
+		return "OK (oom check skipped: custom allocator could not be installed)";
+	}
+	XMLValidity validity = XMLUtils::CheckXML("<r/>");
+	// Restore the real allocators before anything else allocates through libxml2.
+	xmlMemSetup(saved_free, saved_malloc, saved_realloc, saved_strdup);
+
+	if (validity == XMLValidity::Valid) {
+		// The injected allocator had no effect (no-op on this libxml2 build).
+		return "OK (oom check skipped: allocator injection not supported on this platform)";
+	}
+	if (validity != XMLValidity::ResourceError) {
+		return "FAIL: allocation failure reported as Malformed instead of ResourceError";
+	}
+	return "OK";
+}
+} // namespace
+
+void XMLScalarFunctions::OOMSelfTestFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	// Run once (it mutates process-global allocator state) and replicate to all output rows.
+	std::string status = RunOOMSelfTest();
+	for (idx_t i = 0; i < args.size(); i++) {
+		result.SetValue(i, Value(status));
+	}
 }
 
 void XMLScalarFunctions::XMLCommonNamespacesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1409,6 +1480,12 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	                   XMLCommonNamespacesFunction);
 	PreventStructConstantFolding(xml_common_namespaces_function);
 	loader.RegisterFunction(xml_common_namespaces_function);
+
+	// Internal regression self-test for the libxml2 out-of-memory path (see OOMSelfTestFunction).
+	// Returns 'OK' (or 'OK (oom check skipped...)' where the allocator can't be injected); any other
+	// value indicates a regression. Result is deterministic, so default stability is fine.
+	loader.RegisterFunction(
+	    ScalarFunction("xml_oom_selftest", {}, LogicalType::VARCHAR, OOMSelfTestFunction));
 
 	// Register xml_detect_prefixes function (returns LIST<VARCHAR> of namespace prefixes in XPath expression)
 	auto xml_detect_prefixes_function =

--- a/test/sql/oom_resource_error.test
+++ b/test/sql/oom_resource_error.test
@@ -1,0 +1,25 @@
+# name: test/sql/oom_resource_error.test
+# description: libxml2 out-of-memory path (#84/#94) — CheckXML must report ResourceError (not
+#              Malformed) under allocation failure, and resource_error must survive XMLDocRAII moves
+# group: [sql]
+
+require webbed
+
+# The OOM path cannot be triggered from SQL directly (it needs an injected failing libxml2
+# allocator), so xml_oom_selftest() exercises it in-process: it installs an always-failing
+# allocator, confirms CheckXML('<r/>') returns ResourceError rather than Malformed, restores the
+# allocator, and checks that the resource-failure flag is carried through the XMLDocRAII move
+# constructor and move-assignment (the bug on the read_xml DOM path). It returns 'OK' on success,
+# 'OK (oom check skipped...)' where the allocator cannot be injected (e.g. macOS system libxml2),
+# or 'FAIL: <reason>' on a regression.
+
+query I
+SELECT xml_oom_selftest() LIKE 'OK%';
+----
+true
+
+# A regression would start with 'FAIL'
+query I
+SELECT starts_with(xml_oom_selftest(), 'FAIL');
+----
+false


### PR DESCRIPTION
Closes the one coverage gap from the v2.2.0 batch: the libxml2 out-of-memory path (#84/#94) had **no** automated test, because triggering `XML_ERR_NO_MEMORY` needs an injected failing allocator that `sqllogictest` can't install (and macOS's system libxml2 no-ops `xmlMemSetup`).

## Approach
Adds an internal `xml_oom_selftest()` scalar function that exercises the path in-process and deterministically:
- installs an **always-failing** allocator (so `xmlNewParserCtxt` returns NULL — hitting #84's "parser context couldn't allocate → resource_error" branch, no fragile threshold tuning),
- asserts `CheckXML('<r/>')` returns `ResourceError`, **not** `Malformed`,
- restores the real allocators immediately (the swap is process-global, so it's contained to this one call),
- checks `resource_error` survives the `XMLDocRAII` **move constructor and move-assignment** — the exact bug the #94 fix addressed on the `read_xml` DOM path.

Returns `OK`, `OK (oom check skipped...)` where the allocator can't be injected, or `FAIL: <reason>` on a regression. `test/sql/oom_resource_error.test` asserts the result. Verified it returns plain `OK` (path actually exercised) on Linux; suite is 2866 assertions / 82 cases.

## Tradeoff (your call)
This **ships a diagnostic function** (`xml_oom_selftest`) in the extension — the only way to test internal C++ behavior from the SQL-only harness. If you'd rather not ship it, alternatives: gate it behind a build flag (then it won't run in release CI), or move it to a standalone C++ test target. Happy to switch — flagging it explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)