### PR TITLE
test: NULL-safe SAX/DOM equivalence in github_issue_77 (fixes duckdb-main canary)

### DIFF
--- a/test/sql/github_issue_77_sax_edge_cases.test
+++ b/test/sql/github_issue_77_sax_edge_cases.test
@@ -31,10 +31,13 @@ FROM read_xml('test/xml/sax_mixed_order.xml', record_element:='record', maximum_
 ----
 3	true	deep	true
 
-# SAX <-> DOM equivalence on the full ordered list
+# SAX <-> DOM equivalence on the full ordered list.
+# IS NOT DISTINCT FROM (not =) so the comparison is NULL-safe: the item structs carry NULL
+# `nested` fields, and DuckDB's nested-type = propagates NULL (NULL = NULL -> NULL), which
+# would make a bare `=` yield NULL instead of true (fails on duckdb main).
 query I
 SELECT (SELECT item FROM read_xml('test/xml/sax_mixed_order.xml', record_element:='record', maximum_file_size:=1))
-     = (SELECT item FROM read_xml('test/xml/sax_mixed_order.xml', record_element:='record'));
+     IS NOT DISTINCT FROM (SELECT item FROM read_xml('test/xml/sax_mixed_order.xml', record_element:='record'));
 ----
 true
 


### PR DESCRIPTION
The `github_issue_77_sax_edge_cases.test:35` equivalence check compares two lists of structs whose `nested` field is NULL with a bare `=`. duckdb `main` made nested-type equality SQL-correct (`NULL = NULL -> NULL`), so the comparison now yields `NULL` instead of `true` — failing the `duckdb-next-build` (duckdb main) canary on **every** PR. `IS NOT DISTINCT FROM` is NULL-safe and passes on both v1.5.4 and main. Verified locally on v1.5.4 (30 assertions). One-line test fix.