### PR TITLE
fix: support XML/HTML documents between 2 GiB and 4 GiB (supersedes #103)

### DIFF
--- a/src/xml_reader_functions.cpp
+++ b/src/xml_reader_functions.cpp
@@ -5,6 +5,7 @@
 #include "duckdb_compat.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/helper.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/replacement_scan.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
@@ -30,6 +31,30 @@ static bool HasComplexXPath(const std::string &record_element) {
 	}
 	// Any remaining XPath tokens mean SAX can't handle it
 	return re.find_first_of("/[@]()*:.") != std::string::npos;
+}
+
+// Read an entire file into `data` (which must already hold `size` bytes) using bounded
+// chunks. A single FileHandle::Read of more than ~2 GiB fails on platforms whose underlying
+// read/pread caps at INT_MAX bytes — notably macOS, where it surfaces as
+// "IO Error: Could not read from file ...: Invalid argument". Reading in <=1 GiB chunks lets
+// XML files larger than 2 GiB load instead of erroring. (libxml2 DOM parsing of the result
+// is still memory-bound; true >RAM streaming is the SAX path.)
+//
+// FileHandle::Read returns the bytes actually read for that call, which may be fewer than
+// requested on non-local handles (network/FUSE) even when more data remains. Advance by the
+// returned count rather than the requested size so a legal short read can't silently leave a
+// zero-filled gap; only a non-positive return signals a genuine EOF/error.
+static void ReadFileFully(duckdb::FileHandle &handle, char *data, duckdb::idx_t size) {
+	duckdb::idx_t offset = 0;
+	while (offset < size) {
+		duckdb::idx_t want = duckdb::MinValue<duckdb::idx_t>(size - offset, duckdb::idx_t(1) << 30);
+		int64_t got = handle.Read(data + offset, want);
+		if (got <= 0) {
+			throw duckdb::IOException("Could not read from file \"%s\": unexpected end of file at offset %llu of %llu",
+			                          handle.path, offset, size);
+		}
+		offset += duckdb::UnsafeNumericCast<duckdb::idx_t>(got);
+	}
 }
 
 // Raise the error used when libxml2 cannot allocate memory while parsing a file. A
@@ -565,7 +590,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 
 						string content;
 						content.resize(file_size);
-						file_handle->Read((void *)content.data(), file_size);
+						ReadFileFully(*file_handle, (char *)content.data(), file_size);
 
 						if (mode == ParseMode::XML) {
 							auto validity = XMLUtils::CheckXML(content);
@@ -701,7 +726,7 @@ void XMLReaderFunctions::ReadDocumentObjectsFunction(ClientContext &context, Tab
 			// Read file content
 			string content;
 			content.resize(file_size);
-			file_handle->Read((void *)content.data(), file_size);
+			ReadFileFully(*file_handle, (char *)content.data(), file_size);
 
 			// Validate content based on mode
 			if (is_html) {
@@ -849,7 +874,7 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 					// DOM mode: read file content and build DOM
 					string content;
 					content.resize(file_size);
-					file_handle->Read((void *)content.data(), file_size);
+					ReadFileFully(*file_handle, (char *)content.data(), file_size);
 
 					// Parse DOM — DOM makes its own copy, so content string can be freed.
 					// This single parse is also the validity check: a separate pre-validation
@@ -1141,7 +1166,7 @@ void XMLReaderFunctions::ReadXMLObjectsFunction(ClientContext &context, TableFun
 			// Read file content
 			string content;
 			content.resize(file_size);
-			file_handle->Read((void *)content.data(), file_size);
+			ReadFileFully(*file_handle, (char *)content.data(), file_size);
 
 			// Validate XML
 			auto validity = XMLUtils::CheckXML(content);
@@ -1457,7 +1482,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context,
 
 						string content;
 						content.resize(file_size);
-						file_handle->Read((void *)content.data(), file_size);
+						ReadFileFully(*file_handle, (char *)content.data(), file_size);
 
 						auto validity = XMLUtils::CheckXML(content);
 						if (validity == XMLValidity::ResourceError) {

--- a/src/xml_utils.cpp
+++ b/src/xml_utils.cpp
@@ -10,6 +10,7 @@
 #include <libxml/valid.h>
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 #include <iostream>
 #include <functional>
 #include <map>
@@ -38,6 +39,41 @@ void XMLSilentErrorHandler(void *ctx, const char *msg, ...) {
 	// Silently capture errors without printing to stderr
 	xml_parse_error_occurred = true;
 }
+
+// Parse documents larger than ~2 GiB. libxml2's in-memory parse entry points
+// (xmlCtxtReadMemory / htmlReadMemory) take the buffer length as an `int`, so a document
+// larger than INT_MAX (~2.147 GB) wraps to a negative size and the parse fails with a spurious
+// "invalid document" error — even after the file itself is read correctly. The IO-based entry
+// points (xmlCtxtReadIO / htmlReadIO) take no total-size parameter: they pull bytes through a
+// callback whose per-call length is always a small, safe int, so they parse buffers up to
+// libxml2's true (size_t) limits. We feed libxml2 from the already-in-memory document via this
+// callback. (DuckDB caps a single string/XML value at 4 GiB, so whole-document readers still top
+// out there; genuinely larger inputs must use record-level streaming via read_xml.)
+namespace {
+struct InMemoryReader {
+	const char *data;
+	size_t size;
+	size_t pos;
+};
+
+int InMemoryReaderRead(void *context, char *buffer, int len) {
+	if (len < 0) {
+		return -1;
+	}
+	auto *reader = static_cast<InMemoryReader *>(context);
+	size_t remaining = reader->size - reader->pos;
+	size_t n = remaining < static_cast<size_t>(len) ? remaining : static_cast<size_t>(len);
+	if (n > 0) {
+		memcpy(buffer, reader->data + reader->pos, n);
+		reader->pos += n;
+	}
+	return static_cast<int>(n);
+}
+
+int InMemoryReaderClose(void *context) {
+	return 0;
+}
+} // namespace
 
 // Escape a UTF-8 string for safe embedding inside a JSON string literal (GitHub Issue #78).
 // libxml2 returns entity-decoded text (e.g. &quot; -> ", &#10; -> newline), so characters that
@@ -151,8 +187,9 @@ XMLDocRAII::XMLDocRAII(const std::string &xml_str) {
 	// Note: We intentionally DO NOT use XML_PARSE_RECOVER to maintain strict parsing behavior
 	xmlParserCtxtPtr parser_ctx = xmlNewParserCtxt();
 	if (parser_ctx) {
-		doc = xmlCtxtReadMemory(parser_ctx, xml_str.c_str(), xml_str.length(), nullptr, nullptr,
-		                        XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
+		InMemoryReader reader {xml_str.data(), xml_str.size(), 0};
+		doc = xmlCtxtReadIO(parser_ctx, InMemoryReaderRead, InMemoryReaderClose, &reader, nullptr, nullptr,
+		                    XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
 
 		// Check if parsing failed (NULL doc means fatal error)
 		if (!doc) {
@@ -194,15 +231,17 @@ XMLDocRAII::XMLDocRAII(const std::string &content, bool is_html) {
 		// which would cause UTF-8 multi-byte characters to be misinterpreted (Issue #53)
 		// TODO: Future enhancement - consider making encoding configurable via parameter
 		// (with UTF-8 as default) or deriving it from database collation settings
-		doc = htmlReadMemory(content.c_str(), content.length(), nullptr, "UTF-8",
-		                     HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING);
+		InMemoryReader reader {content.data(), content.size(), 0};
+		doc = htmlReadIO(InMemoryReaderRead, InMemoryReaderClose, &reader, nullptr, "UTF-8",
+		                 HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING);
 	} else {
 		// Parse as XML with error message suppression (thread-safe, per-operation config)
 		// Do NOT use RECOVER flag to maintain strict XML parsing behavior
 		xmlParserCtxtPtr parser_ctx = xmlNewParserCtxt();
 		if (parser_ctx) {
-			doc = xmlCtxtReadMemory(parser_ctx, content.c_str(), content.length(), nullptr, nullptr,
-			                        XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
+			InMemoryReader reader {content.data(), content.size(), 0};
+			doc = xmlCtxtReadIO(parser_ctx, InMemoryReaderRead, InMemoryReaderClose, &reader, nullptr, nullptr,
+			                    XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
 			if (!doc) {
 				// Distinguish an allocation failure from malformed input before freeing
 				// the context (the error object is owned by the parser context).


### PR DESCRIPTION
## Summary

Makes `read_xml_objects` / `read_xml` / `read_html` work on XML/HTML documents
between **2 GiB and 4 GiB** (e.g. the ~2.8 GiB Czech justice bulk register from
#103). Supersedes and folds in #103, crediting @onnimonni.

## Two independent ~2 GiB barriers

**1. Whole-file read** (this is what #103 found). `FileHandle::Read` issues a
single `read()`/`pread()`; one call for >2 GiB returns `EINVAL` on macOS and
short-reads on Linux, and the readers ignored the return value. Fixed with a
chunked `ReadFileFully` (≤1 GiB/call) — hardened over #103 to **advance by the
bytes actually returned** and error only on a non-positive return, so a legal
short read on a network/FUSE handle can't silently leave a zero-filled gap.

**2. DOM parse/validate** (why #103 alone didn't fix the bug). `xmlCtxtReadMemory`
/ `htmlReadMemory` take the buffer length as an **`int`**, so a >INT_MAX
(~2.147 GiB) buffer wraps negative and libxml2 returns "invalid document" — even
after the file is read correctly. Switched to the IO-based `xmlCtxtReadIO` /
`htmlReadIO`, which pull bytes through a callback (no total-size parameter), fed
from the in-memory document.

No `XML_PARSE_HUGE`: the `int` parameter was the only barrier (confirmed by
parsing 2.5 GiB with HUGE off), so libxml2's DoS limits from the v2.2.0 security
hardening stay in place.

## Known upper bound

The ceiling is now DuckDB's **4 GiB single-value cap** (`string_t` length is
`uint32`), not libxml2. Genuinely larger documents must use record-level
streaming via `read_xml` (which already handles >2 GiB). Returning a >4 GiB
document as one value is a DuckDB-level limitation, tracked separately.

## Verification

No >2 GiB fixture can live in the repo, so this was verified manually against a
generated 2.5 GiB file (2,508,203,750 bytes):

| | result |
|---|---|
| **before** (main + #103) | `Invalid Input Error: contains invalid XML` |
| **after** | `read_xml_objects` → rows=1, `length(xml)`=2,508,203,750 (full), last record present |
| control (1.9 GiB, <INT_MAX) | parses before and after |
| `read_xml` streaming (2.5 GiB) | reads all 21,350,125 records |
| suite | 2875 assertions in 83 test cases pass |

Closes #103
