### PR TITLE
test(wasm): make the live duckdb-wasm load test actually load (not hang)

### DIFF
--- a/test/wasm/load_test.cjs
+++ b/test/wasm/load_test.cjs
@@ -14,7 +14,10 @@ const Worker = require("web-worker");
 function arg(name, def) { const i = process.argv.indexOf(`--${name}`); return i >= 0 ? process.argv[i + 1] : def; }
 
 const repoDir = arg("repo"), name = arg("name"), platform = arg("platform", "eh");
-const enginePkg = arg("engine", "@haybarn/haybarn-wasm"), query = arg("query"), expect = arg("expect");
+// @duckdb/duckdb-wasm@1.33.1-dev55.0 ships engine v1.5.3 (source_id 14eca11bd9) -- the exact
+// duckdb commit the v1.5.3 build targets -- so it loads the v1.5.3/wasm_eh artifact cleanly.
+// (@haybarn/haybarn-wasm has drifted to v1.5.4-dev, a version skew that fails to load.)
+const enginePkg = arg("engine", "@duckdb/duckdb-wasm"), query = arg("query"), expect = arg("expect");
 
 if (!repoDir || !name || !query) {
   console.error("usage: node load_test.cjs --repo <dir> --name <ext> --query <sql> [--expect s] [--platform eh|mvp] [--engine pkg]");
@@ -28,9 +31,13 @@ const BUNDLES = {
   eh: { mainModule: path.join(dist, "duckdb-eh.wasm"), mainWorker: path.join(dist, "duckdb-node-eh.worker.cjs") },
 };
 
+const repoRoot = path.resolve(repoDir);
 const server = http.createServer((req, res) => {
-  const fp = path.join(repoDir, decodeURIComponent(req.url.split("?")[0]));
-  if (!fp.startsWith(path.resolve(repoDir))) { res.writeHead(403); return res.end(); }
+  // Resolve to an absolute path before the traversal check: path.join with a relative repoDir
+  // (e.g. --repo repo, as CI invokes it) yields a relative fp that never startsWith the absolute
+  // repoRoot, so the guard returned 403 for the extension fetch and the engine hung on LOAD.
+  const fp = path.resolve(repoRoot, "." + path.sep + decodeURIComponent(req.url.split("?")[0]));
+  if (fp !== repoRoot && !fp.startsWith(repoRoot + path.sep)) { res.writeHead(403); return res.end(); }
   fs.readFile(fp, (err, buf) => {
     if (err) { res.writeHead(404); return res.end(String(err)); }
     res.writeHead(200, { "Content-Type": "application/wasm" }); res.end(buf);

--- a/test/wasm/load_test.cjs
+++ b/test/wasm/load_test.cjs
@@ -33,10 +33,15 @@ const BUNDLES = {
 
 const repoRoot = path.resolve(repoDir);
 const server = http.createServer((req, res) => {
+  // decodeURIComponent throws URIError on malformed percent-encoding; catch it so a bad request
+  // returns 400 instead of crashing the in-process server (which would hang the load test).
+  let rel;
+  try { rel = decodeURIComponent(req.url.split("?")[0]); }
+  catch { res.writeHead(400); return res.end("bad request URI"); }
   // Resolve to an absolute path before the traversal check: path.join with a relative repoDir
   // (e.g. --repo repo, as CI invokes it) yields a relative fp that never startsWith the absolute
   // repoRoot, so the guard returned 403 for the extension fetch and the engine hung on LOAD.
-  const fp = path.resolve(repoRoot, "." + path.sep + decodeURIComponent(req.url.split("?")[0]));
+  const fp = path.resolve(repoRoot, "." + path.sep + rel);
   if (fp !== repoRoot && !fp.startsWith(repoRoot + path.sep)) { res.writeHead(403); return res.end(); }
   fs.readFile(fp, (err, buf) => {
     if (err) { res.writeHead(404); return res.end(String(err)); }

--- a/test/wasm/package.json
+++ b/test/wasm/package.json
@@ -1,9 +1,9 @@
 {
   "name": "webbed-wasm-tests",
   "private": true,
-  "description": "Dependencies for the duckdb-wasm live load test (load_test.cjs). The static check (check_wasm_imports.mjs / run_wasm_checks.sh) needs no dependencies.",
+  "description": "Dependencies for the duckdb-wasm live load test (load_test.cjs). The static check (check_wasm_imports.mjs / run_wasm_checks.sh) needs no dependencies. The engine pin must match the DuckDB the extension is built against: 1.33.1-dev55.0 ships engine v1.5.3 (source_id 14eca11bd9), the exact duckdb commit the v1.5.3 build targets. Bump in lockstep with the duckdb submodule.",
   "dependencies": {
-    "@haybarn/haybarn-wasm": "1.5.3-rc15",
+    "@duckdb/duckdb-wasm": "1.33.1-dev55.0",
     "web-worker": "1.2.0"
   }
 }


### PR DESCRIPTION
Makes the `wasm-load-test` job's live step actually load the extension, instead of hanging to the 240s timeout (it was `continue-on-error`, so it shipped silently red).

## Root cause — not version/emsdk skew

The hang was a bug in the test's **own HTTP server**, not the engine. The traversal guard compared a *relative* `path.join(repoDir, url)` against the *absolute* `path.resolve(repoDir)`:

```js
const fp = path.join(repoDir, decodeURIComponent(req.url...));     // "repo/v1.5.3/..."  (relative)
if (!fp.startsWith(path.resolve(repoDir))) { res.writeHead(403); } // "/work/.../repo"   (absolute) → always 403
```

The workflow invokes it as `--repo repo` (relative), so **every** extension fetch returned **403**, and the engine hung forever on the failed load.

## Fix

- Resolve the served path to absolute before the guard (still blocks `../` traversal — verified).
- Default `--engine` to `@duckdb/duckdb-wasm@1.33.1-dev55.0`, which ships engine **v1.5.3 (`14eca11bd9`)** — the exact duckdb commit the v1.5.3 build targets. `@haybarn/haybarn-wasm` has drifted to `v1.5.4-dev` (a real version skew that also fails).

## Validation

Locally against the dev55 engine with the guard fixed, the engine fetches the served extension and reaches real module instantiation — erroring only on a deliberately-garbage payload (`need to see wasm magic number`) instead of hanging. The real `v1.5.3/wasm_eh` artifact should now `LOAD` + run `xml_valid('<a/>')`; this PR's CI exercises it end to end.

Once green, the workflow's `continue-on-error: true` on that step can be dropped to make it a hard gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YK2zHBz326w3k8kVEYXXPF)_