### PR TITLE
fix(read_xml): wire sample_size + safe out-of-sample fallback (#102)

### DIFF
--- a/src/xml_reader_functions.cpp
+++ b/src/xml_reader_functions.cpp
@@ -406,6 +406,11 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 			schema_options.auto_detect = kv.second.GetValue<bool>();
 		} else if (kv.first == "max_depth") {
 			schema_options.max_depth = kv.second.GetValue<int32_t>();
+		} else if (kv.first == "sample_size") {
+			// #102: how many element values the type sniffer inspects before locking a column's
+			// type. <= 0 samples every value (always-correct detection at the cost of a full scan
+			// at bind time).
+			schema_options.sample_size = kv.second.GetValue<int32_t>();
 		} else if (kv.first == "unnest_as") {
 			auto unnest_mode = kv.second.ToString();
 			if (unnest_mode == "columns") {
@@ -1297,6 +1302,11 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context,
 			schema_options.auto_detect = kv.second.GetValue<bool>();
 		} else if (kv.first == "max_depth") {
 			schema_options.max_depth = kv.second.GetValue<int32_t>();
+		} else if (kv.first == "sample_size") {
+			// #102: how many element values the type sniffer inspects before locking a column's
+			// type. <= 0 samples every value (always-correct detection at the cost of a full scan
+			// at bind time).
+			schema_options.sample_size = kv.second.GetValue<int32_t>();
 		} else if (kv.first == "unnest_as") {
 			auto unnest_mode = kv.second.ToString();
 			if (unnest_mode == "columns") {
@@ -1762,6 +1772,11 @@ unique_ptr<FunctionData> XMLReaderFunctions::ParseDocumentBind(ClientContext &co
 			schema_options.auto_detect = kv.second.GetValue<bool>();
 		} else if (kv.first == "max_depth") {
 			schema_options.max_depth = kv.second.GetValue<int32_t>();
+		} else if (kv.first == "sample_size") {
+			// #102: how many element values the type sniffer inspects before locking a column's
+			// type. <= 0 samples every value (always-correct detection at the cost of a full scan
+			// at bind time).
+			schema_options.sample_size = kv.second.GetValue<int32_t>();
 		} else if (kv.first == "unnest_as") {
 			auto unnest_mode = kv.second.ToString();
 			if (unnest_mode == "columns") {
@@ -2045,6 +2060,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_xml_single.named_parameters["empty_elements"] = LogicalType::VARCHAR; // 'null' | 'string' | 'object'
 	read_xml_single.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
 	read_xml_single.named_parameters["max_depth"] = LogicalType::INTEGER;
+	read_xml_single.named_parameters["sample_size"] = LogicalType::INTEGER;
 	read_xml_single.named_parameters["unnest_as"] = LogicalType::VARCHAR; // 'columns' (default) or 'struct' (future)
 	read_xml_single.named_parameters["record_element"] =
 	    LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
@@ -2076,6 +2092,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_xml_array.named_parameters["empty_elements"] = LogicalType::VARCHAR; // 'null' | 'string' | 'object'
 	read_xml_array.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
 	read_xml_array.named_parameters["max_depth"] = LogicalType::INTEGER;
+	read_xml_array.named_parameters["sample_size"] = LogicalType::INTEGER;
 	read_xml_array.named_parameters["unnest_as"] = LogicalType::VARCHAR; // 'columns' (default) or 'struct' (future)
 	read_xml_array.named_parameters["record_element"] =
 	    LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
@@ -2111,6 +2128,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_html_single.named_parameters["empty_elements"] = LogicalType::VARCHAR; // 'null' | 'string' | 'object'
 	read_html_single.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
 	read_html_single.named_parameters["max_depth"] = LogicalType::INTEGER;
+	read_html_single.named_parameters["sample_size"] = LogicalType::INTEGER;
 	read_html_single.named_parameters["unnest_as"] = LogicalType::VARCHAR; // 'columns' (default) or 'struct' (future)
 	read_html_single.named_parameters["record_element"] =
 	    LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
@@ -2141,6 +2159,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_html_array.named_parameters["empty_elements"] = LogicalType::VARCHAR; // 'null' | 'string' | 'object'
 	read_html_array.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
 	read_html_array.named_parameters["max_depth"] = LogicalType::INTEGER;
+	read_html_array.named_parameters["sample_size"] = LogicalType::INTEGER;
 	read_html_array.named_parameters["unnest_as"] = LogicalType::VARCHAR; // 'columns' (default) or 'struct' (future)
 	read_html_array.named_parameters["record_element"] =
 	    LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
@@ -2215,6 +2234,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	parse_xml.named_parameters["empty_elements"] = LogicalType::VARCHAR;
 	parse_xml.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
 	parse_xml.named_parameters["max_depth"] = LogicalType::INTEGER;
+	parse_xml.named_parameters["sample_size"] = LogicalType::INTEGER;
 	parse_xml.named_parameters["unnest_as"] = LogicalType::VARCHAR;
 	parse_xml.named_parameters["all_varchar"] = LogicalType::BOOLEAN;
 	parse_xml.named_parameters["datetime_format"] = LogicalType::ANY; // VARCHAR or LIST(VARCHAR)
@@ -2239,6 +2259,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	parse_html.named_parameters["empty_elements"] = LogicalType::VARCHAR;
 	parse_html.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
 	parse_html.named_parameters["max_depth"] = LogicalType::INTEGER;
+	parse_html.named_parameters["sample_size"] = LogicalType::INTEGER;
 	parse_html.named_parameters["unnest_as"] = LogicalType::VARCHAR;
 	parse_html.named_parameters["all_varchar"] = LogicalType::BOOLEAN;
 	parse_html.named_parameters["datetime_format"] = LogicalType::ANY; // VARCHAR or LIST(VARCHAR)

--- a/src/xml_schema_inference.cpp
+++ b/src/xml_schema_inference.cpp
@@ -357,6 +357,30 @@ static std::unordered_set<std::string> ParseForceListElements(const std::string 
 }
 
 // Phase 3: Infer Column Type
+// #102: how many element values the type sniffer inspects before locking a column's type.
+// options.sample_size <= 0 means "sample every value" -> always-correct detection (the bind-time
+// half of read_csv-style robustness; the runtime-widening half is tracked as #102 "C").
+static size_t XmlSampleLimit(const XMLSchemaOptions &options) {
+	return options.sample_size <= 0 ? static_cast<size_t>(-1) : static_cast<size_t>(options.sample_size);
+}
+
+// #102: a value that does not match the column type the sniffer inferred from the sample window.
+// Under ignore_errors we emit a typed NULL (row preserved, value dropped); otherwise we raise a
+// clear, actionable error. (Previously this path returned a VARCHAR Value, which then aborted with
+// a generic cast error when written into the typed output column.) This is the single chokepoint a
+// future read_csv-style runtime column-widening (#102 "C") would hook into.
+static Value XmlUncastableValue(const std::string &text, const LogicalType &target_type,
+                                const XMLSchemaOptions &options) {
+	if (options.ignore_errors) {
+		return Value(target_type);
+	}
+	throw InvalidInputException(
+	    "read_xml: value '%s' does not match column type %s, which was inferred from the first %d "
+	    "sampled values. Increase sample_size (or set sample_size := -1 to sample every value), set "
+	    "all_varchar := true, or set ignore_errors := true to skip such values. (issue #102)",
+	    text, target_type.ToString(), options.sample_size);
+}
+
 LogicalType XMLSchemaInference::InferColumnType(const ColumnAnalysis &column, int remaining_depth,
                                                 const XMLSchemaOptions &options, std::string &winning_datetime_format) {
 	winning_datetime_format.clear();
@@ -406,7 +430,7 @@ LogicalType XMLSchemaInference::InferColumnType(const ColumnAnalysis &column, in
 		}
 
 		// Collect text content for type detection
-		if (text_samples.size() < 20) {
+		if (text_samples.size() < XmlSampleLimit(options)) {
 			xmlChar *content = xmlNodeGetContent(node);
 			if (content) {
 				std::string text = CleanTextContent((const char *)content, options.preserve_whitespace);
@@ -487,7 +511,7 @@ LogicalType XMLSchemaInference::InferColumnType(const ColumnAnalysis &column, in
 			// Collect text samples from all instances for type inference
 			std::vector<std::string> list_text_samples;
 			for (xmlNodePtr instance : column.instances) {
-				if (list_text_samples.size() >= 20) {
+				if (list_text_samples.size() >= XmlSampleLimit(options)) {
 					break;
 				}
 				xmlChar *content = xmlNodeGetContent(instance);
@@ -620,7 +644,7 @@ LogicalType XMLSchemaInference::InferColumnType(const ColumnAnalysis &column, in
 				}
 			}
 			// Collect text content samples for type inference
-			if (cross_record_text_samples.size() < 20) {
+			if (cross_record_text_samples.size() < XmlSampleLimit(options)) {
 				xmlChar *content = xmlNodeGetContent(instance);
 				if (content) {
 					std::string text = CleanTextContent((const char *)content, options.preserve_whitespace);
@@ -863,7 +887,7 @@ void XMLSchemaInference::AnalyzeElement(xmlNodePtr node, std::unordered_map<std:
 		std::string text_content = CleanTextContent((const char *)content, options.preserve_whitespace);
 		if (!text_content.empty()) {
 			pattern.has_text = true;
-			if (pattern.sample_values.size() < 20) { // Limit sample size
+			if (pattern.sample_values.size() < XmlSampleLimit(options)) { // #102: was hardcoded 20
 				pattern.sample_values.push_back(text_content);
 			}
 		}
@@ -1779,21 +1803,21 @@ Value XMLSchemaInference::ConvertToValue(const std::string &text, const LogicalT
 			if (TryCast::Operation(string_t(text), int_result, false)) {
 				return Value::INTEGER(int_result);
 			}
-			return Value(text); // Fall back to VARCHAR value on conversion failure
+			return XmlUncastableValue(text, target_type, options);
 		}
 		case LogicalTypeId::BIGINT: {
 			int64_t bigint_result;
 			if (TryCast::Operation(string_t(text), bigint_result, false)) {
 				return Value::BIGINT(bigint_result);
 			}
-			return Value(text);
+			return XmlUncastableValue(text, target_type, options);
 		}
 		case LogicalTypeId::DOUBLE: {
 			double double_result;
 			if (TryCast::Operation(string_t(text), double_result, false)) {
 				return Value::DOUBLE(double_result);
 			}
-			return Value(text);
+			return XmlUncastableValue(text, target_type, options);
 		}
 		case LogicalTypeId::DATE: {
 			if (!datetime_format.empty()) {
@@ -1868,10 +1892,23 @@ Value XMLSchemaInference::ConvertToValue(const std::string &text, const LogicalT
 			return Value(text);
 		}
 	} catch (ConversionException &) {
-		throw; // Re-throw ConversionException as-is
+		// A typed parse failure (e.g. DATE/TIMESTAMP). Under ignore_errors drop to NULL instead of
+		// aborting the whole scan; otherwise surface the original conversion error.
+		if (options.ignore_errors && target_type.id() != LogicalTypeId::VARCHAR) {
+			return Value(target_type);
+		}
+		throw;
+	} catch (InvalidInputException &) {
+		// Our own #102 error from XmlUncastableValue() (thrown from a typed branch above) — it is
+		// already actionable, so propagate it as-is rather than re-entering the chokepoint.
+		throw;
 	} catch (...) {
-		// If conversion fails, return as VARCHAR
-		return Value(text);
+		// VARCHAR target keeps the text; a typed target routes through the #102 chokepoint rather
+		// than returning a VARCHAR Value that would abort when written into the typed output column.
+		if (target_type.id() == LogicalTypeId::VARCHAR) {
+			return Value(text);
+		}
+		return XmlUncastableValue(text, target_type, options);
 	}
 }
 

--- a/src/xml_schema_inference.cpp
+++ b/src/xml_schema_inference.cpp
@@ -527,7 +527,8 @@ LogicalType XMLSchemaInference::InferColumnType(const ColumnAnalysis &column, in
 				std::string list_text_winning_fmt;
 				LogicalType text_type = InferTypeFromSamples(list_text_samples, options, list_text_winning_fmt);
 				// Insert #text as first field (before attribute fields)
-				struct_fields.insert(struct_fields.begin(), make_pair(CompatMakeIdentifier(options.text_key), text_type));
+				struct_fields.insert(struct_fields.begin(),
+				                     make_pair(CompatMakeIdentifier(options.text_key), text_type));
 			}
 		}
 
@@ -1869,7 +1870,14 @@ Value XMLSchemaInference::ConvertToValue(const std::string &text, const LogicalT
 				}
 				throw ConversionException("Could not parse '%s' as TIME with format '%s'", text, datetime_format);
 			}
-			return Value(text);
+			// #102: empty datetime_format (e.g. an explicit TIME column) — parse via DuckDB's default
+			// cast and route failures through the chokepoint instead of returning a VARCHAR Value that
+			// would abort at the typed output column.
+			Value parsed_time;
+			if (Value(text).DefaultTryCastAs(target_type, parsed_time, nullptr)) {
+				return parsed_time;
+			}
+			return XmlUncastableValue(text, target_type, options);
 		}
 		case LogicalTypeId::TIME_TZ: {
 			if (!datetime_format.empty()) {
@@ -1885,7 +1893,13 @@ Value XMLSchemaInference::ConvertToValue(const std::string &text, const LogicalT
 				}
 				throw ConversionException("Could not parse '%s' as TIMETZ with format '%s'", text, datetime_format);
 			}
-			return Value(text);
+			// #102: empty datetime_format — parse via DuckDB's default cast and route failures through
+			// the chokepoint instead of returning a VARCHAR Value.
+			Value parsed_timetz;
+			if (Value(text).DefaultTryCastAs(target_type, parsed_timetz, nullptr)) {
+				return parsed_timetz;
+			}
+			return XmlUncastableValue(text, target_type, options);
 		}
 		case LogicalTypeId::VARCHAR:
 		default:

--- a/test/sql/issue_102_out_of_sample_cast.test
+++ b/test/sql/issue_102_out_of_sample_cast.test
@@ -1,0 +1,38 @@
+# name: test/sql/issue_102_out_of_sample_cast.test
+# description: Reproduction for #102 — read_xml() auto type-detection hard-fails on an
+#              out-of-sample value instead of falling back, aborting the whole scan.
+# group: [sql]
+
+require webbed
+
+# -----------------------------------------------------------------------------
+# Control (works today): when the non-numeric value is WITHIN the type-detection
+# sample window, the column is correctly inferred as VARCHAR and the read succeeds.
+# Here the column has only 3 values, all sampled, so the '24 495,40 Kč' is seen.
+# -----------------------------------------------------------------------------
+
+query I
+SELECT count(*) FROM read_xml('test/xml/schema_inference/issue_102_in_sample_mixed.xml')
+WHERE amount = '24 495,40 Kč';
+----
+1
+
+# -----------------------------------------------------------------------------
+# Reproduction (#102): 30 numeric <amount> values followed by one '24 495,40 Kč'.
+# InferColumnType samples only the first 20 instances (src/xml_schema_inference.cpp,
+# `text_samples.size() < 20`), so it infers INTEGER and never sees the outlier. At
+# extraction, ConvertToValue's numeric TryCast fails and returns a VARCHAR Value,
+# which then aborts when written into the INTEGER output column:
+#
+#   Invalid Input Error: Failed to cast value: Could not convert string '24 495,40 Kč' to INT32
+#
+# Expected after the fix: read_xml must NOT abort the scan on an out-of-sample value.
+# It should return all 31 rows (ideally widening the column to VARCHAR and preserving
+# the value, matching read_csv's robustness). This assertion currently FAILS (the
+# query errors) and is what the fix must make pass.
+# -----------------------------------------------------------------------------
+
+query I
+SELECT count(*) FROM read_xml('test/xml/schema_inference/issue_102_out_of_sample_cast.xml');
+----
+31

--- a/test/sql/issue_102_out_of_sample_cast.test
+++ b/test/sql/issue_102_out_of_sample_cast.test
@@ -1,16 +1,19 @@
 # name: test/sql/issue_102_out_of_sample_cast.test
-# description: Reproduction for #102 — read_xml() auto type-detection hard-fails on an
-#              out-of-sample value instead of falling back, aborting the whole scan.
+# description: #102 — read_xml() auto type-detection on an out-of-sample value. Covers
+#              A (configurable sample_size) and B (safe ignore_errors fallback + clear error).
+#              The C target (runtime VARCHAR widening) lives in issue_102_runtime_widening.test.future.
 # group: [sql]
 
 require webbed
 
-# -----------------------------------------------------------------------------
-# Control (works today): when the non-numeric value is WITHIN the type-detection
-# sample window, the column is correctly inferred as VARCHAR and the read succeeds.
-# Here the column has only 3 values, all sampled, so the '24 495,40 Kč' is seen.
-# -----------------------------------------------------------------------------
+# Fixtures:
+#   issue_102_in_sample_mixed.xml     — 2 ints + 1 non-numeric, all within the sample window.
+#   issue_102_out_of_sample_cast.xml  — 30 ints (<amount>1..30</amount>) then one '24 495,40 Kč'.
 
+# -----------------------------------------------------------------------------
+# Baseline: a non-numeric value WITHIN the detection window is correctly inferred
+# as VARCHAR (this already worked, and must keep working).
+# -----------------------------------------------------------------------------
 query I
 SELECT count(*) FROM read_xml('test/xml/schema_inference/issue_102_in_sample_mixed.xml')
 WHERE amount = '24 495,40 Kč';
@@ -18,21 +21,45 @@ WHERE amount = '24 495,40 Kč';
 1
 
 # -----------------------------------------------------------------------------
-# Reproduction (#102): 30 numeric <amount> values followed by one '24 495,40 Kč'.
-# InferColumnType samples only the first 20 instances (src/xml_schema_inference.cpp,
-# `text_samples.size() < 20`), so it infers INTEGER and never sees the outlier. At
-# extraction, ConvertToValue's numeric TryCast fails and returns a VARCHAR Value,
-# which then aborts when written into the INTEGER output column:
-#
-#   Invalid Input Error: Failed to cast value: Could not convert string '24 495,40 Kč' to INT32
-#
-# Expected after the fix: read_xml must NOT abort the scan on an out-of-sample value.
-# It should return all 31 rows (ideally widening the column to VARCHAR and preserving
-# the value, matching read_csv's robustness). This assertion currently FAILS (the
-# query errors) and is what the fix must make pass.
+# A — configurable sample_size. Previously the sniffer hardcoded a 20-value window
+# and ignored the sample_size option entirely. With the default window (50) now
+# covering all 31 values, the bare call sees the outlier and infers VARCHAR,
+# preserving the value (31 rows, 31 non-null, VARCHAR) instead of aborting.
 # -----------------------------------------------------------------------------
-
-query I
-SELECT count(*) FROM read_xml('test/xml/schema_inference/issue_102_out_of_sample_cast.xml');
+query III
+SELECT count(*), count(amount), max(typeof(amount))
+FROM read_xml('test/xml/schema_inference/issue_102_out_of_sample_cast.xml');
 ----
-31
+31	31	VARCHAR
+
+# A — an explicit window large enough to see the outlier: same correct result.
+query III
+SELECT count(*), count(amount), max(typeof(amount))
+FROM read_xml('test/xml/schema_inference/issue_102_out_of_sample_cast.xml', sample_size := 40);
+----
+31	31	VARCHAR
+
+# A — sample_size := -1 samples every value (always-correct detection).
+query III
+SELECT count(*), count(amount), max(typeof(amount))
+FROM read_xml('test/xml/schema_inference/issue_102_out_of_sample_cast.xml', sample_size := -1);
+----
+31	31	VARCHAR
+
+# A (negative) / B (clear error): force the window below the outlier (sample_size := 10)
+# so the column is inferred INTEGER, and DON'T opt into recovery. Instead of the old generic
+# "Could not convert string '24 495,40 Kč' to INT32" abort, the error now names the value, the
+# inferred type, and the remedies.
+statement error
+SELECT amount FROM read_xml('test/xml/schema_inference/issue_102_out_of_sample_cast.xml', sample_size := 10);
+----
+does not match column type INTEGER
+
+# B — safe fallback: same too-small window, but ignore_errors:=true. The scan no longer aborts;
+# the out-of-sample value becomes NULL while the column stays INTEGER (detection is unchanged).
+# 31 rows, 30 non-null, INTEGER — distinct from A, which widens to VARCHAR and keeps the value.
+query III
+SELECT count(*), count(amount), max(typeof(amount))
+FROM read_xml('test/xml/schema_inference/issue_102_out_of_sample_cast.xml', sample_size := 10, ignore_errors := true);
+----
+31	30	INTEGER

--- a/test/sql/issue_102_runtime_widening.test.future
+++ b/test/sql/issue_102_runtime_widening.test.future
@@ -1,0 +1,21 @@
+# name: test/sql/issue_102_runtime_widening.test.future
+# description: #102 "C" target — read_csv-style RUNTIME column widening. When an out-of-sample
+#              value cannot fit the type inferred from the sample, the column should auto-widen to
+#              VARCHAR and PRESERVE the value, with NO sample_size bump and NO ignore_errors.
+#              NOT yet implemented: A widens the *detection window* (needs a big-enough sample),
+#              B NULLs the value under ignore_errors. C preserves it unconditionally.
+#              Parked as .test.future so the suite does not run it. The XmlUncastableValue()
+#              chokepoint in src/xml_schema_inference.cpp is where C would hook in.
+# group: [sql]
+
+require webbed
+
+# Out-of-sample outlier (sample_size := 10 forces the window below it), no ignore_errors:
+# C must return all 31 rows AND keep the value as text — 31 / 31 / VARCHAR. Today this errors
+# (see issue_102_out_of_sample_cast.test). Neither A (too-small window) nor B (NULLs the value)
+# produces this result, which is exactly what distinguishes C.
+query III
+SELECT count(*), count(amount), max(typeof(amount))
+FROM read_xml('test/xml/schema_inference/issue_102_out_of_sample_cast.xml', sample_size := 10);
+----
+31	31	VARCHAR

--- a/test/xml/schema_inference/issue_102_in_sample_mixed.xml
+++ b/test/xml/schema_inference/issue_102_in_sample_mixed.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<root>
+  <r><amount>1</amount></r>
+  <r><amount>2</amount></r>
+  <r><amount>24 495,40 Kč</amount></r>
+</root>

--- a/test/xml/schema_inference/issue_102_out_of_sample_cast.xml
+++ b/test/xml/schema_inference/issue_102_out_of_sample_cast.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<root>
+  <r><amount>1</amount></r>
+  <r><amount>2</amount></r>
+  <r><amount>3</amount></r>
+  <r><amount>4</amount></r>
+  <r><amount>5</amount></r>
+  <r><amount>6</amount></r>
+  <r><amount>7</amount></r>
+  <r><amount>8</amount></r>
+  <r><amount>9</amount></r>
+  <r><amount>10</amount></r>
+  <r><amount>11</amount></r>
+  <r><amount>12</amount></r>
+  <r><amount>13</amount></r>
+  <r><amount>14</amount></r>
+  <r><amount>15</amount></r>
+  <r><amount>16</amount></r>
+  <r><amount>17</amount></r>
+  <r><amount>18</amount></r>
+  <r><amount>19</amount></r>
+  <r><amount>20</amount></r>
+  <r><amount>21</amount></r>
+  <r><amount>22</amount></r>
+  <r><amount>23</amount></r>
+  <r><amount>24</amount></r>
+  <r><amount>25</amount></r>
+  <r><amount>26</amount></r>
+  <r><amount>27</amount></r>
+  <r><amount>28</amount></r>
+  <r><amount>29</amount></r>
+  <r><amount>30</amount></r>
+  <r><amount>24 495,40 Kč</amount></r>
+</root>


### PR DESCRIPTION
Fixes the `read_xml()` hard-fail reported in #102: a value outside the type-detection sample (e.g. `'24 495,40 Kč'` after many integers) aborted the whole scan with `Could not convert string '24 495,40 Kč' to INT32` instead of degrading gracefully like `read_csv`. Two independent causes, fixed as stepping stones toward read_csv-style runtime widening ("C").

## Root cause
1. The `sample_size` option existed in `XMLSchemaOptions` (default 50) but was **never parsed** and the sniffer **hardcoded a 20-value window** (4 sites). So a non-numeric value beyond the first 20 was never seen → column typed INTEGER.
2. At extraction, `ConvertToValue()` returned a VARCHAR `Value` on a failed numeric cast — a dead fallback that then **aborted** when written into the INTEGER output column (`Vector::SetValue`).

## A — configurable `sample_size`
- Parsed for all `read_xml` / `read_html` / `parse_*` functions and registered as a named parameter (6 sites).
- Drives every sample cap via `XmlSampleLimit()` (the four hardcoded `20`s are gone). Default window is now the struct's documented **50**; **`sample_size := -1` samples every value** (always-correct detection — the bind-time half of "C").

## B — safe out-of-sample fallback
- The dead VARCHAR fallback is replaced by a single chokepoint, `XmlUncastableValue()`:
  - under `ignore_errors` → a **typed NULL** (scan continues, value dropped);
  - otherwise → a **clear, actionable error** naming the value, the inferred type, and the remedies (`sample_size`, `all_varchar`, `ignore_errors`).
- This chokepoint is exactly where "C" (runtime column widening) will hook in (commented as such).

## Tests — distinctly separating A / B / C
`test/sql/issue_102_out_of_sample_cast.test`:
| case | call | result |
|---|---|---|
| A (default / `40` / `-1`) | sees the outlier | VARCHAR — **31 / 31**, value preserved |
| A-neg + B's clear error | `sample_size:=10` | errors: *"…does not match column type INTEGER…"* |
| B | `sample_size:=10, ignore_errors:=true` | INTEGER — **31 / 30**, outlier NULLed |

`test/sql/issue_102_runtime_widening.test.future` — the "C" target (auto-widen to VARCHAR with no `sample_size` bump and no `ignore_errors`); parked, not run yet.

## Validation
CI build+test green on linux (the repro previously failed with the exact issue error; the 20→50 default-window change regressed none of the existing tests).

Scope note: the **SAX streaming** inference path has its own sampling and is out of scope here — the repro is DOM.

Closes #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YK2zHBz326w3k8kVEYXXPF)_