### PR TITLE
release: v2.3.0

### DIFF
--- a/RELEASE_NOTES_v2.3.0.md
+++ b/RELEASE_NOTES_v2.3.0.md
@@ -1,0 +1,36 @@
+# webbed v2.3.0
+
+## `read_xml` type detection is now robust to out-of-sample values (#102)
+
+`read_xml()` auto type-detection hard-failed when a value outside the detection
+sample didn't fit the inferred type — e.g. `'24 495,40 Kč'` after a run of integers
+raised `Invalid Input Error: Could not convert string '24 495,40 Kč' to INT32` and
+aborted the whole query, where `read_csv` would recover. (Reported by @onnimonni
+against the Czech Justice public-register bulk XML.)
+
+- **`sample_size` now works.** The option existed but was ignored (the sniffer
+  hardcoded a 20-value window), so a non-numeric value beyond the first 20 was never
+  seen. It now drives type detection for `read_xml` / `read_html` / `parse_xml` /
+  `parse_html` across every path. `sample_size := -1` samples every value
+  (always-correct detection); the default window is 50.
+- **Safe out-of-sample fallback.** A value that can't be cast to its column's
+  inferred type no longer aborts the scan: with `ignore_errors := true` it becomes
+  NULL and the read continues; otherwise it raises a clear error naming the value,
+  the inferred type, and the remedies (`sample_size`, `all_varchar`,
+  `ignore_errors`). Covers numeric and `TIME` / `TIME_TZ` columns.
+
+### Behavior changes
+
+- A numeric/temporal column with a value beyond the detection sample now widens
+  (larger `sample_size`), NULLs the value (`ignore_errors`), or errors with a clear
+  message — previously a generic cast abort.
+- Under `ignore_errors := true`, an un-castable value is skipped (NULL) instead of
+  aborting the file.
+
+### Not yet
+
+Runtime VARCHAR widening — preserving an out-of-sample value with *no* options set,
+matching `read_csv` — is a tracked follow-up; the `XmlUncastableValue()` chokepoint
+is already in place (`test/sql/issue_102_runtime_widening.test.future`).
+
+No DuckDB submodule bump (stays on v1.5.3). Native build and full test suite pass.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,54 @@
 Changelog
 =========
 
-v2.2.1 (Current)
+v2.3.0 (Current)
 ----------------
+
+Makes ``read_xml`` type detection robust to out-of-sample values, matching
+``read_csv``'s recovery instead of aborting the scan. No DuckDB submodule bump
+(stays on v1.5.3).
+
+**New Features**
+
+- ``sample_size`` now actually controls type detection. The option existed but was
+  ignored — the sniffer hardcoded a 20-value window — so a non-numeric value
+  beyond the first 20 was never seen and the column mis-typed. It is now honored by
+  ``read_xml`` / ``read_html`` / ``parse_xml`` / ``parse_html`` across every
+  detection path. ``sample_size := -1`` samples every value (always-correct
+  detection); the default window is 50. (Issue #102)
+
+**Bug Fixes**
+
+- ``read_xml`` no longer hard-fails when a value outside the type-detection sample
+  doesn't match the inferred type — e.g. ``'24 495,40 Kč'`` after a run of integers
+  raised ``Could not convert string ... to INT32`` and aborted the whole query.
+  An out-of-sample / uncastable value now degrades safely: with
+  ``ignore_errors := true`` it becomes NULL and the scan continues; otherwise it
+  raises a clear, actionable error naming the value, the inferred type, and the
+  remedies (``sample_size``, ``all_varchar``, ``ignore_errors``). Applies to
+  numeric and ``TIME`` / ``TIME_TZ`` columns. (Issue #102)
+
+**Behavior changes (review before upgrading)**
+
+- A numeric/temporal column with a value beyond the detection sample now widens
+  (larger ``sample_size``), NULLs the value (``ignore_errors``), or errors with a
+  clear message — previously it aborted with a generic cast error.
+- Under ``ignore_errors := true``, a value that cannot be cast to a column's
+  inferred type is now skipped (NULL) instead of aborting the file.
+
+**Internal**
+
+- ``vcpkg.json`` manifest version → 2.3.0.
+
+**Known limitations / next**
+
+- The SAX streaming inference path has its own sampling and is unchanged here.
+- Runtime VARCHAR widening (preserve an out-of-sample value with no options set,
+  like ``read_csv``) is a tracked follow-up; the ``XmlUncastableValue`` chokepoint
+  is in place (see ``test/sql/issue_102_runtime_widening.test.future``).
+
+v2.2.1
+------
 
 A patch release: the DuckDB-WASM build now loads, plus a SAX streaming
 attribute-parity fix. No DuckDB submodule bump (stays on v1.5.3).

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
         "name": "duckdb-webbed",
-        "version": "2.2.1",
+        "version": "2.3.0",
         "dependencies": [
                 {
                         "name": "libxml2",


### PR DESCRIPTION
Cuts **v2.3.0**. The only user-facing change since v2.2.1 is the #102 fix (PR #104); #100/#101 were docs/test-infra.

- `vcpkg.json` → **2.3.0**
- `docs/changelog.rst` → v2.3.0 entry
- `RELEASE_NOTES_v2.3.0.md`

## What's in it (#102)
- **`sample_size` now works** — it was a dead option (the sniffer hardcoded a 20-value window); now honored by `read_xml`/`read_html`/`parse_xml`/`parse_html` across every detection path. `sample_size := -1` samples every value; default 50.
- **Safe out-of-sample fallback** — an out-of-sample / uncastable value no longer aborts the scan: `ignore_errors := true` → NULL; otherwise a clear, actionable error (value + inferred type + remedies). Numeric and `TIME`/`TIME_TZ`.

No DuckDB submodule bump (stays on v1.5.3).

After merge: tag `v2.3.0` on the merge commit. Runtime VARCHAR widening ("true C") is the tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YK2zHBz326w3k8kVEYXXPF)_