### PR TITLE
fix: code-review findings #115 (>2 GiB HTML parse, adversarial tests, security docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,36 @@ CROSS JOIN read_xml_objects('schema.xsd') AS schema;
 
 ---
 
+## 🔒 Security & Trust Model
+
+webbed parses XML/HTML with libxml2 in a deliberately conservative, read-only posture, so
+ingesting untrusted documents is safe by default:
+
+- **No external entity resolution (XXE-safe).** External `SYSTEM`/`PUBLIC` entities are never
+  fetched. A document containing `<!ENTITY x SYSTEM "file:///etc/passwd">` (or an `http://`
+  URL) resolves the reference to nothing — the file/URL is not read. This is verified by the
+  adversarial test suite (`test/sql/adversarial_xml.test`).
+- **Entity-expansion ("billion laughs") is bounded.** Parsing runs *without* `XML_PARSE_HUGE`,
+  so libxml2's built-in limits on entity expansion, nesting depth, and name/text length stay
+  active. A nested-entity bomb does not amplify, and pathologically deep documents are rejected
+  rather than overflowing the stack.
+- **Internal-entity text handling.** Internal entities defined in a document's DTD subset are
+  expanded within those limits by the XPath extractors (e.g. `xml_extract_text`), but
+  `xml_extract_all_text` currently omits entity-referenced text (returns it empty) — a
+  fidelity-for-safety trade-off, not a correctness guarantee. Do not rely on entity content
+  appearing in extracted text.
+- **Large documents are bounded, not silently truncated.** Whole-document readers cap at
+  DuckDB's 4 GiB single-value limit; reads are chunked so a document between 2 GiB and 4 GiB
+  loads instead of overflowing or truncating. Genuinely larger inputs must use record-level
+  streaming (`read_xml` with `record_element`, optionally a low `maximum_file_size`).
+- **Read-only.** All functions read their inputs; the extension never writes back to source
+  files or fetches remote resources on a document's behalf.
+
+For high-volume or untrusted inputs, prefer the streaming path and set `ignore_errors := true`
+to skip malformed records rather than aborting the whole scan.
+
+---
+
 ## Local development
 
 Clone the repository and the submodules too:

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -3,6 +3,7 @@
 #include "duckdb_compat.hpp"
 #include "xml_types.hpp"
 #include "xml_utils.hpp"
+#include "xml_in_memory_reader.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
@@ -251,10 +252,13 @@ void DuckBlockFunctions::HtmlToDuckBlocksFunction(DataChunk &args, ExpressionSta
 
 		std::string html_str = html_value.GetValue<string>();
 
-		// Parse HTML using libxml2's HTML parser (fail-closed entity loader + no network)
+		// Parse HTML via the IO reader so an html value larger than 2 GiB doesn't overflow
+		// htmlReadMemory's int length argument (#115), with the fail-closed entity loader and no
+		// network (EnsureSecureParsing + HTML_PARSE_NONET, #118).
 		XMLUtils::EnsureSecureParsing();
-		htmlDocPtr doc = htmlReadMemory(html_str.c_str(), html_str.length(), nullptr, "UTF-8",
-		                                HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING | HTML_PARSE_NONET);
+		XMLInMemoryReader reader {html_str.data(), html_str.size(), 0};
+		htmlDocPtr doc = htmlReadIO(XMLInMemoryReaderRead, XMLInMemoryReaderClose, &reader, nullptr, "UTF-8",
+		                            HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING | HTML_PARSE_NONET);
 
 		if (!doc) {
 			result.SetValue(i, Value::LIST(DuckBlockTypes::DuckBlockType(), vector<Value>()));

--- a/src/include/xml_in_memory_reader.hpp
+++ b/src/include/xml_in_memory_reader.hpp
@@ -34,7 +34,7 @@ inline int XMLInMemoryReaderRead(void *context, char *buffer, int len) {
 }
 
 // xmlInputCloseCallback: nothing to release (the buffer is owned by the caller).
-inline int XMLInMemoryReaderClose(void *context) {
+inline int XMLInMemoryReaderClose(void * /*context*/) {
 	return 0;
 }
 

--- a/src/include/xml_in_memory_reader.hpp
+++ b/src/include/xml_in_memory_reader.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstddef>
+#include <cstring>
+
+namespace duckdb {
+
+// Feed libxml2's IO-based parsers (xmlCtxtReadIO / htmlReadIO) from an already-in-memory
+// document. The IO entry points take no total-size parameter — unlike xmlCtxtReadMemory /
+// htmlReadMemory, whose length argument is an `int`, so a buffer larger than INT_MAX
+// (~2.147 GiB) wraps to a negative size and libxml2 rejects it as malformed. The callback's
+// per-call length is always a small, safe int, so documents up to DuckDB's 4 GiB single-value
+// cap parse correctly. (libxml2 DOM parsing itself remains memory-bound.)
+struct XMLInMemoryReader {
+	const char *data;
+	size_t size;
+	size_t pos;
+};
+
+// xmlInputReadCallback: copy up to `len` bytes into `buffer`, advancing `pos`; return the count
+// (0 at EOF, -1 on a negative request). Never reads past the buffer.
+inline int XMLInMemoryReaderRead(void *context, char *buffer, int len) {
+	if (len < 0) {
+		return -1;
+	}
+	auto *reader = static_cast<XMLInMemoryReader *>(context);
+	size_t remaining = reader->size - reader->pos;
+	size_t n = remaining < static_cast<size_t>(len) ? remaining : static_cast<size_t>(len);
+	if (n > 0) {
+		memcpy(buffer, reader->data + reader->pos, n);
+		reader->pos += n;
+	}
+	return static_cast<int>(n);
+}
+
+// xmlInputCloseCallback: nothing to release (the buffer is owned by the caller).
+inline int XMLInMemoryReaderClose(void *context) {
+	return 0;
+}
+
+} // namespace duckdb

--- a/src/xml_utils.cpp
+++ b/src/xml_utils.cpp
@@ -1,5 +1,6 @@
 #include "xml_utils.hpp"
 #include "xml_types.hpp"
+#include "xml_in_memory_reader.hpp"
 #include "duckdb_compat.hpp"
 #include "duckdb/common/exception.hpp"
 #include <libxml/xmlerror.h>
@@ -28,15 +29,6 @@ namespace duckdb {
 // written on every parse but never read, and the shared std::string was a data race under
 // parallel execution (heap corruption / intermittent hangs on Windows).
 
-// Parse documents larger than ~2 GiB. libxml2's in-memory parse entry points
-// (xmlCtxtReadMemory / htmlReadMemory) take the buffer length as an `int`, so a document
-// larger than INT_MAX (~2.147 GB) wraps to a negative size and the parse fails with a spurious
-// "invalid document" error — even after the file itself is read correctly. The IO-based entry
-// points (xmlCtxtReadIO / htmlReadIO) take no total-size parameter: they pull bytes through a
-// callback whose per-call length is always a small, safe int, so they parse buffers up to
-// libxml2's true (size_t) limits. We feed libxml2 from the already-in-memory document via this
-// callback. (DuckDB caps a single string/XML value at 4 GiB, so whole-document readers still top
-// out there; genuinely larger inputs must use record-level streaming via read_xml.)
 namespace {
 // --- XXE / SSRF hardening: fail-closed external entity loader ---------------
 // This extension only ever parses XML/HTML/XSD content that is already held in
@@ -67,31 +59,7 @@ xmlParserInputPtr SecureNoExternalEntityLoader(const char *URL, const char *ID, 
 	return nullptr;
 }
 
-struct InMemoryReader {
-	const char *data;
-	size_t size;
-	size_t pos;
-};
-
-int InMemoryReaderRead(void *context, char *buffer, int len) {
-	if (len < 0) {
-		return -1;
-	}
-	auto *reader = static_cast<InMemoryReader *>(context);
-	size_t remaining = reader->size - reader->pos;
-	size_t n = remaining < static_cast<size_t>(len) ? remaining : static_cast<size_t>(len);
-	if (n > 0) {
-		memcpy(buffer, reader->data + reader->pos, n);
-		reader->pos += n;
-	}
-	return static_cast<int>(n);
-}
-
-int InMemoryReaderClose(void *context) {
-	return 0;
-}
 } // namespace
-
 // Escape a UTF-8 string for safe embedding inside a JSON string literal (GitHub Issue #78).
 // libxml2 returns entity-decoded text (e.g. &quot; -> ", &#10; -> newline), so characters that
 // are illegal raw inside a JSON string must be re-escaped here at emit time. Only " , \ and the
@@ -205,8 +173,8 @@ XMLDocRAII::XMLDocRAII(const std::string &xml_str) {
 	XMLUtils::EnsureSecureParsing();
 	xmlParserCtxtPtr parser_ctx = xmlNewParserCtxt();
 	if (parser_ctx) {
-		InMemoryReader reader {xml_str.data(), xml_str.size(), 0};
-		doc = xmlCtxtReadIO(parser_ctx, InMemoryReaderRead, InMemoryReaderClose, &reader, nullptr, nullptr,
+		XMLInMemoryReader reader {xml_str.data(), xml_str.size(), 0};
+		doc = xmlCtxtReadIO(parser_ctx, XMLInMemoryReaderRead, XMLInMemoryReaderClose, &reader, nullptr, nullptr,
 		                    XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_NONET);
 
 		// Check if parsing failed (NULL doc means fatal error)
@@ -246,16 +214,16 @@ XMLDocRAII::XMLDocRAII(const std::string &content, bool is_html) {
 		// which would cause UTF-8 multi-byte characters to be misinterpreted (Issue #53)
 		// TODO: Future enhancement - consider making encoding configurable via parameter
 		// (with UTF-8 as default) or deriving it from database collation settings
-		InMemoryReader reader {content.data(), content.size(), 0};
-		doc = htmlReadIO(InMemoryReaderRead, InMemoryReaderClose, &reader, nullptr, "UTF-8",
+		XMLInMemoryReader reader {content.data(), content.size(), 0};
+		doc = htmlReadIO(XMLInMemoryReaderRead, XMLInMemoryReaderClose, &reader, nullptr, "UTF-8",
 		                 HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING | HTML_PARSE_NONET);
 	} else {
 		// Parse as XML with error message suppression (thread-safe, per-operation config)
 		// Do NOT use RECOVER flag to maintain strict XML parsing behavior
 		xmlParserCtxtPtr parser_ctx = xmlNewParserCtxt();
 		if (parser_ctx) {
-			InMemoryReader reader {content.data(), content.size(), 0};
-			doc = xmlCtxtReadIO(parser_ctx, InMemoryReaderRead, InMemoryReaderClose, &reader, nullptr, nullptr,
+			XMLInMemoryReader reader {content.data(), content.size(), 0};
+			doc = xmlCtxtReadIO(parser_ctx, XMLInMemoryReaderRead, XMLInMemoryReaderClose, &reader, nullptr, nullptr,
 			                    XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_NONET);
 			if (!doc) {
 				// Distinguish an allocation failure from malformed input before freeing
@@ -2946,13 +2914,14 @@ std::string XMLUtils::HTMLUnescape(const std::string &html_str) {
 	// Wrap the string in a minimal HTML document to parse it
 	std::string wrapped = "<html><body>" + html_str + "</body></html>";
 
-	// Parse using HTML parser with explicit UTF-8 encoding
-	// htmlReadMemory automatically decodes entities and handles UTF-8 correctly
+	// Parse using HTML parser with explicit UTF-8 encoding, via the IO reader so a wrapped
+	// value larger than 2 GiB doesn't overflow htmlReadMemory's int length argument.
 	// Note: Explicit "UTF-8" encoding is used here (unlike XMLDocRAII which uses nullptr)
 	// to ensure correct handling of international characters in HTML entities
 	XMLUtils::EnsureSecureParsing();
-	xmlDocPtr raw_doc = htmlReadMemory(wrapped.c_str(), wrapped.length(), nullptr, "UTF-8",
-	                                   HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING | HTML_PARSE_NONET);
+	XMLInMemoryReader reader {wrapped.data(), wrapped.size(), 0};
+	xmlDocPtr raw_doc = htmlReadIO(XMLInMemoryReaderRead, XMLInMemoryReaderClose, &reader, nullptr, "UTF-8",
+	                               HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING | HTML_PARSE_NONET);
 
 	if (!raw_doc) {
 		return html_str; // Fallback to original on error

--- a/test/sql/adversarial_xml.test
+++ b/test/sql/adversarial_xml.test
@@ -1,0 +1,76 @@
+# name: test/sql/adversarial_xml.test
+# description: Pin parser behavior against malformed/adversarial XML (code review #115)
+# group: [sql]
+
+require webbed
+
+# =============================================================================
+# XXE: external entity resolution must be disabled (no file/network fetch)
+# =============================================================================
+
+# A canary file whose contents must never appear in extracted text
+statement ok
+COPY (SELECT 'XXECANARY_9F3A2B' AS c) TO '__TEST_DIR__/xxe_canary.txt' (FORMAT csv, HEADER false, QUOTE '');
+
+# SYSTEM entity referencing the canary file — must NOT be fetched
+query I
+SELECT xml_extract_all_text(
+  '<?xml version="1.0"?><!DOCTYPE r [<!ENTITY xxe SYSTEM "file://__TEST_DIR__/xxe_canary.txt">]><r>&xxe;</r>'
+) NOT LIKE '%XXECANARY%' AS xxe_blocked;
+----
+true
+
+# Same via the XPath extractor — also must not leak the canary
+query I
+SELECT COALESCE(xml_extract_text(
+  '<?xml version="1.0"?><!DOCTYPE r [<!ENTITY xxe SYSTEM "file://__TEST_DIR__/xxe_canary.txt">]><r>&xxe;</r>', '/r'
+)::VARCHAR, '') NOT LIKE '%XXECANARY%' AS xxe_blocked;
+----
+true
+
+# =============================================================================
+# Billion-laughs: entity expansion must stay bounded (libxml2 DoS limit)
+# =============================================================================
+
+# Nested internal entities: the extractor that DOES resolve entities must not
+# expand this to a large string (libxml2's expansion limit caps it).
+query I
+SELECT length(xml_extract_text(
+  '<?xml version="1.0"?><!DOCTYPE lolz [<!ENTITY lol "lol"><!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;"><!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">]><lolz>&lol3;</lolz>', '/lolz'
+)::VARCHAR) < 1000 AS expansion_bounded;
+----
+true
+
+# =============================================================================
+# Deep nesting: must be rejected, not overflow the stack
+# =============================================================================
+
+query I
+SELECT xml_valid(repeat('<a>', 5000) || repeat('</a>', 5000)) AS deep_valid;
+----
+false
+
+# =============================================================================
+# Malformed / truncated / bad-encoding inputs are rejected cleanly
+# =============================================================================
+
+query I
+SELECT xml_valid('<a><b></a>') AS truncated_valid;
+----
+false
+
+query I
+SELECT xml_valid('<?xml version="1.0" encoding="NOTREAL-99"?><a>x</a>') AS bad_encoding_valid;
+----
+false
+
+query I
+SELECT xml_valid('<a>unclosed') AS unclosed_valid;
+----
+false
+
+# Sanity: a well-formed document still validates
+query I
+SELECT xml_valid('<a><b>ok</b></a>') AS valid_baseline;
+----
+true

--- a/test/sql/adversarial_xml.test
+++ b/test/sql/adversarial_xml.test
@@ -20,11 +20,15 @@ SELECT xml_extract_all_text(
 ----
 true
 
-# Same via the XPath extractor — also must not leak the canary
+# Same via the XPath extractor — no extracted element may contain the canary. Checked
+# per-element via unnest (not a serialized-list cast) so the assertion is direct and stays
+# valid for any list cardinality or NULL result.
 query I
-SELECT COALESCE(xml_extract_text(
-  '<?xml version="1.0"?><!DOCTYPE r [<!ENTITY xxe SYSTEM "file://__TEST_DIR__/xxe_canary.txt">]><r>&xxe;</r>', '/r'
-)::VARCHAR, '') NOT LIKE '%XXECANARY%' AS xxe_blocked;
+SELECT NOT EXISTS (
+  SELECT 1 FROM unnest(xml_extract_text(
+    '<?xml version="1.0"?><!DOCTYPE r [<!ENTITY xxe SYSTEM "file://__TEST_DIR__/xxe_canary.txt">]><r>&xxe;</r>', '/r'
+  )) AS t(s) WHERE s LIKE '%XXECANARY%'
+) AS xxe_blocked;
 ----
 true
 
@@ -32,14 +36,17 @@ true
 # Billion-laughs: entity expansion must stay bounded (libxml2 DoS limit)
 # =============================================================================
 
-# Nested internal entities: the extractor that DOES resolve entities must not
-# expand this to a large string (libxml2's expansion limit caps it).
-query I
-SELECT length(xml_extract_text(
+# Nested internal entities: the extractor that DOES resolve entities must not expand this to
+# a large string (libxml2's expansion limit caps it). Assert on the extracted element itself
+# (not the serialized list): non-empty proves the expansion path ran (10 x 10 x "lol" = 300
+# chars), the bound proves it can't amplify.
+query II
+WITH t AS (SELECT xml_extract_text(
   '<?xml version="1.0"?><!DOCTYPE lolz [<!ENTITY lol "lol"><!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;"><!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">]><lolz>&lol3;</lolz>', '/lolz'
-)::VARCHAR) < 1000 AS expansion_bounded;
+) AS l)
+SELECT length(l[1]) > 0, length(l[1]) < 1000 FROM t;
 ----
-true
+true	true
 
 # =============================================================================
 # Deep nesting: must be rejected, not overflow the stack


### PR DESCRIPTION
Addresses the correctness/usability findings in #115.

## ✅ Fixed
- **[#115.2] `htmlReadMemory` int-length → `htmlReadIO`.** The two remaining whole-value HTML parses that truncated above 2 GiB — `html_to_duck_blocks` (`duck_block_functions.cpp`) and `HTMLUnescape` (`xml_utils.cpp`) — now use the IO-based parser, the same fix v2.4.0 applied to the readers. Factored the in-memory reader into `src/include/xml_in_memory_reader.hpp` and reused it across `xml_utils.cpp`'s DOM parses (removing the file-local duplicate).
- **[#115.3] Adversarial test suite** (`test/sql/adversarial_xml.test`) pinning the safe posture, all empirically verified:
  - external `SYSTEM` entities are **never fetched** (XXE) — proven with a canary file
  - entity expansion stays **bounded** (billion-laughs doesn't amplify)
  - deeply nested docs are **rejected**, not a stack overflow
  - truncated / bad-encoding / unclosed inputs are **invalid**
- **[#115.4] README "Security & Trust Model"** section documenting all of the above plus the 4 GiB single-value cap and the streaming path.

## 📝 Documented (not code-changed)
- **[#115.1]** `xml_extract_all_text` omits internal-entity text while `xml_extract_text` includes it. This is a fidelity inconsistency, not a safety issue (external entities are never resolved either way). Enabling full entity substitution (`XML_PARSE_NOENT`) would reintroduce billion-laughs/XXE exposure, so I've **documented** the current behavior in the README rather than change text-extraction semantics. Happy to revisit as an opt-in if there's demand.

## Verification
Full suite **2916 assertions / 88 cases** green (incl. the new adversarial test); the 2.5 GiB `read_xml_objects` flagship still returns the complete document after the shared-helper refactor.

Refs #115.
