### PR TITLE
Disable external entity resolution and network fetch in XML parsing

### DIFF
--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -251,9 +251,10 @@ void DuckBlockFunctions::HtmlToDuckBlocksFunction(DataChunk &args, ExpressionSta
 
 		std::string html_str = html_value.GetValue<string>();
 
-		// Parse HTML using libxml2's HTML parser
+		// Parse HTML using libxml2's HTML parser (fail-closed entity loader + no network)
+		XMLUtils::EnsureSecureParsing();
 		htmlDocPtr doc = htmlReadMemory(html_str.c_str(), html_str.length(), nullptr, "UTF-8",
-		                                HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING);
+		                                HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING | HTML_PARSE_NONET);
 
 		if (!doc) {
 			result.SetValue(i, Value::LIST(DuckBlockTypes::DuckBlockType(), vector<Value>()));

--- a/src/include/xml_utils.hpp
+++ b/src/include/xml_utils.hpp
@@ -313,6 +313,12 @@ public:
 	static std::string GetNodePath(xmlNodePtr node);
 	static void InitializeLibXML();
 	static void CleanupLibXML();
+
+	// Install libxml2's fail-closed external-entity loader (idempotent, thread-safe).
+	// Must run before any parse so that every entry point — including the XSD schema
+	// parser, which accepts no XML_PARSE_* flags — refuses external file/network
+	// resources (XXE / SSRF hardening). Safe to call from any parse site.
+	static void EnsureSecureParsing();
 };
 
 } // namespace duckdb

--- a/src/xml_reader_functions.cpp
+++ b/src/xml_reader_functions.cpp
@@ -859,6 +859,8 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 					gstate.sax_ctx->preserve_whitespace = bind_data.schema_options.preserve_whitespace;
 
 					gstate.sax_handler = SAXStreamReader::CreateSAXHandler();
+					// Fail-closed entity loader: refuse external DTD/entity fetch during streaming parse.
+					XMLUtils::EnsureSecureParsing();
 					gstate.sax_parser_ctx = xmlCreatePushParserCtxt(&gstate.sax_handler, gstate.sax_ctx.get(), nullptr,
 					                                                0, filename.c_str());
 					if (!gstate.sax_parser_ctx) {

--- a/src/xml_sax_reader.cpp
+++ b/src/xml_sax_reader.cpp
@@ -1,4 +1,5 @@
 #include "xml_sax_reader.hpp"
+#include "xml_utils.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include <sstream>
@@ -424,7 +425,8 @@ std::vector<SAXRecordAccumulator> SAXStreamReader::ReadRecords(FileSystem &fs, c
 	// Open file via DuckDB FileSystem (supports S3, HTTP, VFS, etc.)
 	auto file_handle = fs.OpenFile(filename, FileFlags::FILE_FLAGS_READ);
 
-	// Create push parser context
+	// Create push parser context (fail-closed entity loader: refuse external DTD/entity fetch)
+	XMLUtils::EnsureSecureParsing();
 	xmlParserCtxtPtr parser_ctx = xmlCreatePushParserCtxt(&handler, &ctx, nullptr, 0, filename.c_str());
 	if (!parser_ctx) {
 		throw IOException("Could not create SAX push parser context for '%s'", filename);

--- a/src/xml_utils.cpp
+++ b/src/xml_utils.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <functional>
 #include <map>
+#include <mutex>
 #include <regex>
 #include <set>
 #include <unordered_set>
@@ -50,6 +51,35 @@ void XMLSilentErrorHandler(void *ctx, const char *msg, ...) {
 // callback. (DuckDB caps a single string/XML value at 4 GiB, so whole-document readers still top
 // out there; genuinely larger inputs must use record-level streaming via read_xml.)
 namespace {
+// --- XXE / SSRF hardening: fail-closed external entity loader ---------------
+// This extension only ever parses XML/HTML/XSD content that is already held in
+// memory (string arguments, or files it has itself opened via DuckDB's FileSystem
+// and streamed through an in-memory reader). It never legitimately needs libxml2 to
+// resolve an *external* resource on its behalf. libxml2 would otherwise open arbitrary
+// local files or network URLs referenced from attacker-controlled input via SYSTEM
+// external entities, external DTDs, or XSD <xs:import>/<xs:include schemaLocation="...">.
+// The schema parser (xmlSchemaNewMemParserCtxt/xmlSchemaParse) accepts no XML_PARSE_*
+// flags, so overriding the process-wide external entity loader is the only place these
+// schema-side resolutions can be intercepted. Refusing every external URL closes the
+// class (arbitrary local file read + SSRF) at all parse sites at once.
+xmlExternalEntityLoader g_prev_entity_loader = nullptr;
+std::once_flag g_secure_parsing_once;
+
+xmlParserInputPtr SecureNoExternalEntityLoader(const char *URL, const char *ID, xmlParserCtxtPtr ctxt) {
+	if (URL != nullptr) {
+		// Any external resource (file://, http://, ftp://, absolute or relative path):
+		// refuse. Returning nullptr fails the resolution closed — no file is opened and
+		// no network request is attempted.
+		return nullptr;
+	}
+	// URL == nullptr means there is no external resource to fetch (e.g. predefined
+	// entities); defer to libxml2's prior loader so normal parsing is unaffected.
+	if (g_prev_entity_loader) {
+		return g_prev_entity_loader(URL, ID, ctxt);
+	}
+	return nullptr;
+}
+
 struct InMemoryReader {
 	const char *data;
 	size_t size;
@@ -184,12 +214,17 @@ XMLDocRAII::XMLDocRAII(const std::string &xml_str) {
 	// Parse the XML with options to suppress error messages (thread-safe, per-operation config)
 	// XML_PARSE_NOERROR: suppress error reports to stderr
 	// XML_PARSE_NOWARNING: suppress warning reports to stderr
+	// XML_PARSE_NONET: forbid network access. We deliberately do NOT set XML_PARSE_NOENT,
+	//   XML_PARSE_DTDLOAD or XML_PARSE_DTDVALID, so external entities are never substituted or
+	//   fetched. The fail-closed entity loader (EnsureSecureParsing) is the primary XXE defense;
+	//   NONET is belt-and-suspenders for the network case.
 	// Note: We intentionally DO NOT use XML_PARSE_RECOVER to maintain strict parsing behavior
+	XMLUtils::EnsureSecureParsing();
 	xmlParserCtxtPtr parser_ctx = xmlNewParserCtxt();
 	if (parser_ctx) {
 		InMemoryReader reader {xml_str.data(), xml_str.size(), 0};
 		doc = xmlCtxtReadIO(parser_ctx, InMemoryReaderRead, InMemoryReaderClose, &reader, nullptr, nullptr,
-		                    XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
+		                    XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_NONET);
 
 		// Check if parsing failed (NULL doc means fatal error)
 		if (!doc) {
@@ -224,6 +259,7 @@ XMLDocRAII::XMLDocRAII(const std::string &content, bool is_html) {
 	xml_parse_error_occurred = false;
 	xml_parse_error_message.clear();
 
+	XMLUtils::EnsureSecureParsing();
 	if (is_html) {
 		// Parse as HTML using libxml2's HTML parser with error suppression
 		// HTML needs RECOVER flag to handle malformed HTML gracefully
@@ -233,7 +269,7 @@ XMLDocRAII::XMLDocRAII(const std::string &content, bool is_html) {
 		// (with UTF-8 as default) or deriving it from database collation settings
 		InMemoryReader reader {content.data(), content.size(), 0};
 		doc = htmlReadIO(InMemoryReaderRead, InMemoryReaderClose, &reader, nullptr, "UTF-8",
-		                 HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING);
+		                 HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING | HTML_PARSE_NONET);
 	} else {
 		// Parse as XML with error message suppression (thread-safe, per-operation config)
 		// Do NOT use RECOVER flag to maintain strict XML parsing behavior
@@ -241,7 +277,7 @@ XMLDocRAII::XMLDocRAII(const std::string &content, bool is_html) {
 		if (parser_ctx) {
 			InMemoryReader reader {content.data(), content.size(), 0};
 			doc = xmlCtxtReadIO(parser_ctx, InMemoryReaderRead, InMemoryReaderClose, &reader, nullptr, nullptr,
-			                    XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
+			                    XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_NONET);
 			if (!doc) {
 				// Distinguish an allocation failure from malformed input before freeing
 				// the context (the error object is owned by the parser context).
@@ -347,9 +383,21 @@ case_insensitive_map_t<string> XMLDocRAII::GetDeclaredNamespaces() const {
 	return result;
 }
 
+void XMLUtils::EnsureSecureParsing() {
+	std::call_once(g_secure_parsing_once, []() {
+		xmlInitParser();
+		g_prev_entity_loader = xmlGetExternalEntityLoader();
+		xmlSetExternalEntityLoader(SecureNoExternalEntityLoader);
+	});
+}
+
 void XMLUtils::InitializeLibXML() {
 	xmlInitParser();
 	LIBXML_TEST_VERSION;
+	// Install the fail-closed entity loader at extension load. A call_once guard at every
+	// parse site (below) is the belt-and-suspenders backstop in case any code path parses
+	// before Load() runs.
+	EnsureSecureParsing();
 }
 
 void XMLUtils::CleanupLibXML() {
@@ -816,6 +864,11 @@ std::string XMLUtils::MinifyXML(const std::string &xml_str) {
 }
 
 bool XMLUtils::ValidateXMLSchema(const std::string &xml_str, const std::string &xsd_schema) {
+	// Fail-closed entity loader must be installed before parsing the caller-supplied XSD:
+	// an <xs:import>/<xs:include schemaLocation="file://..."> (or external DTD) would otherwise
+	// make libxml2 open arbitrary local files (GHSA-vf8w-rr6w-h445). The schema parser takes no
+	// XML_PARSE_* options, so the external entity loader is the only interception point.
+	EnsureSecureParsing();
 	// Parse the XSD schema using DuckDB-style smart pointers
 	XMLSchemaParserPtr parser_ctx(xmlSchemaNewMemParserCtxt(xsd_schema.c_str(), xsd_schema.length()));
 	if (!parser_ctx) {
@@ -2518,8 +2571,13 @@ xmlNodePtr XMLUtils::ConvertValueToXMLNode(const Value &value, const LogicalType
 			std::string json_str = value.GetValue<string>();
 			std::string xml_result = JSONToXML(json_str);
 
-			// Parse the XML result and add child nodes
-			xmlDocPtr temp_doc = xmlParseMemory(xml_result.c_str(), xml_result.length());
+			// Parse the XML result and add child nodes.
+			// Use xmlReadMemory with explicit safe flags instead of the deprecated xmlParseMemory
+			// (which honors mutable libxml2 globals): forbid network and never substitute/fetch
+			// external entities. See EnsureSecureParsing() for the class-level defense.
+			XMLUtils::EnsureSecureParsing();
+			xmlDocPtr temp_doc = xmlReadMemory(xml_result.c_str(), xml_result.length(), "internal.xml", nullptr,
+			                                   XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_NONET);
 			if (temp_doc && xmlDocGetRootElement(temp_doc)) {
 				xmlNodePtr temp_root = xmlDocGetRootElement(temp_doc);
 
@@ -2550,8 +2608,11 @@ xmlNodePtr XMLUtils::ConvertValueToXMLNode(const Value &value, const LogicalType
 
 			// Check if input is already valid XML
 			if (type.id() == LogicalTypeId::VARCHAR && IsValidXML(value_str)) {
-				// Parse and add as child nodes
-				xmlDocPtr temp_doc = xmlParseMemory(value_str.c_str(), value_str.length());
+				// Parse and add as child nodes. Explicit safe flags (see above): no network,
+				// no external entity substitution/fetch.
+				XMLUtils::EnsureSecureParsing();
+				xmlDocPtr temp_doc = xmlReadMemory(value_str.c_str(), value_str.length(), "internal.xml", nullptr,
+				                                   XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_NONET);
 				if (temp_doc && xmlDocGetRootElement(temp_doc)) {
 					xmlNodePtr temp_root = xmlDocGetRootElement(temp_doc);
 					xmlNodePtr copied_node = xmlCopyNode(temp_root, 1);
@@ -2913,8 +2974,9 @@ std::string XMLUtils::HTMLUnescape(const std::string &html_str) {
 	// htmlReadMemory automatically decodes entities and handles UTF-8 correctly
 	// Note: Explicit "UTF-8" encoding is used here (unlike XMLDocRAII which uses nullptr)
 	// to ensure correct handling of international characters in HTML entities
+	XMLUtils::EnsureSecureParsing();
 	xmlDocPtr raw_doc = htmlReadMemory(wrapped.c_str(), wrapped.length(), nullptr, "UTF-8",
-	                                   HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING);
+	                                   HTML_PARSE_RECOVER | HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING | HTML_PARSE_NONET);
 
 	if (!raw_doc) {
 		return html_str; // Fallback to original on error

--- a/test/sql/xxe_external_entity.test
+++ b/test/sql/xxe_external_entity.test
@@ -1,0 +1,82 @@
+# name: test/sql/xxe_external_entity.test
+# description: XXE hardening — external entity / external XSD resolution must fail closed (GHSA-vf8w-rr6w-h445)
+# group: [sql]
+
+require webbed
+
+# =============================================================================
+# Positive controls: ordinary, self-contained schema validation still works.
+# These must stay green before AND after the fix (they use no external resources).
+# =============================================================================
+
+query I
+SELECT xml_validate_schema('<root>hi</root>',
+  '<?xml version="1.0"?><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"><xs:element name="root" type="xs:string"/></xs:schema>');
+----
+true
+
+# Negative control: a document that does not match the schema is invalid.
+query I
+SELECT xml_validate_schema('<other>hi</other>',
+  '<?xml version="1.0"?><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"><xs:element name="root" type="xs:string"/></xs:schema>');
+----
+false
+
+# Ordinary XML/HTML parsing continues to work (no external references involved).
+query I
+SELECT xml_to_json('<a><b>1</b><b>2</b></a>');
+----
+{"a":{"b":[{"#text":"1"},{"#text":"2"}]}}
+
+query I
+SELECT html_extract_text('<html><body><p>hello</p></body></html>');
+----
+hello
+
+# =============================================================================
+# Fixture: a local, self-created XSD fragment that DEFINES the <root> element and
+# carries a SECRET-CANARY marker in its contents. It never lives at a real system
+# path — it is materialized under the test's own temp dir.
+# =============================================================================
+
+statement ok
+COPY (SELECT '<?xml version="1.0"?><!-- SECRET-CANARY do-not-read --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"><xs:element name="root" type="xs:string"/></xs:schema>' AS x)
+TO '__TEST_DIR__/xxe_include_helper.xsd' (FORMAT 'csv', HEADER false, QUOTE '');
+
+# =============================================================================
+# Core regression: a malicious XSD whose <xs:include schemaLocation="file://...">
+# pulls the <root> definition from the local file above.
+#
+#   * On a VULNERABLE build libxml2 opens and reads that local file, the schema
+#     completes, and the document validates -> TRUE.
+#   * On a HARDENED build the fail-closed external entity loader refuses the read,
+#     the schema fails to parse, and validation returns -> FALSE.
+#
+# Asserting FALSE means this test FAILS on the vulnerable code (reproduce-first)
+# and passes only once external resolution is disabled. The file that would be
+# read carries SECRET-CANARY, so a passing (FALSE) result proves the local file
+# was NOT consulted.
+# =============================================================================
+
+query I
+SELECT xml_validate_schema('<root>hi</root>',
+  '<?xml version="1.0"?><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"><xs:include schemaLocation="__TEST_DIR__/xxe_include_helper.xsd"/></xs:schema>');
+----
+false
+
+# An external general entity in the instance document must never be resolved into
+# output (the primary DOM path never substitutes entities). Points at the same
+# local canary file, which must not be read.
+query I
+SELECT xml_to_json('<?xml version="1.0"?><!DOCTYPE r [ <!ENTITY x SYSTEM "__TEST_DIR__/xxe_include_helper.xsd"> ]><r>&x;</r>');
+----
+{"r":{}}
+
+# An http:// SystemId must fail closed with NO network attempt. A reserved
+# ".invalid" host (RFC 2606) guarantees this never touches a real endpoint; the
+# assertion also guards against the call hanging on a network round-trip.
+query I
+SELECT xml_validate_schema('<root>hi</root>',
+  '<?xml version="1.0"?><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"><xs:include schemaLocation="http://webbed-xxe-test.invalid/evil.xsd"/></xs:schema>');
+----
+false


### PR DESCRIPTION
## Summary

Untrusted XML/HTML/XSD input could make libxml2 open **external resources** — local files or network URLs — during parsing. The most direct path was the XSD argument of `xml_validate_schema`: an external `<xs:import>` / `<xs:include schemaLocation="…">` (or an external DTD) was resolved by libxml2, opening arbitrary local files. The primary DOM path also omitted a network-forbidding flag.

This PR disables external entity resolution and network fetch at **every** libxml2 parse entry point, failing closed. Private security ref: `GHSA-vf8w-rr6w-h445`.

## Fix (class-level, not a single input)

1. **Fail-closed external entity loader.** Install a process-wide loader (`xmlSetExternalEntityLoader`) that refuses every external URL (`file://`, `http://`, `ftp://`, absolute/relative paths). This is the *only* interception point for the XSD schema parser, which accepts no `XML_PARSE_*` flags. Installed once via `std::call_once` at extension load and, defensively, at every parse site through `XMLUtils::EnsureSecureParsing()` (idempotent), so no path can parse before it is armed.
2. **`XML_PARSE_NONET` / `HTML_PARSE_NONET`** added to the DOM, HTML, and streaming (SAX push) parse contexts. `NOENT` / `DTDLOAD` / `DTDVALID` remain unset, so external entities are never substituted or fetched — which also means entity-expansion ("billion laughs") bombs never expand, rather than relying on a separate cap.
3. Replaced the two deprecated `xmlParseMemory` calls (which honour mutable libxml2 globals) with `xmlReadMemory` using explicit safe flags.

Normal parsing is unaffected: self-contained schemas need no external loads, so the loader is never invoked on the happy path.

## Parse sites hardened (all enumerated)

| Site | File | Change |
|---|---|---|
| XSD schema parse (`xml_validate_schema`) | `xml_utils.cpp` `ValidateXMLSchema` | entity loader (primary vector) |
| XML DOM constructor | `xml_utils.cpp` `XMLDocRAII(str)` | loader + `NONET` |
| XML/HTML DOM constructor | `xml_utils.cpp` `XMLDocRAII(str,is_html)` | loader + `NONET`/`HTML_PARSE_NONET` |
| value→XML (JSON + VARCHAR) | `xml_utils.cpp` (×2) | `xmlParseMemory`→`xmlReadMemory` + `NONET` |
| `html_unescape` | `xml_utils.cpp` `HTMLUnescape` | loader + `HTML_PARSE_NONET` |
| duck_block HTML parse | `duck_block_functions.cpp` | loader + `HTML_PARSE_NONET` |
| SAX push parser (`read_xml` file) | `xml_sax_reader.cpp` | loader (already `NONET`) |
| SAX push parser (streaming bind) | `xml_reader_functions.cpp` | loader (already `NONET`) |

## Tests — reproduce-first

`test/sql/xxe_external_entity.test` (self-contained; materialises its own fixture under the test temp dir — no real system path, no real network host):

- **Core regression:** a schema whose `<xs:include schemaLocation="…">` pulls the root-element definition from a **local fixture** file. On unpatched code libxml2 reads the file → schema completes → the document validates **TRUE**; hardened, the read is refused → schema parse fails → **FALSE**. The test asserts FALSE, so it **fails on the current code and passes only after the fix**. The fixture carries a `SECRET-CANARY` marker, so a FALSE result proves the local file was not consulted.
- **No network:** an `http://…​.invalid` (RFC 2606 reserved, non-resolvable) SystemId fails closed with no network attempt (also guards against hangs).
- **Invariants:** ordinary XML/HTML parsing and self-contained schema validation still work; an external `SYSTEM` entity in an instance document is never resolved into output.

### Verification status

Built and tested against the repository's release checkout using the same vendored **libxml2 2.13.8** and byte-identical security edits:

- **Red→green (reproduce-first):** the committed test **fails** on the pre-fix binary (the `xs:include` file-read discriminator returns TRUE) and **passes** on the rebuilt binary (returns FALSE) — verified against the actual built extension, not only an ad-hoc harness.
- **Regression:** full SQL suite green — **2915 assertions across 88 test cases**.
- Supplementary (out-of-band): with the pre-fix build, a malicious `<xs:import schemaLocation="file://…canary">` echoed the fixture's contents to stderr; post-fix stderr contains no file contents (the file is never opened).

## Residual risk / notes

- The fix refuses **all** external schema resolution. Legitimately loading a trusted external/split XSD is not supported; if needed later, it should be an explicit, off-by-default, documented-as-unsafe opt-in (future work — deliberately out of scope here).
- Post-fix, a blocked resolution may still surface the attacker-supplied *URL string* (not file contents) in a libxml diagnostic; that is data the caller already provided, not disclosure.
- The loader is process-global (libxml2's only mechanism for the schema path). Within a DuckDB process this extension is the libxml2 consumer; the loader is left installed (fail-closed) rather than restored on unload to avoid a race that could reopen the hole.
- Scope is the XXE hardening only; the `#115` correctness/usability items are intentionally not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjVKQED5RRjQzArQZA8X4n
