### PR TITLE
fix(extract): serialize XML fragments as literal UTF-8

### DIFF
--- a/src/xml_utils.cpp
+++ b/src/xml_utils.cpp
@@ -1607,7 +1607,13 @@ std::string XMLUtils::ExtractXMLFragment(const std::string &xml_str, const std::
 					// Dump the node as XML string
 					xmlChar *node_str = nullptr;
 					int size = 0;
-					xmlDocDumpMemory(temp_doc.get(), &node_str, &size);
+					// Serialize as literal UTF-8. Plain xmlDocDumpMemory() runs with no
+					// output-encoding handler (temp_doc has encoding=NULL), so libxml2
+					// escapes every non-ASCII character to a numeric character reference
+					// (e.g. 'ö' -> '&#xF6;'). Passing "UTF-8" explicitly keeps non-ASCII
+					// literal, matching the read_xml reader and xml_extract_text. The
+					// JSON->XML path already does this (see xmlDocDumpFormatMemoryEnc above).
+					xmlDocDumpFormatMemoryEnc(temp_doc.get(), &node_str, &size, "UTF-8", 0);
 
 					if (node_str) {
 						XMLCharPtr node_ptr(node_str);
@@ -1668,7 +1674,13 @@ std::string XMLUtils::ExtractXMLFragment(const std::string &xml_str, const std::
 
 					xmlChar *node_str = nullptr;
 					int size = 0;
-					xmlDocDumpMemory(temp_doc.get(), &node_str, &size);
+					// Serialize as literal UTF-8. Plain xmlDocDumpMemory() runs with no
+					// output-encoding handler (temp_doc has encoding=NULL), so libxml2
+					// escapes every non-ASCII character to a numeric character reference
+					// (e.g. 'ö' -> '&#xF6;'). Passing "UTF-8" explicitly keeps non-ASCII
+					// literal, matching the read_xml reader and xml_extract_text. The
+					// JSON->XML path already does this (see xmlDocDumpFormatMemoryEnc above).
+					xmlDocDumpFormatMemoryEnc(temp_doc.get(), &node_str, &size, "UTF-8", 0);
 
 					if (node_str) {
 						XMLCharPtr node_ptr(node_str);
@@ -1727,7 +1739,13 @@ std::string XMLUtils::ExtractXMLFragmentAll(const std::string &xml_str, const st
 					// Dump the node as XML string
 					xmlChar *node_str = nullptr;
 					int size = 0;
-					xmlDocDumpMemory(temp_doc.get(), &node_str, &size);
+					// Serialize as literal UTF-8. Plain xmlDocDumpMemory() runs with no
+					// output-encoding handler (temp_doc has encoding=NULL), so libxml2
+					// escapes every non-ASCII character to a numeric character reference
+					// (e.g. 'ö' -> '&#xF6;'). Passing "UTF-8" explicitly keeps non-ASCII
+					// literal, matching the read_xml reader and xml_extract_text. The
+					// JSON->XML path already does this (see xmlDocDumpFormatMemoryEnc above).
+					xmlDocDumpFormatMemoryEnc(temp_doc.get(), &node_str, &size, "UTF-8", 0);
 
 					if (node_str) {
 						XMLCharPtr node_ptr(node_str);
@@ -1797,7 +1815,13 @@ std::string XMLUtils::ExtractXMLFragmentAll(const std::string &xml_str, const st
 
 					xmlChar *node_str = nullptr;
 					int size = 0;
-					xmlDocDumpMemory(temp_doc.get(), &node_str, &size);
+					// Serialize as literal UTF-8. Plain xmlDocDumpMemory() runs with no
+					// output-encoding handler (temp_doc has encoding=NULL), so libxml2
+					// escapes every non-ASCII character to a numeric character reference
+					// (e.g. 'ö' -> '&#xF6;'). Passing "UTF-8" explicitly keeps non-ASCII
+					// literal, matching the read_xml reader and xml_extract_text. The
+					// JSON->XML path already does this (see xmlDocDumpFormatMemoryEnc above).
+					xmlDocDumpFormatMemoryEnc(temp_doc.get(), &node_str, &size, "UTF-8", 0);
 
 					if (node_str) {
 						XMLCharPtr node_ptr(node_str);
@@ -1902,7 +1926,13 @@ std::string XMLUtils::ExtractXMLFragmentAll(const std::string &xml_str, const st
 
 					xmlChar *node_str = nullptr;
 					int size = 0;
-					xmlDocDumpMemory(temp_doc.get(), &node_str, &size);
+					// Serialize as literal UTF-8. Plain xmlDocDumpMemory() runs with no
+					// output-encoding handler (temp_doc has encoding=NULL), so libxml2
+					// escapes every non-ASCII character to a numeric character reference
+					// (e.g. 'ö' -> '&#xF6;'). Passing "UTF-8" explicitly keeps non-ASCII
+					// literal, matching the read_xml reader and xml_extract_text. The
+					// JSON->XML path already does this (see xmlDocDumpFormatMemoryEnc above).
+					xmlDocDumpFormatMemoryEnc(temp_doc.get(), &node_str, &size, "UTF-8", 0);
 
 					if (node_str) {
 						XMLCharPtr node_ptr(node_str);
@@ -1968,7 +1998,13 @@ std::vector<std::string> XMLUtils::ExtractXMLFragmentList(const std::string &xml
 					// Dump the node as XML string
 					xmlChar *node_str = nullptr;
 					int size = 0;
-					xmlDocDumpMemory(temp_doc.get(), &node_str, &size);
+					// Serialize as literal UTF-8. Plain xmlDocDumpMemory() runs with no
+					// output-encoding handler (temp_doc has encoding=NULL), so libxml2
+					// escapes every non-ASCII character to a numeric character reference
+					// (e.g. 'ö' -> '&#xF6;'). Passing "UTF-8" explicitly keeps non-ASCII
+					// literal, matching the read_xml reader and xml_extract_text. The
+					// JSON->XML path already does this (see xmlDocDumpFormatMemoryEnc above).
+					xmlDocDumpFormatMemoryEnc(temp_doc.get(), &node_str, &size, "UTF-8", 0);
 
 					if (node_str) {
 						XMLCharPtr node_ptr(node_str);
@@ -2029,7 +2065,13 @@ std::vector<std::string> XMLUtils::ExtractXMLFragmentList(const std::string &xml
 
 					xmlChar *node_str = nullptr;
 					int size = 0;
-					xmlDocDumpMemory(temp_doc.get(), &node_str, &size);
+					// Serialize as literal UTF-8. Plain xmlDocDumpMemory() runs with no
+					// output-encoding handler (temp_doc has encoding=NULL), so libxml2
+					// escapes every non-ASCII character to a numeric character reference
+					// (e.g. 'ö' -> '&#xF6;'). Passing "UTF-8" explicitly keeps non-ASCII
+					// literal, matching the read_xml reader and xml_extract_text. The
+					// JSON->XML path already does this (see xmlDocDumpFormatMemoryEnc above).
+					xmlDocDumpFormatMemoryEnc(temp_doc.get(), &node_str, &size, "UTF-8", 0);
 
 					if (node_str) {
 						XMLCharPtr node_ptr(node_str);
@@ -2126,7 +2168,13 @@ std::vector<std::string> XMLUtils::ExtractXMLFragmentList(const std::string &xml
 
 					xmlChar *node_str = nullptr;
 					int size = 0;
-					xmlDocDumpMemory(temp_doc.get(), &node_str, &size);
+					// Serialize as literal UTF-8. Plain xmlDocDumpMemory() runs with no
+					// output-encoding handler (temp_doc has encoding=NULL), so libxml2
+					// escapes every non-ASCII character to a numeric character reference
+					// (e.g. 'ö' -> '&#xF6;'). Passing "UTF-8" explicitly keeps non-ASCII
+					// literal, matching the read_xml reader and xml_extract_text. The
+					// JSON->XML path already does this (see xmlDocDumpFormatMemoryEnc above).
+					xmlDocDumpFormatMemoryEnc(temp_doc.get(), &node_str, &size, "UTF-8", 0);
 
 					if (node_str) {
 						XMLCharPtr node_ptr(node_str);

--- a/test/sql/fragment_serialize_utf8.test
+++ b/test/sql/fragment_serialize_utf8.test
@@ -1,0 +1,36 @@
+# name: test/sql/fragment_serialize_utf8.test
+# description: xml_extract_elements()/XMLFragment::VARCHAR must serialize non-ASCII text as literal UTF-8, not numeric character references
+# group: [sql]
+
+require webbed
+
+# Non-ASCII stored as literal UTF-8 must round-trip as literal UTF-8.
+# Before the fix this serialized as '<c>H&#xF6;he</c>'.
+query T
+SELECT unnest(xml_extract_elements('<r><c>Höhe</c></r>', '//c'))::VARCHAR;
+----
+<c>Höhe</c>
+
+# Non-ASCII stored as a numeric character reference is decoded to literal UTF-8.
+query T
+SELECT unnest(xml_extract_elements('<r><c>H&#xF6;he</c></r>', '//c'))::VARCHAR;
+----
+<c>Höhe</c>
+
+# Mandatory markup escaping is preserved (&, <, > stay escaped).
+query T
+SELECT unnest(xml_extract_elements('<r><c>a &amp; b</c></r>', '//c'))::VARCHAR;
+----
+<c>a &amp; b</c>
+
+# No numeric character reference must leak for non-ASCII text.
+query I
+SELECT instr(unnest(xml_extract_elements('<r><c>öäüß ≠ —</c></r>', '//c'))::VARCHAR, '&#x');
+----
+0
+
+# Accented Latin-1 character round-trips literally as well.
+query T
+SELECT unnest(xml_extract_elements('<r><c>café</c></r>', '//c'))::VARCHAR;
+----
+<c>café</c>


### PR DESCRIPTION
Fixes #108.

## Summary

`xml_extract_elements(...)` (and the resulting `XMLFragment::VARCHAR`) escapes
**every non-ASCII character** in text content to a numeric character reference
(`ö` → `&#xF6;`, `≠` → `&#x2260;`), even when the source stored the character as
literal UTF-8. The serialized fragment is valid, lossless XML but is **not usable
as text** — and it is inconsistent with the `read_xml` reader column-capture and
with `xml_extract_text`, which both return literal UTF-8.

## Root cause

The fragment serializers create a fresh container doc with `xmlNewDoc("1.0")`
(its `encoding` is `NULL`) and dump it with `xmlDocDumpMemory()`, which takes no
output-encoding argument. With no encoding handler libxml2 conservatively escapes
all non-ASCII to numeric character references. Same class as the HTML reader's
Issue #53 (Latin-1 default).

The encoding-aware call already exists in the same file — the JSON→XML path uses
`xmlDocDumpFormatMemoryEnc(doc, &str, &size, "UTF-8", 0)`.

## Fix

Switch the eight fragment-serializer call sites in `ExtractXMLFragment` /
`ExtractXMLFragmentAll` / `ExtractXMLFragmentList` to
`xmlDocDumpFormatMemoryEnc(..., "UTF-8", 0)`. Non-ASCII now serializes as literal
UTF-8; mandatory markup escaping (`&`, `<`, `>`) and round-trip control-character
escaping (e.g. CR → `&#13;`) are unchanged.

```sql
-- before:  <c>H&#xF6;he</c>
-- after:   <c>Höhe</c>
SELECT unnest(xml_extract_elements('<r><c>Höhe</c></r>', '//c'))::VARCHAR;
```

## Tests

Adds `test/sql/fragment_serialize_utf8.test` (literal UTF-8, NCR-source decode,
mandatory `&<>` escaping preserved, no `&#x` leak). Existing extraction/HTML tests
unchanged and green.

## Notes / scope

- The same `xmlNewDoc`-without-encoding pattern also appears in the value-builder
  family (`ScalarToXML` etc., `xml_utils.cpp:2192/2264/2335`) and in the minify
  path (`:773`, which serializes a *parsed* doc, so encoding may be inherited).
  Happy to extend this PR to those if you'd prefer a single sweep; kept it scoped
  to the extraction surface for review clarity.
- Backward-compat: output stays valid XML (an NCR and the literal char parse
  identically), so consumers that re-parse are unaffected; only the string form
  changes from `&#xNN;` to literal UTF-8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
