### PR TITLE
SAX streaming drops the attributes of a record's nested child elements (empty STRUCT)

### DIFF
--- a/src/include/xml_sax_reader.hpp
+++ b/src/include/xml_sax_reader.hpp
@@ -21,8 +21,12 @@ enum class SAXAccumulatorState {
 // A single occurrence of a record field, tagged by payload kind. Occurrences are stored in
 // document order so a field mixing bare-text and nested-XML siblings keeps its original sequence.
 struct FieldOccurrence {
-	bool is_xml;         // true = nested-XML fragment, false = text payload
-	std::string payload; // serialized XML fragment (is_xml) or cleaned text (!is_xml)
+	bool is_xml;          // true = nested-XML fragment, false = text payload
+	std::string payload;  // serialized XML fragment (is_xml) or cleaned text (!is_xml)
+	std::string own_attrs; // the field element's OWN attributes, pre-serialized and escaped as
+	                        // ` name="value"...` (empty if none), spliced into the reconstructed
+	                        // open tag so a direct child like <CustomFunctionReference id=".."/>
+	                        // keeps its attributes under streaming (DOM parity).
 };
 
 // Accumulates field data from SAX events for a single XML record
@@ -59,6 +63,11 @@ struct SAXRecordAccumulator {
 	std::string current_text;
 	std::string current_element_name; // Name of the element whose text we're accumulating
 
+	// Own attributes of the direct child of the record currently being accumulated (relative_depth==1),
+	// serialized as ` name="value"...` (escaped). Held from the child's start until its close, then
+	// stored on the FieldOccurrence so reconstruction can splice them into the field's open tag.
+	std::string current_field_attrs;
+
 	// Nested XML accumulation (for elements deeper than record_depth+1)
 	std::string nested_xml;
 	int nested_depth = 0; // How deep we are in nested elements (0 = direct child of record)
@@ -91,6 +100,7 @@ struct SAXCallbackContext {
 	bool stop_parsing = false;                                      // Signal to stop the push parser
 	std::vector<SAXRecordAccumulator> *completed_records = nullptr; // Where to store completed records
 	bool preserve_whitespace = true;
+	std::string attr_mode = "columns"; // mirrors XMLSchemaOptions::attr_mode; "discard" drops attributes
 };
 
 // SAX2 callback functions (static, matching libxml2 signatures)

--- a/src/include/xml_sax_reader.hpp
+++ b/src/include/xml_sax_reader.hpp
@@ -100,7 +100,7 @@ struct SAXCallbackContext {
 	bool stop_parsing = false;                                      // Signal to stop the push parser
 	std::vector<SAXRecordAccumulator> *completed_records = nullptr; // Where to store completed records
 	bool preserve_whitespace = true;
-	std::string attr_mode = "columns"; // mirrors XMLSchemaOptions::attr_mode; "discard" drops attributes
+	bool discard_attrs = false; // precomputed from XMLSchemaOptions::attr_mode == "discard" (hot-path flag)
 };
 
 // SAX2 callback functions (static, matching libxml2 signatures)

--- a/src/include/xml_schema_inference.hpp
+++ b/src/include/xml_schema_inference.hpp
@@ -230,9 +230,15 @@ public:
 	// Parse an XML fragment (the inner contents of a wrapper element) and extract a value of the
 	// given target type. Used by the SAX reader to materialize STRUCT / LIST<STRUCT> columns whose
 	// inner content was captured as raw XML during streaming.
+	// extra_ns_decls / extra_attrs are spliced verbatim into the synthetic wrapper's open tag
+	// (`<wrapper extra_ns_decls extra_attrs>inner</wrapper>`). extra_attrs carries the wrapped
+	// element's OWN attributes (e.g. ` id="1" UUID=".."`) so an attribute-only fragment (empty
+	// inner_xml) still yields a non-NULL STRUCT — needed by the SAX path where a nested element's
+	// attributes are captured separately from its inner content.
 	static Value ExtractValueFromXmlFragment(const std::string &wrapper_name, const std::string &inner_xml,
 	                                         const LogicalType &target_type, const XMLSchemaOptions &options,
-	                                         const std::string &extra_ns_decls = "");
+	                                         const std::string &extra_ns_decls = "",
+	                                         const std::string &extra_attrs = "");
 
 	// Trim edges, optionally normalize EOL or collapse whitespace (used by both DOM and SAX paths)
 	static std::string CleanTextContent(const std::string &text, bool preserve_whitespace);

--- a/src/xml_sax_reader.cpp
+++ b/src/xml_sax_reader.cpp
@@ -17,6 +17,7 @@ void SAXRecordAccumulator::Reset() {
 	attribute_order.clear();
 	current_text.clear();
 	current_element_name.clear();
+	current_field_attrs.clear();
 	nested_xml.clear();
 	nested_depth = 0;
 	row_ready = false;
@@ -202,23 +203,30 @@ void SAXStartElementNs(void *ctx, const xmlChar *localname, const xmlChar *prefi
 			acc->current_text.clear();
 			acc->current_element_name = name;
 			acc->nested_depth = 0;
+			acc->current_field_attrs.clear();
 
-			// Extract attributes from child elements too
-			for (int i = 0; i < nb_attributes; i++) {
-				const char *attr_localname = reinterpret_cast<const char *>(attributes[i * 5]);
-				const char *attr_prefix_ptr = reinterpret_cast<const char *>(attributes[i * 5 + 1]);
-				const char *value_start = reinterpret_cast<const char *>(attributes[i * 5 + 3]);
-				const char *value_end = reinterpret_cast<const char *>(attributes[i * 5 + 4]);
+			// Serialize this direct child's OWN attributes so they can be spliced into the field
+			// element's open tag during reconstruction (schema inference + row build). Without this an
+			// attribute-only child such as <CustomFunctionReference id=".." UUID=".."/> loses its
+			// attributes under SAX streaming, while the DOM path keeps them. Held in current_field_attrs
+			// until the element closes (children, if any, arrive in between). Skipped under
+			// attr_mode='discard' to match DOM, where attributes are dropped entirely.
+			if (sax_ctx->attr_mode != "discard") {
+				for (int i = 0; i < nb_attributes; i++) {
+					const char *attr_localname = reinterpret_cast<const char *>(attributes[i * 5]);
+					const char *attr_prefix_ptr = reinterpret_cast<const char *>(attributes[i * 5 + 1]);
+					const char *value_start = reinterpret_cast<const char *>(attributes[i * 5 + 3]);
+					const char *value_end = reinterpret_cast<const char *>(attributes[i * 5 + 4]);
 
-				std::string attr_name;
-				if (acc->namespace_mode == "keep" && attr_prefix_ptr != nullptr) {
-					attr_name = std::string(attr_prefix_ptr) + ":" + attr_localname;
-				} else {
-					attr_name = attr_localname;
+					std::string attr_name;
+					if (acc->namespace_mode == "keep" && attr_prefix_ptr != nullptr) {
+						attr_name = std::string(attr_prefix_ptr) + ":" + attr_localname;
+					} else {
+						attr_name = attr_localname;
+					}
+					std::string attr_value(value_start, value_end);
+					acc->current_field_attrs += " " + attr_name + "=\"" + XmlEscapeAttr(attr_value) + "\"";
 				}
-				std::string attr_value(value_start, value_end);
-				// Store child attributes with element.attribute naming
-				acc->current_attributes[name + "." + attr_name] = attr_value;
 			}
 		} else if (relative_depth > 1) {
 			// Deeper nested element: accumulate raw XML
@@ -271,15 +279,24 @@ void SAXEndElementNs(void *ctx, const xmlChar *localname, const xmlChar *prefix,
 				sax_ctx->stop_parsing = true;
 			}
 		} else if (relative_depth == 1) {
-			// Closing a direct child of the record. If we accumulated nested XML (the child has
-			// element children), the payload is the raw fragment so rich-typing can re-parse it;
-			// otherwise it is text. Append in close order, capturing document order across a field's
-			// text and XML occurrences.
-			bool is_xml = !acc->nested_xml.empty();
+			// Closing a direct child of the record. The child is captured as a nested-XML fragment when
+			// it has element children (acc->nested_xml) OR carries its own attributes
+			// (acc->current_field_attrs), so the rich-typing path reconstructs a STRUCT (@attrs plus
+			// #text/children); otherwise it is plain text. own_attrs rides on the occurrence and is
+			// spliced into the reconstructed open tag. Append in close order, capturing document order
+			// across a field's text and XML occurrences.
+			std::string own_attrs = std::move(acc->current_field_attrs);
+			bool has_attrs = !own_attrs.empty();
+			bool is_xml = !acc->nested_xml.empty() || has_attrs;
 			std::string value;
-			if (is_xml) {
-				value = acc->nested_xml;
+			if (!acc->nested_xml.empty()) {
+				value = std::move(acc->nested_xml);
 				acc->nested_xml.clear();
+			} else if (has_attrs) {
+				// Attribute-only (or attribute + text) child: the inner content is the element's text,
+				// escaped so it stays well-formed when wrapped as <field own_attrs>text</field>.
+				value = XmlEscapeText(
+				    XMLSchemaInference::CleanTextContent(acc->current_text, sax_ctx->preserve_whitespace));
 			} else {
 				value = XMLSchemaInference::CleanTextContent(acc->current_text, sax_ctx->preserve_whitespace);
 			}
@@ -289,10 +306,11 @@ void SAXEndElementNs(void *ctx, const xmlChar *localname, const xmlChar *prefix,
 				field_it = acc->current_fields.emplace(name, std::vector<FieldOccurrence>()).first;
 				acc->field_order.push_back(name);
 			}
-			field_it->second.push_back({is_xml, std::move(value)});
+			field_it->second.push_back({is_xml, std::move(value), std::move(own_attrs)});
 
 			acc->current_text.clear();
 			acc->current_element_name.clear();
+			acc->current_field_attrs.clear();
 			acc->nested_depth = 0;
 		} else {
 			// Closing a deeper nested element: append closing tag to raw XML
@@ -378,6 +396,7 @@ std::vector<SAXRecordAccumulator> SAXStreamReader::ReadRecords(FileSystem &fs, c
 	ctx.stop_parsing = false;
 	ctx.completed_records = &results;
 	ctx.preserve_whitespace = options.preserve_whitespace;
+	ctx.attr_mode = options.attr_mode;
 
 	xmlSAXHandler handler = CreateSAXHandler();
 
@@ -453,7 +472,10 @@ std::vector<XMLColumnInfo> SAXStreamReader::InferSchemaFromStream(FileSystem &fs
 		// fragments emitted structurally so DOM inference reconstructs the STRUCT / LIST shape.
 		for (const auto &field_name : record.field_order) {
 			for (const auto &occ : record.GetOccurrences(field_name)) {
-				xml << "<" << field_name << ">";
+				// occ.own_attrs is pre-escaped and only populated when attr_mode != 'discard', so the
+				// synthetic element carries the child's own attributes and DOM inference types it as a
+				// STRUCT (@attrs + #text/children) — matching the non-streaming path.
+				xml << "<" << field_name << occ.own_attrs << ">";
 				xml << (occ.is_xml ? occ.payload : XmlEscapeText(occ.payload));
 				xml << "</" << field_name << ">";
 			}
@@ -528,13 +550,15 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 			}
 		} else if (col_type.id() == LogicalTypeId::STRUCT) {
 			// STRUCT column: a non-LIST struct implies a single occurrence. If it carried element
-			// children it was captured as inner XML; re-parse and dispatch through the DOM extractor.
+			// children or its own attributes it was captured as inner XML; re-parse and dispatch through
+			// the DOM extractor. occ.own_attrs is appended to the wrapper open tag (via extra_ns_decls,
+			// which is spliced there verbatim) so attribute-only children yield their @attr fields.
 			const auto &occs = accumulator.GetOccurrences(col_name);
 			if (occs.empty()) {
 				value = Value(col_type); // typed NULL
 			} else if (occs.front().is_xml) {
-				value = XMLSchemaInference::ExtractValueFromXmlFragment(col_name, occs.front().payload, col_type,
-				                                                        options, ns_decls);
+				value = XMLSchemaInference::ExtractValueFromXmlFragment(
+				    col_name, occs.front().payload, col_type, options, ns_decls, occs.front().own_attrs);
 			} else {
 				// Text-only occurrence: wrap escaped text so the extractor yields a non-NULL struct
 				// shell (fields NULL), matching DOM, rather than a fully-NULL struct.
@@ -556,24 +580,26 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 
 			std::vector<Value> list_vals;
 
-			auto append_text = [&](const std::string &item) {
+			// own_attrs (pre-escaped, empty unless the element carried attributes) is appended to the
+			// wrapper open tag via extra_ns_decls so list items keep their @attr fields.
+			auto append_text = [&](const std::string &item, const std::string &own_attrs) {
 				if (IsNullString(item, options)) {
 					list_vals.push_back(Value(child_type));
 				} else if (child_is_complex) {
 					// Text inside a complex-typed list: wrap so ExtractValueFromXmlFragment can
 					// surface it as a #text-bearing struct (NULL for missing fields). Escape XML
 					// special chars first so '&', '<', '>' do not break the synthetic wrapper.
-					list_vals.push_back(XMLSchemaInference::ExtractValueFromXmlFragment(col_name, XmlEscapeText(item),
-					                                                                    child_type, options, ns_decls));
+					list_vals.push_back(XMLSchemaInference::ExtractValueFromXmlFragment(
+					    col_name, XmlEscapeText(item), child_type, options, ns_decls, own_attrs));
 				} else {
 					list_vals.push_back(
 					    XMLSchemaInference::ConvertToValuePublic(item, child_type, options, datetime_fmt));
 				}
 			};
-			auto append_xml = [&](const std::string &frag) {
+			auto append_xml = [&](const std::string &frag, const std::string &own_attrs) {
 				if (child_is_complex) {
-					list_vals.push_back(
-					    XMLSchemaInference::ExtractValueFromXmlFragment(col_name, frag, child_type, options, ns_decls));
+					list_vals.push_back(XMLSchemaInference::ExtractValueFromXmlFragment(
+					    col_name, frag, child_type, options, ns_decls, own_attrs));
 				} else if (child_type.id() == LogicalTypeId::VARCHAR) {
 					// Scalar-typed list with an XML item: surface the serialized fragment.
 					list_vals.push_back(Value(frag));
@@ -584,9 +610,9 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 
 			for (const auto &occ : accumulator.GetOccurrences(col_name)) {
 				if (occ.is_xml) {
-					append_xml(occ.payload);
+					append_xml(occ.payload, occ.own_attrs);
 				} else {
-					append_text(occ.payload);
+					append_text(occ.payload, occ.own_attrs);
 				}
 			}
 

--- a/src/xml_sax_reader.cpp
+++ b/src/xml_sax_reader.cpp
@@ -211,7 +211,7 @@ void SAXStartElementNs(void *ctx, const xmlChar *localname, const xmlChar *prefi
 			// attributes under SAX streaming, while the DOM path keeps them. Held in current_field_attrs
 			// until the element closes (children, if any, arrive in between). Skipped under
 			// attr_mode='discard' to match DOM, where attributes are dropped entirely.
-			if (sax_ctx->attr_mode != "discard") {
+			if (!sax_ctx->discard_attrs) {
 				for (int i = 0; i < nb_attributes; i++) {
 					const char *attr_localname = reinterpret_cast<const char *>(attributes[i * 5]);
 					const char *attr_prefix_ptr = reinterpret_cast<const char *>(attributes[i * 5 + 1]);
@@ -396,7 +396,7 @@ std::vector<SAXRecordAccumulator> SAXStreamReader::ReadRecords(FileSystem &fs, c
 	ctx.stop_parsing = false;
 	ctx.completed_records = &results;
 	ctx.preserve_whitespace = options.preserve_whitespace;
-	ctx.attr_mode = options.attr_mode;
+	ctx.discard_attrs = (options.attr_mode == "discard");
 
 	xmlSAXHandler handler = CreateSAXHandler();
 
@@ -551,8 +551,8 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 		} else if (col_type.id() == LogicalTypeId::STRUCT) {
 			// STRUCT column: a non-LIST struct implies a single occurrence. If it carried element
 			// children or its own attributes it was captured as inner XML; re-parse and dispatch through
-			// the DOM extractor. occ.own_attrs is appended to the wrapper open tag (via extra_ns_decls,
-			// which is spliced there verbatim) so attribute-only children yield their @attr fields.
+			// the DOM extractor. occ.own_attrs is appended to the wrapper open tag (via the extra_attrs
+			// parameter, which is spliced there verbatim) so attribute-only children yield their @attr fields.
 			const auto &occs = accumulator.GetOccurrences(col_name);
 			if (occs.empty()) {
 				value = Value(col_type); // typed NULL
@@ -581,7 +581,7 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 			std::vector<Value> list_vals;
 
 			// own_attrs (pre-escaped, empty unless the element carried attributes) is appended to the
-			// wrapper open tag via extra_ns_decls so list items keep their @attr fields.
+			// wrapper open tag via the extra_attrs parameter so list items keep their @attr fields.
 			auto append_text = [&](const std::string &item, const std::string &own_attrs) {
 				if (IsNullString(item, options)) {
 					list_vals.push_back(Value(child_type));

--- a/src/xml_schema_inference.cpp
+++ b/src/xml_schema_inference.cpp
@@ -1882,19 +1882,24 @@ Value XMLSchemaInference::ConvertToValuePublic(const std::string &text, const Lo
 
 Value XMLSchemaInference::ExtractValueFromXmlFragment(const std::string &wrapper_name, const std::string &inner_xml,
                                                       const LogicalType &target_type, const XMLSchemaOptions &options,
-                                                      const std::string &extra_ns_decls) {
-	if (inner_xml.empty()) {
+                                                      const std::string &extra_ns_decls,
+                                                      const std::string &extra_attrs) {
+	// Empty inner content yields NULL only when the element also has no own attributes; an
+	// attribute-only element (inner_xml empty, extra_attrs set) must still parse to a non-NULL STRUCT.
+	if (inner_xml.empty() && extra_attrs.empty()) {
 		return Value(target_type);
 	}
 	// Wrap the fragment in its element so the parser sees a single root and so ExtractValueFromNode
 	// receives a node whose ->children are the original siblings. extra_ns_decls injects any xmlns:
 	// declarations the fragment's prefixed names depend on (the originating decls are not part of the
 	// captured fragment), without which strict parsing would fail and the value would be lost.
+	// extra_attrs carries the element's own attributes (already escaped) so they become STRUCT fields.
 	std::string wrapped;
-	wrapped.reserve(inner_xml.size() + wrapper_name.size() * 2 + extra_ns_decls.size() + 5);
+	wrapped.reserve(inner_xml.size() + wrapper_name.size() * 2 + extra_ns_decls.size() + extra_attrs.size() + 5);
 	wrapped.append("<")
 	    .append(wrapper_name)
 	    .append(extra_ns_decls)
+	    .append(extra_attrs)
 	    .append(">")
 	    .append(inner_xml)
 	    .append("</")

--- a/test/sql/sax_nested_child_attr_parity.test
+++ b/test/sql/sax_nested_child_attr_parity.test
@@ -1,0 +1,41 @@
+# name: test/sql/sax_nested_child_attr_parity.test
+# description: SAX streaming must keep the OWN attributes of repeated nested child elements,
+#             which webbed exposes as LIST<STRUCT(@attrs...)>. Regression for: under streaming
+#             the per-item attributes were dropped, so each list STRUCT came back NULL
+#             ([NULL, NULL]) while the DOM path returned the attribute values.
+# group: [sql]
+
+require webbed
+
+# <rec> repeats <CustomFunctionReference id=".." UUID=".." name=".."/>, so the column is
+# LIST<STRUCT(id, UUID, name)> built from the elements' own attributes.
+
+# DOM baseline (non-streaming): first reference's UUID per record.
+query II
+SELECT id, (CustomFunctionReference[1]).UUID AS first_uuid
+FROM read_xml('test/xml/sax_nested_child_attr_parity.xml', record_element := 'rec')
+ORDER BY id;
+----
+1	AAAA-0001
+2	AAAA-0003
+
+# SAX streaming (maximum_file_size := 1 forces streaming) must match the DOM baseline.
+# Before the fix this returned NULL — the per-item STRUCT was empty.
+query II
+SELECT id, (CustomFunctionReference[1]).UUID AS first_uuid
+FROM read_xml('test/xml/sax_nested_child_attr_parity.xml', record_element := 'rec', maximum_file_size := 1)
+ORDER BY id;
+----
+1	AAAA-0001
+2	AAAA-0003
+
+# Every nested reference keeps all its attributes under streaming: 4 refs, none NULL.
+query I
+SELECT COUNT(*)
+FROM (
+    SELECT UNNEST(CustomFunctionReference) AS cfr
+    FROM read_xml('test/xml/sax_nested_child_attr_parity.xml', record_element := 'rec', maximum_file_size := 1)
+)
+WHERE cfr.id IS NOT NULL AND cfr.UUID IS NOT NULL;
+----
+4

--- a/test/xml/sax_nested_child_attr_parity.xml
+++ b/test/xml/sax_nested_child_attr_parity.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <rec id="1"><CustomFunctionReference id="101" UUID="AAAA-0001" name="MyFunc"/><CustomFunctionReference id="102" UUID="AAAA-0002" name="OtherFunc"/></rec>
+  <rec id="2"><CustomFunctionReference id="103" UUID="AAAA-0003" name="ThirdFunc"/><CustomFunctionReference id="104" UUID="AAAA-0004" name="FourthFunc"/></rec>
+</root>


### PR DESCRIPTION
## What this PR does

Under **SAX streaming**, a *repeated* nested child element typed as `LIST<STRUCT(@attr…)>` lost its per-item attributes: every list item came back as a `NULL` struct (`[NULL, NULL]`), while the DOM (non-streaming) path returns the attribute values. The records and the list cardinality were correct — only the per-item attribute values were dropped.

This completes part of the nested-extraction work that was flagged as not-yet-implemented and restores the DOM/SAX behavioral equivalence that the Phase-2 SAX spec requires.

Relates to #68 (SAX-based streaming parser).

> `docs/changelog.rst` — v2.0.0 *Limitations*:
> “SAX mode currently handles flat records (scalars, attributes, repeated elements).
> **Nested STRUCT extraction from SAX events is not yet implemented** — deeply nested records fall back to raw XML string values.”

> `docs/tasks/issue-17-phase2-sax-streaming.md` — *Verification* #4:
> “Behavioral equivalence: same output for DOM and SAX on identical input.”

## Reproduction

```xml
<root>
  <rec id="1"><CustomFunctionReference id="101" UUID="AAAA-0001" name="MyFunc"/><CustomFunctionReference id="102" UUID="AAAA-0002" name="OtherFunc"/></rec>
  <rec id="2"><CustomFunctionReference id="103" UUID="AAAA-0003" name="ThirdFunc"/><CustomFunctionReference id="104" UUID="AAAA-0004" name="FourthFunc"/></rec>
</root>
```

```sql
-- DOM: attributes present  ✅
SELECT CustomFunctionReference FROM read_xml('repro.xml', record_element := 'rec');
-- [{'id': 101, 'UUID': AAAA-0001, 'name': MyFunc}, {'id': 102, 'UUID': AAAA-0002, 'name': OtherFunc}]

-- SAX (forced via small maximum_file_size): per-item attributes lost  ❌ (before this PR)
SELECT CustomFunctionReference FROM read_xml('repro.xml', record_element := 'rec', maximum_file_size := 1);
-- [NULL, NULL]
```

The inferred type is identical in both cases (`LIST(STRUCT(id, UUID, name))`); only the streamed values were NULL.

## Root cause

Two issues in the SAX path, both relative to the record element:

1. **Direct-child attributes were captured as dead data.** `SAXStartElementNs` stored a `relative_depth == 1` child's attributes as dotted `child.attr` keys in `current_attributes`, which neither schema inference nor row materialization ever read back. (Deeper elements survive because their attributes are serialized into the `nested_xml` fragment.)

2. **The fragment extractor discards attribute-only fragments.**
   `ExtractValueFromXmlFragment` early-returns `NULL` when `inner_xml` is empty — exactly the attribute-only case (`<CustomFunctionReference id=".." …/>`) — so attributes were dropped even once captured.

## Fix

- Carry each direct child's own attributes (pre-escaped) on `FieldOccurrence::own_attrs`, and treat a child with attributes (or element children) as a nested-XML fragment so it routes through the existing DOM extractor. Honors `attr_mode := 'discard'`.
- Add a backward-compatible `extra_attrs` parameter to `ExtractValueFromXmlFragment`: it is spliced into the wrapper's open tag and suppresses the empty-inner `NULL` short-circuit when attributes are present, so an attribute-only fragment yields a populated `STRUCT`.

No new dependencies (libxml2 only).

## Testing

- New parity test `test/sql/sax_nested_child_attr_parity.test` (+ fixture) asserts DOM and SAX return identical values for the repro above — closing the coverage gap in the existing “DOM/SAX equivalence tests.”
- Full suite passes against DuckDB `v1.5.3`: **83 cases / 2875 assertions**.

## Scope

This targets the *repeated* (`LIST<STRUCT>`) case, where DOM already exposes a nested element's attributes. For a *non-repeating* single complex element, webbed's DOM schema inference itself omits the element's own attributes (`InferColumnType`, single-complex branch), so SAX stays in parity with DOM there — that separate gap is out of scope here.
