### PR TITLE
fix(wasm): link libxml2 + zlib via LINKED_LIBS so the WASM build loads (#96)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -43,6 +43,29 @@ jobs:
       # revisit once upstream sets PYTHONIOENCODING / utf8_mode in the runner.
       exclude_archs: 'windows_amd64;windows_amd64_mingw'
 
+  # Guards against the LINKED_LIBS class of WASM bug (issue #96): the reusable
+  # distribution workflow builds and uploads the .wasm but never inspects or
+  # loads it, so a side module with unresolved libxml2/zlib symbols ships green.
+  # This downloads the built v1.5.3 wasm artifacts and statically checks that no
+  # libxml2/zlib symbol is imported-but-undefined (no duckdb-wasm runtime needed).
+  # See test/wasm/ for the full explanation.
+  wasm-symbol-check:
+    name: WASM symbol resolution check
+    needs: [duckdb-stable-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: webbed-v1.5.3-extension-wasm_*
+          path: wasm-artifacts
+      - name: Check for unresolved libxml2/zlib symbols
+        run: bash test/wasm/run_wasm_checks.sh wasm-artifacts
+
 #  code-quality-check:
 #    name: Code Quality Check
 #    uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -46,11 +46,13 @@ jobs:
   # Guards against the LINKED_LIBS class of WASM bug (issue #96): the reusable
   # distribution workflow builds and uploads the .wasm but never inspects or
   # loads it, so a side module with unresolved libxml2/zlib symbols ships green.
-  # This downloads the built v1.5.3 wasm artifacts and statically checks that no
-  # libxml2/zlib symbol is imported-but-undefined (no duckdb-wasm runtime needed).
-  # See test/wasm/ for the full explanation.
-  wasm-symbol-check:
-    name: WASM symbol resolution check
+  # Two layers (see test/wasm/):
+  #   1. static symbol check (hard gate) — no duckdb-wasm runtime needed.
+  #   2. live load+query in duckdb-wasm (informational / continue-on-error) —
+  #      expected-red until official duckdb-wasm ships v1.5.3 (the only public
+  #      v1.5.3 engine, haybarn, uses a newer emscripten -> lseek ABI skew).
+  wasm-load-test:
+    name: WASM load test
     needs: [duckdb-stable-build]
     runs-on: ubuntu-latest
     steps:
@@ -63,8 +65,19 @@ jobs:
         with:
           pattern: webbed-v1.5.3-extension-wasm_*
           path: wasm-artifacts
-      - name: Check for unresolved libxml2/zlib symbols
+      - name: Static symbol check (libxml2/zlib must be linked, not unresolved)
         run: bash test/wasm/run_wasm_checks.sh wasm-artifacts
+      - name: Live load test in duckdb-wasm (informational until official v1.5.3)
+        continue-on-error: true
+        working-directory: test/wasm
+        run: |
+          set -euo pipefail
+          npm install --no-save
+          mkdir -p repo/v1.5.3/wasm_eh
+          cp "$GITHUB_WORKSPACE/wasm-artifacts/webbed-v1.5.3-extension-wasm_eh/webbed.duckdb_extension.wasm" \
+             repo/v1.5.3/wasm_eh/
+          node load_test.cjs --repo repo --name webbed --platform eh \
+            --query "SELECT xml_valid('<a/>') AS ok" --expect '"ok":true'
 
 #  code-quality-check:
 #    name: Code Quality Check

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -69,14 +69,15 @@ jobs:
         run: bash test/wasm/run_wasm_checks.sh wasm-artifacts
       - name: Live load test in duckdb-wasm (informational until official v1.5.3)
         continue-on-error: true
+        timeout-minutes: 10
         working-directory: test/wasm
         run: |
-          set -euo pipefail
-          npm install --no-save
+          set -uo pipefail
+          timeout 300 npm install --no-save
           mkdir -p repo/v1.5.3/wasm_eh
           cp "$GITHUB_WORKSPACE/wasm-artifacts/webbed-v1.5.3-extension-wasm_eh/webbed.duckdb_extension.wasm" \
              repo/v1.5.3/wasm_eh/
-          node load_test.cjs --repo repo --name webbed --platform eh \
+          timeout 240 node load_test.cjs --repo repo --name webbed --platform eh \
             --query "SELECT xml_valid('<a/>') AS ok" --expect '"ok":true'
 
 #  code-quality-check:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,35 @@ set(TARGET_NAME webbed)
 # used in cmake with find_package. Feel free to remove or replace with other dependencies.
 # Note that it should also be removed from vcpkg.json to prevent needlessly installing it..
 find_package(LibXml2 REQUIRED)
+find_package(ZLIB REQUIRED)  # transitive dependency of libxml2 (vcpkg default feature)
+
+# WASM side-module linking: duckdb's emcc step links ONLY the archives named in
+# DUCKDB_EXTENSION_WEBBED_LINKED_LIBS (see duckdb/extension/extension_build_tools.cmake,
+# the EMSCRIPTEN block). target_link_libraries() is ignored there, so both libxml2
+# and its zlib dependency must be named or their symbols are left unresolved and the
+# .wasm fails to load (issue #96). A $<TARGET_FILE:ZLIB::ZLIB> genexpr in
+# extension_config.cmake does not work: FindZLIB sets only the config-specific
+# IMPORTED_LOCATION_RELEASE, and that genexpr is evaluated in a scope whose
+# ZLIB::ZLIB (duckdb's own, for parquet) has no config-agnostic location, so it
+# silently resolves to empty. Resolve both archive paths here and pass them to the
+# WASM link as literal paths via this extension's LINKED_LIBS variable (a normal
+# variable in this scope, read by build_loadable_extension below).
+if(WASM_LOADABLE_EXTENSIONS)
+    macro(_webbed_resolve_imported_lib OUT TGT)
+        get_target_property(${OUT} ${TGT} IMPORTED_LOCATION)
+        if(NOT ${OUT})
+            get_target_property(${OUT} ${TGT} IMPORTED_LOCATION_RELEASE)
+        endif()
+    endmacro()
+    _webbed_resolve_imported_lib(_webbed_xml_lib LibXml2::LibXml2)
+    _webbed_resolve_imported_lib(_webbed_zlib_lib ZLIB::ZLIB)
+    if(_webbed_xml_lib AND _webbed_zlib_lib)
+        set(DUCKDB_EXTENSION_WEBBED_LINKED_LIBS "${_webbed_xml_lib};${_webbed_zlib_lib}")
+        message(STATUS "webbed WASM link libs: ${DUCKDB_EXTENSION_WEBBED_LINKED_LIBS}")
+    else()
+        message(FATAL_ERROR "webbed: could not resolve libxml2/zlib archive paths for WASM link (xml='${_webbed_xml_lib}' zlib='${_webbed_zlib_lib}')")
+    endif()
+endif()
 
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -4,6 +4,14 @@
 duckdb_extension_load(webbed
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
     LOAD_TESTS
+    # WASM side modules are linked by a separate `emcc -sSIDE_MODULE=2 ...
+    # ${LINKED_LIBS}` step (see duckdb/extension/extension_build_tools.cmake)
+    # that ignores target_link_libraries(). LibXml2 (and its zlib dependency)
+    # must be named or their symbols are left unresolved and the .wasm fails to
+    # load. The libxml2+zlib literal paths are injected for WASM by CMakeLists.txt
+    # (the ZLIB::ZLIB genexpr resolves empty in this scope); this libxml2 genexpr
+    # is the fallback/native value. See test/wasm/ and issue #96.
+    LINKED_LIBS "$<TARGET_FILE:LibXml2::LibXml2>"
 )
 
 # Any extra extensions that should be built

--- a/test/wasm/README.md
+++ b/test/wasm/README.md
@@ -51,19 +51,45 @@ Empirically: a broken build has 58 unresolved libxml2 symbols
 (`xmlNewParserCtxt`, `htmlReadMemory`, …); the fixed build has 0 across libxml2
 and zlib.
 
-### Layer 2 — end-to-end sqllogictest against duckdb-wasm (high fidelity)
+### Layer 2 — live load test in duckdb-wasm (`load_test.cjs`)
 
-Rusty Conover's harness instantiates the published WASM engine in Node, does
-`INSTALL ... FROM community; LOAD ...`, and runs the extension's existing
-`test/sql/*.test` files against it. This validates that the extension actually
-*works* under wasm (incl. that iconv really is host-provided), and surfaces
-version/ABI problems. Requires a published artifact + matching engine.
+`load_test.cjs` actually instantiates a duckdb-wasm engine in Node, serves the
+built extension repository over HTTP, `INSTALL`s + `LOAD`s the extension, and
+runs a query (`SELECT xml_valid('<a/>')`). This is the end-to-end proof that the
+module not only resolves symbols but instantiates and runs. It needs the npm
+deps in `package.json` (`npm install` here first).
 
-- Harness: https://github.com/Query-farm-haybarn/haybarn-extension-wasm-tester
-- Writeup: https://rusty.today/blog/testing-duckdb-wasm-extensions/
+```bash
+make wasm_eh
+cd test/wasm && npm install
+mkdir -p repo/v1.5.3/wasm_eh
+cp ../../build/wasm_eh/repository/v1.5.3/wasm_eh/webbed.duckdb_extension.wasm repo/v1.5.3/wasm_eh/
+node load_test.cjs --repo repo --name webbed --platform eh \
+    --query "SELECT xml_valid('<a/>') AS ok" --expect '"ok":true'
+```
+
+**Engine matching (important).** A clean `LOAD` requires an engine matching
+**both** the extension's duckdb version (v1.5.3) **and** its emscripten ABI
+(`extension-ci-tools@v1.5.3` pins emsdk 3.1.71). As of this writing no public
+engine satisfies both:
+
+| engine | duckdb | emsdk ABI | LOAD result |
+| --- | --- | --- | --- |
+| `@duckdb/duckdb-wasm` 1.33 | v1.5.1 (behind) | matches 3.1.71 | `memory access out of bounds` (version skew) |
+| `@haybarn/haybarn-wasm` 1.5.3-rc15 | v1.5.3 | newer emscripten | `lseek` import type mismatch (toolchain skew) |
+
+In both engines the load gets **past symbol resolution** (no missing/undefined
+symbol) — confirming the LINKED_LIBS fix — and fails only on version/toolchain
+ABI. The live test will go green once the official duckdb-wasm ships v1.5.3
+(built with the same pinned emsdk). Until then it is wired into CI as a
+**non-blocking** (informational) step; the Layer 1 static check is the hard gate.
+
+Background: https://rusty.today/blog/testing-duckdb-wasm-extensions/ ·
+https://github.com/Query-farm-haybarn/haybarn-extension-wasm-tester
 
 ## CI
 
-`wasm-symbol-check` in `MainDistributionPipeline.yml` downloads the v1.5.3 wasm
-artifacts and runs Layer 1. The reusable distribution workflow builds the
-`.wasm` but never inspects or loads it — which is why this bug shipped green.
+`wasm-load-test` in `MainDistributionPipeline.yml` downloads the v1.5.3 wasm
+artifacts and runs Layer 1 (hard gate) plus Layer 2 (`continue-on-error`, see
+above). The reusable distribution workflow builds the `.wasm` but never inspects
+or loads it — which is why this bug shipped green.

--- a/test/wasm/README.md
+++ b/test/wasm/README.md
@@ -1,0 +1,69 @@
+# WASM build tests
+
+These tests guard against the failure mode reported in
+[#96](https://github.com/teaguesterling/duckdb_webbed/issues/96): the
+DuckDB-WASM build installs but fails to load (or throws at first call) because a
+dependency's symbols are left unresolved in the side module.
+
+## Root cause
+
+The loadable `webbed.duckdb_extension.wasm` is **not** produced by the normal
+CMake link. DuckDB's `extension/extension_build_tools.cmake` runs a separate
+`emcc -sSIDE_MODULE=2 ... ${LINKED_LIBS}` post-build step that links the
+extension object archive against **only** the libraries named in this
+extension's `LINKED_LIBS`. The `target_link_libraries(... LibXml2::LibXml2)` in
+`CMakeLists.txt` is honored for native builds but **ignored** by this emcc step,
+so LibXml2's symbols become unresolved `env` imports.
+
+LibXml2 also pulls in **zlib** (a vcpkg default feature; used by libxml2's
+gz* compressed-input paths), so zlib must be linked too. **iconv** (the other
+default feature) is *not* linked: on emscripten it is provided by the host libc
+(vcpkg installs no `libiconv.a`), like `memcpy`/`malloc`.
+
+## Fix
+
+`CMakeLists.txt` resolves the libxml2 + zlib archive paths and feeds them to the
+WASM link via the extension's `LINKED_LIBS` variable (literal paths — a
+`$<TARGET_FILE:ZLIB::ZLIB>` genexpr resolves empty in the scope where the emcc
+command is generated; see the comment there). `extension_config.cmake` carries
+the libxml2 genexpr as the native/fallback value.
+
+## Two layers of testing
+
+### Layer 1 — static import check (fast, deterministic, no runtime)
+
+`check_wasm_imports.mjs` parses the built `.wasm` (validate-only, no
+instantiation) and fails if any dependency symbol is **imported but not
+defined/exported** by the module. Resolution is bucket-aware
+(`env`/`GOT.func` → exported functions, `GOT.mem` → exported data globals, so
+unresolved vtables/typeinfo are caught too). Host-provided symbols (duckdb
+runtime, libc incl. iconv) are excluded by matching only the dependency families
+(libxml2 `xml*`/`html*`, zlib `gz*`/`inflate`/…). Needs no duckdb-wasm runtime
+or duckdb-version match, so a failure is unambiguously the LINKED_LIBS bug and
+not an ABI mismatch.
+
+```bash
+make wasm_mvp                  # or wasm_eh / wasm_threads
+test/wasm/run_wasm_checks.sh   # scans build/wasm_* for webbed.*.wasm
+```
+
+Empirically: a broken build has 58 unresolved libxml2 symbols
+(`xmlNewParserCtxt`, `htmlReadMemory`, …); the fixed build has 0 across libxml2
+and zlib.
+
+### Layer 2 — end-to-end sqllogictest against duckdb-wasm (high fidelity)
+
+Rusty Conover's harness instantiates the published WASM engine in Node, does
+`INSTALL ... FROM community; LOAD ...`, and runs the extension's existing
+`test/sql/*.test` files against it. This validates that the extension actually
+*works* under wasm (incl. that iconv really is host-provided), and surfaces
+version/ABI problems. Requires a published artifact + matching engine.
+
+- Harness: https://github.com/Query-farm-haybarn/haybarn-extension-wasm-tester
+- Writeup: https://rusty.today/blog/testing-duckdb-wasm-extensions/
+
+## CI
+
+`wasm-symbol-check` in `MainDistributionPipeline.yml` downloads the v1.5.3 wasm
+artifacts and runs Layer 1. The reusable distribution workflow builds the
+`.wasm` but never inspects or loads it — which is why this bug shipped green.

--- a/test/wasm/check_wasm_imports.mjs
+++ b/test/wasm/check_wasm_imports.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// WASM side-module unresolved-dependency-symbol check.
+//
+// Why this exists: the loadable `.duckdb_extension.wasm` is produced by a
+// separate `emcc -sSIDE_MODULE=2 ... ${LINKED_LIBS}` step (see duckdb's
+// extension/extension_build_tools.cmake). That link ONLY pulls in libraries
+// named in `LINKED_LIBS` in extension_config.cmake -- `target_link_libraries`
+// in CMakeLists.txt is ignored for it. If a dependency (yaml-cpp here, LibXml2
+// for webbed) is not in LINKED_LIBS, its symbols end up imported by the module
+// but defined nowhere; since the duckdb-wasm host does not provide them the
+// module fails to load ("could not load dynamic lib") or throws at first call.
+// CI builds the .wasm but never inspects it, so this ships green.
+//
+// What it checks -- and why "is it imported" is the WRONG question:
+// emscripten side modules use position-independent / interposition linking, so
+// a module legitimately IMPORTS many symbols it also DEFINES/EXPORTS, and also
+// imports host-provided symbols (duckdb's C++ runtime; core deps bundled into
+// the duckdb-wasm host such as yyjson). The genuine bug is a dependency symbol
+// that is imported, NOT defined by this module, and not host-provided -- i.e.
+// genuinely unresolved.
+//
+// Imports come in three relevant buckets and must be resolved against the
+// right export kind (functions vs data globals):
+//   - module "env",      kind function  -> direct call          -> exported fn
+//   - module "GOT.func", kind global    -> function address slot -> exported fn
+//   - module "GOT.mem",  kind global    -> data address slot     -> exported global
+// A GOT.mem entry is how data symbols (vtables _ZTV*, typeinfo _ZTI*) are
+// referenced, so checking only function imports would miss an unresolved
+// vtable that breaks loading just like a missing function.
+//
+// Static parse only (WebAssembly.Module) -- no instantiation, no duckdb-wasm
+// runtime, no duckdb version match -- so a failure is unambiguously the
+// LINKED_LIBS bug and not an ABI/version mismatch.
+//
+// Usage:
+//   node check_wasm_imports.mjs <path-to.wasm> --forbid <regex> [--forbid <regex> ...] [--verbose]
+//
+// Exit: 0 = clean, 1 = unresolved dependency symbols found, 2 = usage/file error.
+
+import { readFileSync } from "node:fs";
+
+const argv = process.argv.slice(2);
+const forbid = [];
+let wasmPath = null;
+let verbose = false;
+
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (a === "--forbid") forbid.push(new RegExp(argv[++i]));
+  else if (a === "--verbose" || a === "-v") verbose = true;
+  else if (!wasmPath) wasmPath = a;
+  else { console.error(`unexpected argument: ${a}`); process.exit(2); }
+}
+
+if (!wasmPath || forbid.length === 0) {
+  console.error("usage: node check_wasm_imports.mjs <path-to.wasm> --forbid <regex> [--forbid <regex> ...] [--verbose]");
+  process.exit(2);
+}
+
+let bytes;
+try { bytes = readFileSync(wasmPath); }
+catch (e) { console.error(`cannot read ${wasmPath}: ${e.message}`); process.exit(2); }
+
+let mod;
+try { mod = new WebAssembly.Module(bytes); }
+catch (e) { console.error(`not a valid wasm module: ${e.message}`); process.exit(2); }
+
+const matches = (name) => forbid.some((re) => re.test(name));
+
+const imports = WebAssembly.Module.imports(mod);
+const exports = WebAssembly.Module.exports(mod);
+const expFn = new Set(exports.filter((e) => e.kind === "function").map((e) => e.name));
+const expGl = new Set(exports.filter((e) => e.kind === "global").map((e) => e.name));
+
+// Does this module itself satisfy the import? (interposition self-resolution)
+function selfResolved(imp) {
+  if (imp.kind === "function") return expFn.has(imp.name);     // env.<fn>
+  if (imp.module === "GOT.func") return expFn.has(imp.name);   // function address
+  if (imp.module === "GOT.mem") return expGl.has(imp.name) || expFn.has(imp.name); // data address
+  if (imp.kind === "global") return expGl.has(imp.name);       // env global / data
+  return false; // tables/memories etc. are host-provided runtime, never dep symbols
+}
+
+const depImports = imports.filter((i) => matches(i.name));
+const unresolved = depImports.filter((i) => !selfResolved(i));
+
+if (verbose) {
+  const byBucket = {};
+  for (const u of unresolved) byBucket[u.module] = (byBucket[u.module] || 0) + 1;
+  console.error(`[check] ${wasmPath}`);
+  console.error(`  imports: ${imports.length} | exports: ${expFn.size} fn, ${expGl.size} global`);
+  console.error(`  dependency-matching imports: ${depImports.length} | unresolved: ${unresolved.length} ${JSON.stringify(byBucket)}`);
+}
+
+if (unresolved.length > 0) {
+  console.error(`FAIL: ${unresolved.length} unresolved dependency symbol(s) in ${wasmPath} (imported, not defined by the module, not host-provided). The dependency is missing from LINKED_LIBS:`);
+  for (const o of unresolved.slice(0, 40)) console.error(`  ${o.module}.${o.name}`);
+  if (unresolved.length > 40) console.error(`  ... and ${unresolved.length - 40} more`);
+  process.exit(1);
+}
+
+console.error(`PASS: ${wasmPath} -- ${depImports.length} dependency import(s) all resolved by the module, 0 unresolved (${imports.length} imports inspected).`);
+process.exit(0);

--- a/test/wasm/load_test.cjs
+++ b/test/wasm/load_test.cjs
@@ -1,0 +1,69 @@
+// duckdb-wasm load test: actually LOAD a locally-built extension .wasm into a
+// version-matched duckdb-wasm engine and run a query. End-to-end counterpart to
+// the static check_wasm_imports.mjs gate. Uses the ASYNC API (the blocking API
+// deadlocks on LOAD, which needs async wasm instantiation).
+//
+// Usage:
+//   node load_test.cjs --repo <repository-dir> --name <ext> --query <sql>
+//       [--expect <substr>] [--platform eh|mvp] [--engine <npm-pkg>]
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const Worker = require("web-worker");
+
+function arg(name, def) { const i = process.argv.indexOf(`--${name}`); return i >= 0 ? process.argv[i + 1] : def; }
+
+const repoDir = arg("repo"), name = arg("name"), platform = arg("platform", "eh");
+const enginePkg = arg("engine", "@haybarn/haybarn-wasm"), query = arg("query"), expect = arg("expect");
+
+if (!repoDir || !name || !query) {
+  console.error("usage: node load_test.cjs --repo <dir> --name <ext> --query <sql> [--expect s] [--platform eh|mvp] [--engine pkg]");
+  process.exit(2);
+}
+
+const duckdb = require(`${enginePkg}/dist/duckdb-node`);
+const dist = path.dirname(require.resolve(`${enginePkg}/dist/duckdb-node.cjs`));
+const BUNDLES = {
+  mvp: { mainModule: path.join(dist, "duckdb-mvp.wasm"), mainWorker: path.join(dist, "duckdb-node-mvp.worker.cjs") },
+  eh: { mainModule: path.join(dist, "duckdb-eh.wasm"), mainWorker: path.join(dist, "duckdb-node-eh.worker.cjs") },
+};
+
+const server = http.createServer((req, res) => {
+  const fp = path.join(repoDir, decodeURIComponent(req.url.split("?")[0]));
+  if (!fp.startsWith(path.resolve(repoDir))) { res.writeHead(403); return res.end(); }
+  fs.readFile(fp, (err, buf) => {
+    if (err) { res.writeHead(404); return res.end(String(err)); }
+    res.writeHead(200, { "Content-Type": "application/wasm" }); res.end(buf);
+  });
+});
+
+(async () => {
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const repoUrl = `http://127.0.0.1:${server.address().port}`;
+  console.error(`[load_test] serving ${repoDir} at ${repoUrl}; engine=${enginePkg} platform=${platform}`);
+
+  const bundle = BUNDLES[platform];
+  const worker = new Worker(bundle.mainWorker);
+  const db = new duckdb.AsyncDuckDB(new duckdb.VoidLogger(), worker);
+  await db.instantiate(bundle.mainModule);
+  await db.open({ allowUnsignedExtensions: true });
+  const conn = await db.connect();
+
+  const ver = (await conn.query("SELECT version() AS v")).toArray()[0].v;
+  console.error(`[load_test] engine duckdb version: ${ver}`);
+  await conn.query(`SET custom_extension_repository='${repoUrl}'`);
+  console.error(`[load_test] INSTALL ${name}`); await conn.query(`INSTALL ${name}`);
+  console.error(`[load_test] LOAD ${name}`); await conn.query(`LOAD ${name}`);
+  console.error(`[load_test] query: ${query}`);
+  const rows = (await conn.query(query)).toArray();
+  const out = JSON.stringify(rows.map((r) => Object.fromEntries(Object.entries(r))));
+  console.error(`[load_test] result: ${out}`);
+
+  await conn.close(); await db.terminate(); await worker.terminate(); server.close();
+
+  if (expect !== undefined && !out.includes(expect)) {
+    console.error(`FAIL: expected substring '${expect}' not in result ${out}`); process.exit(1);
+  }
+  console.log(`PASS: ${name} loaded into duckdb-wasm ${ver} (${platform}) and query returned ${out}`);
+  process.exit(0);
+})().catch((e) => { console.error("FAIL:", e && e.message ? e.message : e); try { server.close(); } catch {} process.exit(1); });

--- a/test/wasm/package.json
+++ b/test/wasm/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "webbed-wasm-tests",
+  "private": true,
+  "description": "Dependencies for the duckdb-wasm live load test (load_test.cjs). The static check (check_wasm_imports.mjs / run_wasm_checks.sh) needs no dependencies.",
+  "dependencies": {
+    "@haybarn/haybarn-wasm": "1.5.3-rc15",
+    "web-worker": "1.2.0"
+  }
+}

--- a/test/wasm/run_wasm_checks.sh
+++ b/test/wasm/run_wasm_checks.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Run the WASM dependency-symbol check against built .wasm artifacts.
+#
+# Fast, deterministic gate for the LINKED_LIBS class of bug (see
+# check_wasm_imports.mjs). It statically inspects the side module's imports vs
+# exports; no duckdb-wasm runtime or duckdb-version match needed. Run after
+# `make wasm_mvp` / `wasm_eh`, or point it at downloaded CI artifacts.
+#
+# Usage: test/wasm/run_wasm_checks.sh [dir ...]
+#   defaults to build/wasm_mvp build/wasm_eh build/wasm_threads if present.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+
+# Dependency symbols that MUST be resolved internally (not left unresolved):
+#   libxml2 -> xml*/html* (C symbols)
+#   zlib    -> gz*/inflate/deflate/... (libxml2's transitive dep; guard against
+#              someone dropping it from the link)
+# iconv (iconv_open/close/iconv) is deliberately NOT listed: on emscripten it is
+# provided by the host libc (vcpkg installs no libiconv.a), like memcpy/malloc.
+FORBID=( --forbid '^xml' --forbid '^html'
+         --forbid '^gz' --forbid '^inflate' --forbid '^deflate'
+         --forbid 'crc32' --forbid 'adler32' --forbid 'zlibVersion'
+         --forbid '^uncompress' --forbid '^compress' --forbid 'get_crc_table' )
+
+dirs=("$@")
+if [ ${#dirs[@]} -eq 0 ]; then
+  for d in build/wasm_mvp build/wasm_eh build/wasm_threads; do
+    [ -d "$repo_root/$d" ] && dirs+=("$repo_root/$d")
+  done
+fi
+
+if [ ${#dirs[@]} -eq 0 ]; then
+  echo "no wasm build dirs found; build first (e.g. make wasm_mvp)" >&2
+  exit 2
+fi
+
+found_any=0
+rc=0
+for d in "${dirs[@]}"; do
+  while IFS= read -r -d '' wasm; do
+    found_any=1
+    echo "==> checking $wasm"
+    node "$here/check_wasm_imports.mjs" "$wasm" "${FORBID[@]}" || rc=1
+  done < <(find "$d" -name 'webbed.duckdb_extension.wasm' -print0 2>/dev/null)
+done
+
+if [ "$found_any" -eq 0 ]; then
+  echo "no webbed.duckdb_extension.wasm found under: ${dirs[*]}" >&2
+  exit 2
+fi
+exit $rc


### PR DESCRIPTION
**Draft** — fixes #96. Static symbol-resolution fix is verified; the live duckdb-wasm load test is included but non-blocking pending an engine match (see below).

## Root cause
The loadable `webbed.duckdb_extension.wasm` is produced by a separate
`emcc -sSIDE_MODULE=2 ... ${LINKED_LIBS}` post-build step in duckdb's
`extension/extension_build_tools.cmake`. That link pulls in **only** the libs in
this extension's `LINKED_LIBS`; `target_link_libraries(... LibXml2::LibXml2)` is
honored for native but **ignored** for the wasm side-module link. So LibXml2's
symbols were left unresolved and the module failed to load (@rustyconover's #96).

LibXml2 also pulls in **zlib** (a vcpkg default feature), which must be linked
too. **iconv** (the other default feature) is host-provided by emscripten's libc
(vcpkg installs no `libiconv.a`).

## Fix
`CMakeLists.txt` resolves the libxml2 + zlib archive paths and feeds them to the
WASM link as literal paths via the extension's `LINKED_LIBS` variable. (A
`$<TARGET_FILE:ZLIB::ZLIB>` genexpr in `extension_config.cmake` resolves empty:
FindZLIB sets only `IMPORTED_LOCATION_RELEASE`, and the genexpr is evaluated in a
scope whose `ZLIB::ZLIB` — duckdb's own, for parquet — has no config-agnostic
location. See the comment in `CMakeLists.txt`.)

## Tests (`test/wasm/`)
The reusable distribution workflow **builds and uploads** the `.wasm` but never
inspects or loads it — which is why this shipped green.

- **Layer 1 — static symbol check** (`check_wasm_imports.mjs`, hard CI gate):
  runtime-free; fails if a dependency symbol is imported but not defined by the
  side module (bucket-aware: `env`/`GOT.func` functions, `GOT.mem` data/vtables;
  host-provided symbols excluded by matching only libxml2 `xml*`/`html*` and zlib
  families). No duckdb-wasm runtime or version match needed, so a failure is
  unambiguously the LINKED_LIBS bug, not an ABI mismatch.
- **Layer 2 — live load test** (`load_test.cjs`, non-blocking CI): instantiates
  duckdb-wasm in Node, `INSTALL`+`LOAD`s the built extension, runs a query.

## Verification
Built with emsdk 3.1.71 (`wasm_mvp` **and** `wasm_eh`, matching CI):

| | unresolved libxml2/zlib symbols |
| --- | --- |
| before (no LINKED_LIBS) | **58** (`xmlNewParserCtxt`, `htmlReadMemory`, …) |
| after | **0** across libxml2 and zlib, both platforms |

Native build + full test suite unaffected (**2866 assertions, 82 cases pass**).

## What is and isn't verified — and the live-load caveat
- ✅ **Symbol resolution**: 0 unresolved, clean red→green on `wasm_mvp` + `wasm_eh`.
- ⚠️ **Live `LOAD` can't go green against any public engine yet** — for reasons
  *orthogonal* to this fix. A clean load needs an engine matching both duckdb
  v1.5.3 **and** emsdk 3.1.71:

  | engine | duckdb | emsdk ABI | LOAD result |
  | --- | --- | --- | --- |
  | `@duckdb/duckdb-wasm` 1.33 | v1.5.1 (behind) | matches 3.1.71 | `memory access out of bounds` (version skew) |
  | `@haybarn/haybarn-wasm` 1.5.3-rc15 | v1.5.3 | newer emscripten | `lseek` import type mismatch (toolchain skew) |

  In **both** engines the load gets *past symbol resolution* (no missing symbol),
  confirming the fix; only version/toolchain ABI fails. The live test will go
  green once official duckdb-wasm ships v1.5.3. Until then it's `continue-on-error`.
- ⚠️ `wasm_threads` not built; uses the identical `LINKED_LIBS` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
