### PR TITLE
fix(sax): escape CR (and CR/LF/TAB in attrs) to match DOM serialization

### DIFF
--- a/src/xml_sax_reader.cpp
+++ b/src/xml_sax_reader.cpp
@@ -61,6 +61,15 @@ static std::string XmlEscapeText(const std::string &text) {
 		case '>':
 			result += "&gt;";
 			break;
+		case '\r':
+			// Match libxml2's DOM serializer. A literal CR in text content is
+			// normalized to LF on the next parse (XML 1.0 §2.11), so it must be
+			// escaped to round-trip. DOM (xmlNodeDump/xmlDocDumpMemory) emits
+			// "&#13;"; without this the SAX path emitted a raw CR byte, so the
+			// same node serialized to different bytes under DOM vs SAX — which
+			// also silently breaks any downstream \s-based text processing.
+			result += "&#13;";
+			break;
 		default:
 			result += c;
 			break;
@@ -85,6 +94,18 @@ static std::string XmlEscapeAttr(const std::string &text) {
 			break;
 		case '"':
 			result += "&quot;";
+			break;
+		case '\r':
+			// Attribute-value normalization (XML 1.0 §3.3.3) turns CR/LF/TAB into
+			// spaces on parse, so libxml2's DOM serializer escapes all three in
+			// attribute values. Mirror that here for DOM/SAX byte-parity.
+			result += "&#13;";
+			break;
+		case '\n':
+			result += "&#10;";
+			break;
+		case '\t':
+			result += "&#9;";
 			break;
 		default:
 			result += c;

--- a/test/sql/sax_serialize_cr_parity.test
+++ b/test/sql/sax_serialize_cr_parity.test
@@ -1,0 +1,30 @@
+# name: test/sql/sax_serialize_cr_parity.test
+# description: SAX streaming must serialize carriage returns in captured raw XML the same
+#             way DOM does (&#13;), so a captured-subtree VARCHAR is byte-identical across
+#             reader modes. Regression for: SAX emitted a raw CR byte where DOM emits &#13;.
+# group: [sql]
+
+require webbed
+
+# CR is stored as the &#13; reference in the source. DOM (non-streaming) serializes
+# the captured subtree with CR escaped to &#13; in both text content and attribute value.
+query T
+SELECT s::VARCHAR
+FROM read_xml('test/xml/sax_cr_parity.xml', record_element := 'doc', columns := {'s': 'VARCHAR'}, streaming := false);
+----
+<k a="p&#13;q">k0&#13;m0</k>
+
+# SAX (maximum_file_size := 1 forces streaming) must produce the identical bytes.
+# Before the fix it emitted a raw CR byte instead of &#13;.
+query T
+SELECT s::VARCHAR
+FROM read_xml('test/xml/sax_cr_parity.xml', record_element := 'doc', columns := {'s': 'VARCHAR'}, maximum_file_size := 1);
+----
+<k a="p&#13;q">k0&#13;m0</k>
+
+# No raw CR byte leaks via the SAX path (it is escaped, exactly like DOM).
+query I
+SELECT instr(s::VARCHAR, chr(13))
+FROM read_xml('test/xml/sax_cr_parity.xml', record_element := 'doc', columns := {'s': 'VARCHAR'}, maximum_file_size := 1);
+----
+0

--- a/test/xml/sax_cr_parity.xml
+++ b/test/xml/sax_cr_parity.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<doc id="1"><s><k a="p&#13;q">k0&#13;m0</k></s></doc>
+</root>


### PR DESCRIPTION
Fixes #109.

## Summary

When a captured subtree is materialized as `VARCHAR`, the SAX streaming path and
the DOM path serialize a carriage return differently:

| | CR in captured text | CR in captured attribute |
|---|---|---|
| DOM (`read_xml`, non-streaming) | `&#13;` | `&#13;` |
| SAX (`read_xml`, `streaming=true` / file > `maximum_file_size`) | raw `0x0D` byte | raw `0x0D` byte |

So the *same node* serializes to **different bytes depending on reader mode**
(which depends on file size). That breaks byte-identity across modes and silently
breaks any downstream `\s`/whitespace-based processing of the captured string
(a literal CR matches `\s`, the string `&#13;` does not).

## Root cause

The SAX raw-XML reconstruction escapes text via `XmlEscapeText` and attributes via
`XmlEscapeAttr` (`src/xml_sax_reader.cpp`), which handled only `&`, `<`, `>`
(and `"` for attributes) and passed control characters through literally.
libxml2's DOM serializer, by contrast, escapes a CR in text content to `&#13;`
(a literal CR would be normalized to LF on re-parse, XML 1.0 §2.11) and escapes
CR/LF/TAB in attribute values (attribute-value normalization, §3.3.3).

## Fix

- `XmlEscapeText`: escape `\r` → `&#13;`.
- `XmlEscapeAttr`: escape `\r` → `&#13;`, `\n` → `&#10;`, `\t` → `&#9;`.

SAX output is now byte-identical to DOM:

```sql
-- both reader modes now yield  <k a="p&#13;q">k0&#13;m0</k>
SELECT s::VARCHAR FROM read_xml('test/xml/sax_cr_parity.xml',
  record_element := 'doc', columns := {'s':'VARCHAR'}, streaming := false);     -- DOM
SELECT s::VARCHAR FROM read_xml('test/xml/sax_cr_parity.xml',
  record_element := 'doc', columns := {'s':'VARCHAR'}, maximum_file_size := 1); -- SAX
```

## Tests

Adds `test/sql/sax_serialize_cr_parity.test` (+ fixture `test/xml/sax_cr_parity.xml`):
DOM and SAX produce identical `&#13;`, and no raw CR leaks via SAX. Existing SAX /
streaming / parity tests (`xml_sax_streaming`, `xml_sax_accumulator_parity`,
`sax_nested_child_attr_parity`, `github_issue_17_large_file_streaming`,
`xml_schema_inference_fixes`) unchanged and green.

## Notes / scope

This addresses the control-character class of DOM↔SAX serialization divergence
(the one that causes silent data loss). Other classes between the two serializers
(e.g. CDATA wrapper handling) are out of scope here and would be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
