### PR TITLE
docs: align changelog + v2.2.1 notes with what shipped

### DIFF
--- a/RELEASE_NOTES_v2.2.1.md
+++ b/RELEASE_NOTES_v2.2.1.md
@@ -11,5 +11,15 @@ separate `emcc` step, which links only the libraries named in `LINKED_LIBS`.
 - Add `test/wasm/`: a static symbol-resolution gate (hard CI check) plus a live
   duckdb-wasm load test (non-blocking until official duckdb-wasm ships v1.5.3).
 
-No functional/source changes; native build and full test suite are unchanged
-(2866 assertions, 82 cases).
+The WASM fix itself is build-only — no source changes.
+
+## SAX streaming: nested child attributes (#98, closes #97)
+
+Also included in this release: a SAX streaming fix that landed just before it.
+Under streaming, a record's *repeated* nested child element typed as
+`LIST<STRUCT(@attr…)>` lost its per-item attributes (`[NULL, NULL]`), while the
+DOM path returned them. Each direct child's own attributes are now carried
+(pre-escaped) through the existing fragment extractor, restoring DOM/SAX parity.
+Honors `attr_mode := 'discard'`.
+
+Native build and full test suite pass: **2875 assertions, 83 cases**.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,181 @@
 Changelog
 =========
 
-v2.0.0 (Current)
------------------
+v2.2.1 (Current)
+----------------
+
+A patch release: the DuckDB-WASM build now loads, plus a SAX streaming
+attribute-parity fix. No DuckDB submodule bump (stays on v1.5.3).
+
+**Bug Fixes**
+
+- Fixed the DuckDB-WASM build installing but failing to load — libxml2 (and its
+  ``zlib`` dependency) were not linked into the ``emcc -sSIDE_MODULE=2`` side
+  module, so their symbols were left unresolved and the ``.wasm`` failed to load.
+  ``target_link_libraries`` is ignored by that separate emcc link step; both
+  archives are now passed via ``LINKED_LIBS``. (Issue #96)
+- Fixed SAX streaming dropping the attributes of a record's repeated nested child
+  elements — a ``LIST<STRUCT(@attr…)>`` streamed back as ``[NULL, NULL]`` while the
+  DOM path returned the attribute values. Each direct child's own attributes are
+  now carried through the fragment extractor, restoring DOM/SAX parity.
+  (Issues #97, #98)
+
+**Testing**
+
+- Added a ``test/wasm/`` regression suite wired into CI as the ``wasm-load-test``
+  job: a runtime-free static symbol check (hard gate — libxml2/zlib must be linked
+  into the side module, not left unresolved) plus a duckdb-wasm live load test.
+  The reusable distribution workflow builds the ``.wasm`` but never loads it, which
+  is why #96 shipped green.
+- Added ``test/sql/sax_nested_child_attr_parity.test`` (DOM/SAX parity for the
+  repeated-nested-attribute case); native suite at 83 cases / 2875 assertions.
+
+**Internal**
+
+- ``vcpkg.json`` manifest version → 2.2.1.
+
+v2.2.0
+------
+
+A large correctness and security release: memory-safety, injection, and
+denial-of-service fixes across the scalar functions and parsers, ``read_xml``
+schema-inference fixes, faithful ``parse_html`` whitespace handling, and
+forward-compatibility with current DuckDB ``main``. No DuckDB submodule bump.
+
+**Security**
+
+- Vector memory safety — twelve scalar functions plus ``ConvertList/StructToXML``
+  indexed raw ``FlatVector`` data by row, corrupting the heap on NULL, constant, or
+  dictionary-encoded inputs; they now use ``UnifiedVectorFormat`` with NULL-in/NULL-out
+  semantics (Issue #86)
+- Fixed markup injection in ``xml_wrap_fragment`` — the wrapper name is now validated
+  with ``xmlValidateName`` plus an embedded-NUL guard (Issue #89)
+- Fixed markup injection in ``to_xml`` — the ``node_name`` argument and STRUCT field
+  names are now validated before being emitted into ``xml``-typed output (Issue #93)
+- Fixed memory disclosure in ``read_xml`` — with ``ignore_errors:=true`` and the
+  single-column fallback schema, rows left output slots uninitialized and returned
+  stale heap bytes; a shared ``EmitRow`` helper NULL-fills every column (Issue #87)
+- Fixed denial of service in ``duck_blocks_to_html`` — malformed Pandoc-table JSON
+  could hang the parser indefinitely; the parse loops now guarantee forward progress
+  and no longer read past the end of truncated input (Issue #90)
+
+**Bug Fixes**
+
+- Fixed valid XML mislabeled invalid under ``threads > 1`` — ``IsValidXML`` gated on a
+  process-global parse-error flag; validity is now decided per-thread (Issue #83)
+- Distinguished libxml2 out-of-memory from malformed input — a transient
+  ``XML_ERR_NO_MEMORY`` was reported as invalid XML and dropped under ``ignore_errors``;
+  it now raises ``OutOfMemoryException`` (propagated through ``XMLDocRAII`` moves)
+  (Issues #84, #94)
+- Fixed ``parse_html`` whitespace handling — significant inline whitespace was deleted
+  and ``script``/``style``/CDATA content mangled; whitespace is now normalized on the
+  parse tree, preserving ``pre``/``textarea``/``script``/``style``/CDATA verbatim
+  (Issues #88, #91)
+
+**read_xml Schema Inference** (Issue #87)
+
+- Integer columns now widen INTEGER → BIGINT → DOUBLE by value range (was INT32, then
+  threw at extract time)
+- ``attr_mode:='prefixed'`` columns now extract correctly (prefix stripped on lookup)
+- DESCRIBE column order is now deterministic (first-seen document order, DOM and SAX)
+- Locale-independent numeric parsing via strict ``TryCast``; ``inf``/``nan`` infer VARCHAR
+
+**Compatibility**
+
+- DuckDB ``main`` ``duckdb::Identifier`` change absorbed via ``duckdb_compat.hpp``
+  (no-op against the pinned v1.5.3 build) (Issue #92)
+
+**Testing**
+
+- 2866 assertions across 82 test cases; new ``vector_safety``, injection-validation,
+  schema-inference, ``parse_html_whitespace``, robustness, concurrency-race, and
+  out-of-memory suites
+
+**Internal**
+
+- ``vcpkg.json`` manifest version → 2.2.0
+
+v2.1.1
+------
+
+**Bug Fixes**
+
+- Fixed ``xml_to_json`` emitting malformed JSON for values containing quotes or C0
+  control characters, so output could not round-trip through ``CAST(... AS JSON)``;
+  a new ``EscapeJSONString`` helper escapes ``"``, ``\``, and the C0 range per RFC 8259
+  while leaving valid raw characters and UTF-8 untouched (Issue #78)
+
+**Compatibility**
+
+- Restored ``duckdb-next-build`` against current DuckDB ``main`` (private ``bind_info``,
+  ``ForceMaxLogicalType`` signature change, strict named-argument matching); all changes
+  are no-ops against the pinned v1.5.3 build
+
+**Internal**
+
+- ``vcpkg.json`` manifest version → 2.1.1
+
+v2.1.0
+------
+
+**New Features**
+
+- STRUCT widening in ``read_xml(union_by_name:=true)`` — cross-file STRUCT shape
+  disagreements previously collapsed to VARCHAR; ``MergeXMLColumnType`` now recursively
+  unions STRUCT fields and LIST element types, reconciles scalar-vs-``LIST`` cardinality,
+  and infers a repeated element's fields from all occurrences in document order (Issue #75)
+- SAX streaming path now produces rich types and participates in ``union_by_name``
+  widening, with document-order fragment accumulation and namespace-declaration handling
+  (Issues #75, #77, #80)
+
+**Changes**
+
+- ``duckdb-stable-build`` CI matrix bumped to DuckDB v1.5.3; ``duckdb`` submodule →
+  ``14eca11bd9``, ``extension-ci-tools`` → ``4b3b37b0`` (Issue #79)
+
+**Compatibility**
+
+- ``duckdb_compat.hpp`` keeps ``duckdb-next-build`` green against DuckDB ``main``
+  (per-vector buffer sizing, StructVector/ListVector API changes) (Issue #76)
+- MSVC build fix for DuckDB's vendored ``fmt`` (C++17 inline variables)
+
+**Bug Fixes**
+
+- Mixed text/XML document order and prefixed names under ``namespaces:='keep'`` are now
+  preserved through the SAX path (Issue #77)
+
+**Internal**
+
+- ``vcpkg.json`` manifest version → 2.1.0
+
+v2.0.1
+------
+
+**Bug Fixes**
+
+- Fixed whitespace collapsing in text content — ``read_xml`` collapsed internal
+  whitespace (newlines, tabs, multi-space runs) into a single space, destroying
+  semantically meaningful structure in CDATA sections, source code, and multi-line
+  content (Issue #73)
+
+**New Parameter**
+
+- Added ``preserve_whitespace`` (BOOLEAN, default ``true``) to ``read_xml`` and
+  ``read_html``. Default trims leading/trailing whitespace, normalizes CRLF/CR to LF per
+  XML 1.0 §2.11, and preserves internal whitespace as-is; ``false`` restores the previous
+  collapsing behavior
+
+**Compatibility**
+
+- Added compatibility layer for upcoming DuckDB API breaking changes (bind function
+  signature, private ScalarFunction fields, vector header relocations)
+
+**Internal**
+
+- ``vcpkg.json`` manifest version → 2.0.1
+
+v2.0.0
+------
 
 **New Features**
 


### PR DESCRIPTION
Administrative docs only — no source/version changes.

`docs/changelog.rst` had gone stale at **v2.0.0**. This:

- Adds a **v2.2.1** entry covering **both** fixes that shipped in it: the WASM `LINKED_LIBS` load fix (#96) and the SAX nested-child attribute parity fix (#97/#98).
- Backfills **v2.0.1, v2.1.0, v2.1.1, v2.2.0**, which existed only as GitHub releases — so the changelog is contiguous from v2.2.1 down to v1.0.0.

`RELEASE_NOTES_v2.2.1.md` described only the WASM fix and stated *"no functional/source changes (2866 assertions, 82 cases)."* The SAX fix (#98) merged just before the v2.2.1 release commit and **is** functional, so this adds it and corrects the count to **2875 assertions / 83 cases**.

Verified: changelog versions are in descending order with valid rST underlines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YK2zHBz326w3k8kVEYXXPF)_