### PR TITLE
feat: multi-file parallelism for read_xml/read_html, order-preserving (#72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ A comprehensive XML and HTML processing extension for DuckDB that enables SQL-na
 - Automatic fallback: DOM for small files, SAX for large files
 - Controlled by ``streaming`` parameter (default: true)
 
+### ⚡ **Multi-File Parallelism**
+- ``read_xml`` / ``read_html`` (and the ``_objects`` variants) process a glob or list of
+  files across threads — one worker per file
+- **Order-preserving**: output stays in file order regardless of thread count (DuckDB
+  batch-index reassembly), so results are deterministic
+- Glob matches are sorted lexicographically for stable, filesystem-independent order;
+  an explicit list of paths keeps the order you provide
+- Single-file reads are unchanged (one file → one worker → the existing serial path)
+
 ### 🛠 **Production Ready**
 - Built on libxml2 for robust parsing
 - Comprehensive error handling

--- a/src/include/xml_reader_functions.hpp
+++ b/src/include/xml_reader_functions.hpp
@@ -4,6 +4,8 @@
 #include "xml_sax_reader.hpp"
 #include "xml_schema_inference.hpp"
 
+#include <mutex>
+
 namespace duckdb {
 
 // Parse mode for document reading
@@ -31,6 +33,13 @@ private:
 	static void ReadDocumentObjectsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static void ReadDocumentFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static unique_ptr<GlobalTableFunctionState> ReadDocumentInit(ClientContext &context, TableFunctionInitInput &input);
+	// Per-thread state + batch-index tagging for order-preserving multi-file parallelism (issue #72).
+	// Shared by all four read_xml/read_html(/_objects) table functions.
+	static unique_ptr<LocalTableFunctionState> ReadDocumentInitLocal(ExecutionContext &context,
+	                                                                 TableFunctionInitInput &input,
+	                                                                 GlobalTableFunctionState *global_state);
+	static OperatorPartitionData ReadDocumentGetPartitionData(ClientContext &context,
+	                                                          TableFunctionGetPartitionInput &input);
 
 	// Public XML functions (delegate to internal functions)
 	static void ReadXMLObjectsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
@@ -120,16 +129,55 @@ struct XMLReadFunctionData : public TableFunctionData {
 	bool union_by_name = false;
 };
 
+// Shared, read-only-after-init state plus a mutex-guarded file dispatcher. All per-file
+// cursor state lives in XMLReadLocalState (below), so each worker thread can process a
+// different file concurrently. See issue #72.
 struct XMLReadGlobalState : public GlobalTableFunctionState {
-	idx_t file_index = 0;
 	vector<string> files;
+
+	idx_t MaxThreads() const override {
+		// One worker per file; a single-file read stays single-threaded (behaviour unchanged,
+		// including the 2-4 GiB whole-document path). DuckDB caps this to the available threads.
+		return files.empty() ? 1 : files.size();
+	}
+
+	// Hand the next file index to a worker, or INVALID_INDEX once the work list is exhausted.
+	idx_t ClaimNextFile() {
+		std::lock_guard<std::mutex> guard(file_lock);
+		if (next_file_index >= files.size()) {
+			return DConstants::INVALID_INDEX;
+		}
+		return next_file_index++;
+	}
+
+private:
+	std::mutex file_lock;
+	idx_t next_file_index = 0;
+};
+
+// Per-worker cursor over one file at a time. A worker claims a file from the global
+// dispatcher, emits at most ONE file's rows per output chunk (partial chunks at file
+// boundaries are expected), and tags each chunk with a batch index so DuckDB's
+// order-preserving reassembly restores glob/file order under parallel execution.
+struct XMLReadLocalState : public LocalTableFunctionState {
+	// Batch index layout: high bits = file index (glob order), low bits = chunk-within-file.
+	// FILE_SHIFT gives 2^32 chunks/file and 2^32 files — both far beyond any real input
+	// (2^32 chunks x 2048 rows would need ~10^13 rows in a <=4 GiB file). Keeps batch indices
+	// strictly ordered by (file_index, chunk), i.e. exactly glob/file order.
+	static constexpr idx_t FILE_SHIFT = 32;
+
+	idx_t file_index = DConstants::INVALID_INDEX; // file this worker is processing / last processed
+	string current_filename;                      // name of that file (per-file value source, never the global cursor)
+	idx_t chunk_counter = 0;                      // within-file index for the NEXT produced chunk
+	idx_t last_batch_index = 0; // batch index of the most recent chunk (get_partition_data returns this)
+	bool have_file = false;     // a file is claimed and being processed
+	bool file_loaded = false;   // per-file resources are initialized
 
 	// Lazy DOM iteration state
 	XMLDocRAII current_doc;                  // DOM stays alive across scan calls
 	std::vector<xmlNodePtr> record_elements; // Pointers into DOM; valid only while current_doc is alive
 	idx_t current_record_index = 0;          // Position in record_elements
 	int remaining_depth = 0;                 // For extraction depth calculation
-	bool file_loaded = false;
 
 	// SAX streaming state (used when streaming=true and file exceeds maximum_file_size)
 	bool use_sax = false;
@@ -140,15 +188,29 @@ struct XMLReadGlobalState : public GlobalTableFunctionState {
 	xmlSAXHandler sax_handler;                             // SAX handler (must outlive parser context)
 	std::vector<SAXRecordAccumulator> sax_pending_records; // Records completed during current chunk
 
-	~XMLReadGlobalState() {
+	~XMLReadLocalState() {
 		if (sax_parser_ctx) {
 			xmlFreeParserCtxt(sax_parser_ctx);
 			sax_parser_ctx = nullptr;
 		}
 	}
 
-	idx_t MaxThreads() const override {
-		return 1; // Single-threaded for now
+	// Release all per-file resources (when a file is finished or skipped). Keeps file_index /
+	// last_batch_index so a just-produced chunk can still be tagged by get_partition_data.
+	void ResetFileResources() {
+		current_doc = XMLDocRAII();
+		record_elements.clear();
+		current_record_index = 0;
+		if (sax_parser_ctx) {
+			xmlFreeParserCtxt(sax_parser_ctx);
+			sax_parser_ctx = nullptr;
+		}
+		sax_accumulator.reset();
+		sax_ctx.reset();
+		sax_file_handle.reset();
+		sax_pending_records.clear();
+		use_sax = false;
+		file_loaded = false;
 	}
 };
 

--- a/src/xml_reader_functions.cpp
+++ b/src/xml_reader_functions.cpp
@@ -4,6 +4,7 @@
 #include "xml_types.hpp"
 #include "duckdb_compat.hpp"
 #include "duckdb/function/table_function.hpp"
+#include "duckdb/execution/partition_info.hpp" // OperatorPartitionData (batch-index tagging, issue #72)
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -13,6 +14,8 @@
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
 #include "duckdb/function/scalar/strftime_format.hpp"
+
+#include <algorithm>
 
 namespace {
 
@@ -256,8 +259,17 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentObjectsBind(ClientConte
 	for (const auto &pattern : file_patterns) {
 		auto glob_result = fs.Glob(pattern, nullptr);
 		// Extract file paths from OpenFileInfo results
+		// Sort each glob's matches lexicographically for deterministic, filesystem-independent
+		// order (matching read_csv). This is the order preserved across threads under multi-file
+		// parallelism (issue #72). Explicitly listed paths — each its own single-match pattern —
+		// keep the user-provided order.
+		vector<string> matched;
 		for (const auto &file_info : glob_result) {
-			result->files.push_back(file_info.path);
+			matched.push_back(file_info.path);
+		}
+		std::sort(matched.begin(), matched.end());
+		for (auto &matched_path : matched) {
+			result->files.push_back(std::move(matched_path));
 		}
 	}
 
@@ -300,10 +312,25 @@ unique_ptr<GlobalTableFunctionState> XMLReaderFunctions::ReadDocumentInit(Client
 	auto result = make_uniq<XMLReadGlobalState>();
 	auto &bind_data = input.bind_data->Cast<XMLReadFunctionData>();
 
+	// Shared work list only; per-file cursor state lives in each worker's local state.
 	result->files = bind_data.files;
-	result->file_index = 0;
 
 	return std::move(result);
+}
+
+unique_ptr<LocalTableFunctionState> XMLReaderFunctions::ReadDocumentInitLocal(ExecutionContext &context,
+                                                                              TableFunctionInitInput &input,
+                                                                              GlobalTableFunctionState *global_state) {
+	// Each worker gets its own cursor; it claims its first file lazily on the first scan call.
+	return make_uniq<XMLReadLocalState>();
+}
+
+OperatorPartitionData XMLReaderFunctions::ReadDocumentGetPartitionData(ClientContext &context,
+                                                                       TableFunctionGetPartitionInput &input) {
+	// Tag the just-produced chunk with the batch index computed at chunk finalization. DuckDB
+	// only calls this for non-empty chunks, so last_batch_index always refers to a real chunk.
+	auto &lstate = input.local_state->Cast<XMLReadLocalState>();
+	return OperatorPartitionData(lstate.last_batch_index);
 }
 
 unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &context, TableFunctionBindInput &input,
@@ -348,8 +375,17 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 	for (const auto &pattern : file_patterns) {
 		auto glob_result = fs.Glob(pattern, nullptr);
 		// Extract file paths from OpenFileInfo results
+		// Sort each glob's matches lexicographically for deterministic, filesystem-independent
+		// order (matching read_csv). This is the order preserved across threads under multi-file
+		// parallelism (issue #72). Explicitly listed paths — each its own single-match pattern —
+		// keep the user-provided order.
+		vector<string> matched;
 		for (const auto &file_info : glob_result) {
-			result->files.push_back(file_info.path);
+			matched.push_back(file_info.path);
+		}
+		std::sort(matched.begin(), matched.end());
+		for (auto &matched_path : matched) {
+			result->files.push_back(std::move(matched_path));
 		}
 	}
 
@@ -697,18 +733,28 @@ void XMLReaderFunctions::ReadDocumentObjectsFunction(ClientContext &context, Tab
                                                      DataChunk &output) {
 	auto &bind_data = data_p.bind_data->Cast<XMLReadFunctionData>();
 	auto &gstate = data_p.global_state->Cast<XMLReadGlobalState>();
-
-	if (gstate.file_index >= gstate.files.size()) {
-		// No more files to process
-		return;
-	}
+	auto &lstate = data_p.local_state->Cast<XMLReadLocalState>();
 
 	auto &fs = FileSystem::GetFileSystem(context);
 	idx_t output_idx = 0;
 	const bool is_html = (bind_data.parse_mode == ParseMode::HTML);
 
-	while (output_idx < STANDARD_VECTOR_SIZE && gstate.file_index < gstate.files.size()) {
-		const auto &filename = gstate.files[gstate.file_index++];
+	// _objects yields exactly one row (the whole document) per file. Under multi-file
+	// parallelism each worker claims one file, emits its single row as one chunk, and tags it
+	// with the file's batch index so output stays in glob order.
+	while (output_idx < STANDARD_VECTOR_SIZE) {
+		if (!lstate.have_file) {
+			idx_t claimed = gstate.ClaimNextFile();
+			if (claimed == DConstants::INVALID_INDEX) {
+				break; // no more work for this worker
+			}
+			lstate.file_index = claimed;
+			lstate.current_filename = gstate.files[claimed];
+			lstate.chunk_counter = 0;
+			lstate.have_file = true;
+		}
+		const auto &filename = lstate.current_filename;
+		bool emitted = false;
 
 		try {
 			// Check file size
@@ -720,47 +766,50 @@ void XMLReaderFunctions::ReadDocumentObjectsFunction(ClientContext &context, Tab
 					throw InvalidInputException("File %s exceeds maximum size limit (%llu bytes)", filename,
 					                            bind_data.max_file_size);
 				}
-				continue; // Skip this file
-			}
-
-			// Read file content
-			string content;
-			content.resize(file_size);
-			ReadFileFully(*file_handle, (char *)content.data(), file_size);
-
-			// Validate content based on mode
-			if (is_html) {
-				// HTML mode: be lenient, allow empty files
-				if (content.empty()) {
-					if (bind_data.ignore_errors) {
-						continue; // Skip empty file
-					} else {
-						content = "<html></html>"; // Minimal valid HTML
-					}
-				}
+				// Skip this file (fall through to claim the next one)
 			} else {
-				// XML mode: strict validation
-				auto validity = XMLUtils::CheckXML(content);
-				if (validity == XMLValidity::ResourceError) {
-					ThrowLibxmlOutOfMemory(filename);
-				}
-				if (validity != XMLValidity::Valid) {
-					if (bind_data.ignore_errors) {
-						continue; // Skip this invalid file
-					} else {
-						throw InvalidInputException("File %s contains invalid XML", filename);
+				// Read file content
+				string content;
+				content.resize(file_size);
+				ReadFileFully(*file_handle, (char *)content.data(), file_size);
+
+				bool valid = true;
+				// Validate content based on mode
+				if (is_html) {
+					// HTML mode: be lenient, allow empty files
+					if (content.empty()) {
+						if (bind_data.ignore_errors) {
+							valid = false; // Skip empty file
+						} else {
+							content = "<html></html>"; // Minimal valid HTML
+						}
+					}
+				} else {
+					// XML mode: strict validation
+					auto validity = XMLUtils::CheckXML(content);
+					if (validity == XMLValidity::ResourceError) {
+						ThrowLibxmlOutOfMemory(filename);
+					}
+					if (validity != XMLValidity::Valid) {
+						if (bind_data.ignore_errors) {
+							valid = false; // Skip this invalid file
+						} else {
+							throw InvalidInputException("File %s contains invalid XML", filename);
+						}
 					}
 				}
-			}
 
-			// Set output values based on schema
-			idx_t col_idx = 0;
-			if (bind_data.include_filename) {
-				output.data[col_idx++].SetValue(output_idx, Value(filename));
+				if (valid) {
+					// Set output values based on schema
+					idx_t col_idx = 0;
+					if (bind_data.include_filename) {
+						output.data[col_idx++].SetValue(output_idx, Value(filename));
+					}
+					output.data[col_idx++].SetValue(output_idx, Value(content));
+					output_idx++;
+					emitted = true;
+				}
 			}
-			output.data[col_idx++].SetValue(output_idx, Value(content));
-			output_idx++;
-
 		} catch (const OutOfMemoryException &) {
 			throw;
 		} catch (const Exception &e) {
@@ -769,6 +818,15 @@ void XMLReaderFunctions::ReadDocumentObjectsFunction(ClientContext &context, Tab
 			}
 			// Skip this file and continue
 		}
+
+		// This file is fully handled; claim the next on the following call.
+		lstate.have_file = false;
+		if (emitted) {
+			lstate.last_batch_index = (lstate.file_index << XMLReadLocalState::FILE_SHIFT) | lstate.chunk_counter;
+			lstate.chunk_counter++;
+			break; // one file (one row) per chunk keeps batch indices ordered
+		}
+		// Skipped file produced no row: keep claiming without returning an empty chunk.
 	}
 
 	CompatSetOutputCardinality(output, output_idx);
@@ -795,22 +853,34 @@ static void EmitRow(DataChunk &output, idx_t output_idx, const std::vector<Value
 void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &bind_data = data_p.bind_data->Cast<XMLReadFunctionData>();
 	auto &gstate = data_p.global_state->Cast<XMLReadGlobalState>();
-
-	if (gstate.file_index >= gstate.files.size()) {
-		return; // No more files to process
-	}
+	auto &lstate = data_p.local_state->Cast<XMLReadLocalState>();
 
 	auto &fs = FileSystem::GetFileSystem(context);
 	idx_t output_idx = 0;
 	const bool is_html = (bind_data.parse_mode == ParseMode::HTML);
 	const auto &schema_options = bind_data.schema_options;
 
-	while (output_idx < STANDARD_VECTOR_SIZE && gstate.file_index < gstate.files.size()) {
-		const auto &filename = gstate.files[gstate.file_index];
+	while (output_idx < STANDARD_VECTOR_SIZE) {
+		// Ensure this worker owns a file; claim the next one otherwise.
+		if (!lstate.have_file) {
+			idx_t claimed = gstate.ClaimNextFile();
+			if (claimed == DConstants::INVALID_INDEX) {
+				break; // no more work for this worker
+			}
+			lstate.file_index = claimed;
+			lstate.current_filename = gstate.files[claimed];
+			lstate.chunk_counter = 0;
+			lstate.have_file = true;
+			lstate.file_loaded = false;
+		}
+
+		// Per-file value source: the file THIS worker claimed, never the global cursor.
+		const auto &filename = lstate.current_filename;
+		bool file_done = false;
 
 		try {
 			// Load file if not already loaded
-			if (!gstate.file_loaded) {
+			if (!lstate.file_loaded) {
 				auto file_handle = fs.OpenFile(filename, FileFlags::FILE_FLAGS_READ);
 				auto file_size = fs.GetFileSize(*file_handle);
 
@@ -830,16 +900,18 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 						throw InvalidInputException("File %s exceeds maximum size limit (%llu bytes)", filename,
 						                            bind_data.max_file_size);
 					}
-					gstate.file_index++;
+					// Skip this file: release and claim the next one without emitting a chunk.
+					lstate.ResetFileResources();
+					lstate.have_file = false;
 					continue;
 				}
 
-				gstate.use_sax = use_sax;
+				lstate.use_sax = use_sax;
 
 				if (use_sax) {
 					// SAX mode: initialize push parser for incremental streaming
-					gstate.sax_accumulator = make_uniq<SAXRecordAccumulator>();
-					gstate.sax_accumulator->namespace_mode = schema_options.namespaces;
+					lstate.sax_accumulator = make_uniq<SAXRecordAccumulator>();
+					lstate.sax_accumulator->namespace_mode = schema_options.namespaces;
 
 					// Configure record tag matching
 					if (!schema_options.record_element.empty()) {
@@ -847,31 +919,31 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 						if (tag.size() >= 2 && tag[0] == '/' && tag[1] == '/') {
 							tag = tag.substr(2);
 						}
-						gstate.sax_accumulator->record_tag = tag;
+						lstate.sax_accumulator->record_tag = tag;
 					}
 
-					gstate.sax_ctx = make_uniq<SAXCallbackContext>();
-					gstate.sax_ctx->accumulator = gstate.sax_accumulator.get();
-					gstate.sax_ctx->max_rows = 0; // No limit per chunk
-					gstate.sax_ctx->rows_completed = 0;
-					gstate.sax_ctx->stop_parsing = false;
-					gstate.sax_ctx->completed_records = &gstate.sax_pending_records;
-					gstate.sax_ctx->preserve_whitespace = bind_data.schema_options.preserve_whitespace;
+					lstate.sax_ctx = make_uniq<SAXCallbackContext>();
+					lstate.sax_ctx->accumulator = lstate.sax_accumulator.get();
+					lstate.sax_ctx->max_rows = 0; // No limit per chunk
+					lstate.sax_ctx->rows_completed = 0;
+					lstate.sax_ctx->stop_parsing = false;
+					lstate.sax_ctx->completed_records = &lstate.sax_pending_records;
+					lstate.sax_ctx->preserve_whitespace = bind_data.schema_options.preserve_whitespace;
 
-					gstate.sax_handler = SAXStreamReader::CreateSAXHandler();
+					lstate.sax_handler = SAXStreamReader::CreateSAXHandler();
 					// Fail-closed entity loader: refuse external DTD/entity fetch during streaming parse.
 					XMLUtils::EnsureSecureParsing();
-					gstate.sax_parser_ctx = xmlCreatePushParserCtxt(&gstate.sax_handler, gstate.sax_ctx.get(), nullptr,
+					lstate.sax_parser_ctx = xmlCreatePushParserCtxt(&lstate.sax_handler, lstate.sax_ctx.get(), nullptr,
 					                                                0, filename.c_str());
-					if (!gstate.sax_parser_ctx) {
+					if (!lstate.sax_parser_ctx) {
 						throw IOException("Could not create SAX push parser for '%s'", filename);
 					}
-					xmlCtxtUseOptions(gstate.sax_parser_ctx,
+					xmlCtxtUseOptions(lstate.sax_parser_ctx,
 					                  XML_PARSE_RECOVER | XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_NONET);
 
-					gstate.sax_file_handle = std::move(file_handle);
-					gstate.sax_pending_records.clear();
-					gstate.file_loaded = true;
+					lstate.sax_file_handle = std::move(file_handle);
+					lstate.sax_pending_records.clear();
+					lstate.file_loaded = true;
 				} else {
 					// DOM mode: read file content and build DOM
 					string content;
@@ -881,15 +953,15 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 					// Parse DOM — DOM makes its own copy, so content string can be freed.
 					// This single parse is also the validity check: a separate pre-validation
 					// pass would parse the document twice and could not see why a parse failed.
-					gstate.current_doc = XMLDocRAII(content, is_html);
+					lstate.current_doc = XMLDocRAII(content, is_html);
 
-					if (!gstate.current_doc.IsValid()) {
-						if (gstate.current_doc.HadResourceError()) {
+					if (!lstate.current_doc.IsValid()) {
+						if (lstate.current_doc.HadResourceError()) {
 							ThrowLibxmlOutOfMemory(filename);
 						}
 						if (bind_data.ignore_errors) {
-							gstate.current_doc = XMLDocRAII();
-							gstate.file_index++;
+							lstate.ResetFileResources();
+							lstate.have_file = false;
 							continue;
 						}
 						if (is_html) {
@@ -898,33 +970,33 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 						throw InvalidInputException("File %s contains invalid XML", filename);
 					}
 
-					xmlNodePtr root = xmlDocGetRootElement(gstate.current_doc.doc);
+					xmlNodePtr root = xmlDocGetRootElement(lstate.current_doc.doc);
 					if (!root) {
 						if (bind_data.ignore_errors) {
-							gstate.current_doc = XMLDocRAII();
-							gstate.file_index++;
+							lstate.ResetFileResources();
+							lstate.have_file = false;
 							continue;
 						}
 						throw InvalidInputException("File %s has no root element", filename);
 					}
 
 					// Find record elements in the DOM
-					gstate.record_elements =
-					    XMLSchemaInference::IdentifyRecordElements(gstate.current_doc, root, schema_options);
+					lstate.record_elements =
+					    XMLSchemaInference::IdentifyRecordElements(lstate.current_doc, root, schema_options);
 
 					// Calculate remaining depth for inferred schema extraction
 					int effective_depth = schema_options.max_depth;
 					if (effective_depth > 20 || effective_depth < 0) {
 						effective_depth = 20;
 					}
-					gstate.remaining_depth = effective_depth - 2;
+					lstate.remaining_depth = effective_depth - 2;
 
-					gstate.current_record_index = 0;
-					gstate.file_loaded = true;
+					lstate.current_record_index = 0;
+					lstate.file_loaded = true;
 				}
 			}
 
-			if (gstate.use_sax) {
+			if (lstate.use_sax) {
 				// SAX streaming: feed chunks until we have enough records or EOF
 				constexpr idx_t SAX_CHUNK_SIZE = 65536;
 				char sax_buffer[SAX_CHUNK_SIZE];
@@ -932,8 +1004,8 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 
 				while (output_idx < STANDARD_VECTOR_SIZE) {
 					// First, emit any pending completed records
-					while (!gstate.sax_pending_records.empty() && output_idx < STANDARD_VECTOR_SIZE) {
-						auto &record = gstate.sax_pending_records.front();
+					while (!lstate.sax_pending_records.empty() && output_idx < STANDARD_VECTOR_SIZE) {
+						auto &record = lstate.sax_pending_records.front();
 
 						auto row = SAXStreamReader::AccumulatorToRow(
 						    record, bind_data.column_names, bind_data.column_types, schema_options,
@@ -942,7 +1014,7 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 						EmitRow(output, output_idx, row, bind_data.include_filename, filename);
 
 						output_idx++;
-						gstate.sax_pending_records.erase(gstate.sax_pending_records.begin());
+						lstate.sax_pending_records.erase(lstate.sax_pending_records.begin());
 					}
 
 					// If we've filled the output, stop
@@ -951,50 +1023,42 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 					}
 
 					// Feed another chunk to the parser
-					auto bytes_read = gstate.sax_file_handle->Read(sax_buffer, SAX_CHUNK_SIZE);
+					auto bytes_read = lstate.sax_file_handle->Read(sax_buffer, SAX_CHUNK_SIZE);
 					if (bytes_read == 0) {
 						// EOF — finalize parser
-						xmlParseChunk(gstate.sax_parser_ctx, nullptr, 0, 1);
+						xmlParseChunk(lstate.sax_parser_ctx, nullptr, 0, 1);
 						file_exhausted = true;
 						break;
 					}
 
 					int parse_result =
-					    xmlParseChunk(gstate.sax_parser_ctx, sax_buffer, static_cast<int>(bytes_read), 0);
+					    xmlParseChunk(lstate.sax_parser_ctx, sax_buffer, static_cast<int>(bytes_read), 0);
 					if (parse_result != 0 && !bind_data.ignore_errors) {
 						throw IOException("SAX parsing error in file '%s'", filename);
 					}
 				}
 
 				// Emit any remaining pending records after EOF
-				while (!gstate.sax_pending_records.empty() && output_idx < STANDARD_VECTOR_SIZE) {
-					auto &record = gstate.sax_pending_records.front();
+				while (!lstate.sax_pending_records.empty() && output_idx < STANDARD_VECTOR_SIZE) {
+					auto &record = lstate.sax_pending_records.front();
 					auto row = SAXStreamReader::AccumulatorToRow(record, bind_data.column_names, bind_data.column_types,
 					                                             schema_options, bind_data.column_datetime_formats,
 					                                             bind_data.inferred_schema);
 
 					EmitRow(output, output_idx, row, bind_data.include_filename, filename);
 					output_idx++;
-					gstate.sax_pending_records.erase(gstate.sax_pending_records.begin());
+					lstate.sax_pending_records.erase(lstate.sax_pending_records.begin());
 				}
 
 				// Check if file is done and all records emitted
-				if (file_exhausted && gstate.sax_pending_records.empty()) {
-					if (gstate.sax_parser_ctx) {
-						xmlFreeParserCtxt(gstate.sax_parser_ctx);
-						gstate.sax_parser_ctx = nullptr;
-					}
-					gstate.sax_accumulator.reset();
-					gstate.sax_ctx.reset();
-					gstate.sax_file_handle.reset();
-					gstate.file_loaded = false;
-					gstate.file_index++;
+				if (file_exhausted && lstate.sax_pending_records.empty()) {
+					file_done = true;
 				}
 			} else {
 				// DOM extraction: extract records one at a time
-				while (gstate.current_record_index < gstate.record_elements.size() &&
+				while (lstate.current_record_index < lstate.record_elements.size() &&
 				       output_idx < STANDARD_VECTOR_SIZE) {
-					xmlNodePtr record = gstate.record_elements[gstate.current_record_index];
+					xmlNodePtr record = lstate.record_elements[lstate.current_record_index];
 
 					std::vector<Value> row;
 					if (bind_data.has_explicit_schema) {
@@ -1003,21 +1067,18 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 						                                                        bind_data.column_datetime_formats);
 					} else {
 						row = XMLSchemaInference::ExtractSingleRecord(record, bind_data.inferred_schema,
-						                                              gstate.remaining_depth, schema_options);
+						                                              lstate.remaining_depth, schema_options);
 					}
 
 					EmitRow(output, output_idx, row, bind_data.include_filename, filename);
 
 					output_idx++;
-					gstate.current_record_index++;
+					lstate.current_record_index++;
 				}
 
 				// Check if we've finished all records from this file
-				if (gstate.current_record_index >= gstate.record_elements.size()) {
-					gstate.current_doc = XMLDocRAII();
-					gstate.record_elements.clear();
-					gstate.file_loaded = false;
-					gstate.file_index++;
+				if (lstate.current_record_index >= lstate.record_elements.size()) {
+					file_done = true;
 				}
 			}
 
@@ -1027,22 +1088,32 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 			if (!bind_data.ignore_errors) {
 				throw;
 			}
-			// Skip this file and continue
-			gstate.current_doc = XMLDocRAII();
-			gstate.record_elements.clear();
-			if (gstate.sax_parser_ctx) {
-				xmlFreeParserCtxt(gstate.sax_parser_ctx);
-				gstate.sax_parser_ctx = nullptr;
-			}
-			gstate.sax_accumulator.reset();
-			gstate.sax_ctx.reset();
-			gstate.sax_file_handle.reset();
-			gstate.sax_pending_records.clear();
-			gstate.file_loaded = false;
-			gstate.file_index++;
+			// Skip the rest of this file and claim the next one.
+			lstate.ResetFileResources();
+			lstate.have_file = false;
+			continue;
 		}
 
+		if (file_done) {
+			// File fully consumed. One file (with rows) per output chunk keeps batch indices
+			// ordered, so if we produced rows we tag and return this chunk now; an empty file
+			// produced nothing, so keep claiming rather than returning a spurious 0-row chunk
+			// (which DuckDB reads as end-of-data for this worker).
+			lstate.ResetFileResources();
+			lstate.have_file = false;
+			if (output_idx > 0) {
+				lstate.last_batch_index = (lstate.file_index << XMLReadLocalState::FILE_SHIFT) | lstate.chunk_counter;
+				lstate.chunk_counter++;
+				break;
+			}
+			continue;
+		}
+
+		// File not finished but the output chunk is full: return it; the same file resumes on
+		// the next call (its next chunk gets the following within-file batch index).
 		if (output_idx >= STANDARD_VECTOR_SIZE) {
+			lstate.last_batch_index = (lstate.file_index << XMLReadLocalState::FILE_SHIFT) | lstate.chunk_counter;
+			lstate.chunk_counter++;
 			break;
 		}
 	}
@@ -1093,8 +1164,17 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLObjectsBind(ClientContext &c
 	for (const auto &pattern : file_patterns) {
 		auto glob_result = fs.Glob(pattern, nullptr);
 		// Extract file paths from OpenFileInfo results
+		// Sort each glob's matches lexicographically for deterministic, filesystem-independent
+		// order (matching read_csv). This is the order preserved across threads under multi-file
+		// parallelism (issue #72). Explicitly listed paths — each its own single-match pattern —
+		// keep the user-provided order.
+		vector<string> matched;
 		for (const auto &file_info : glob_result) {
-			result->files.push_back(file_info.path);
+			matched.push_back(file_info.path);
+		}
+		std::sort(matched.begin(), matched.end());
+		for (auto &matched_path : matched) {
+			result->files.push_back(std::move(matched_path));
 		}
 	}
 
@@ -1131,8 +1211,8 @@ unique_ptr<GlobalTableFunctionState> XMLReaderFunctions::ReadXMLObjectsInit(Clie
 	auto result = make_uniq<XMLReadGlobalState>();
 	auto &bind_data = input.bind_data->Cast<XMLReadFunctionData>();
 
+	// Shared work list only; per-file cursor state lives in each worker's local state.
 	result->files = bind_data.files;
-	result->file_index = 0;
 
 	return std::move(result);
 }
@@ -1140,17 +1220,27 @@ unique_ptr<GlobalTableFunctionState> XMLReaderFunctions::ReadXMLObjectsInit(Clie
 void XMLReaderFunctions::ReadXMLObjectsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &bind_data = data_p.bind_data->Cast<XMLReadFunctionData>();
 	auto &gstate = data_p.global_state->Cast<XMLReadGlobalState>();
-
-	if (gstate.file_index >= gstate.files.size()) {
-		// No more files to process
-		return;
-	}
+	auto &lstate = data_p.local_state->Cast<XMLReadLocalState>();
 
 	auto &fs = FileSystem::GetFileSystem(context);
 	idx_t output_idx = 0;
 
-	while (output_idx < STANDARD_VECTOR_SIZE && gstate.file_index < gstate.files.size()) {
-		const auto &filename = gstate.files[gstate.file_index++];
+	// One row (the whole document) per file. Under multi-file parallelism each worker claims
+	// one file, emits its single row as one chunk, and tags it with the file's batch index so
+	// output stays in glob order.
+	while (output_idx < STANDARD_VECTOR_SIZE) {
+		if (!lstate.have_file) {
+			idx_t claimed = gstate.ClaimNextFile();
+			if (claimed == DConstants::INVALID_INDEX) {
+				break; // no more work for this worker
+			}
+			lstate.file_index = claimed;
+			lstate.current_filename = gstate.files[claimed];
+			lstate.chunk_counter = 0;
+			lstate.have_file = true;
+		}
+		const auto &filename = lstate.current_filename;
+		bool emitted = false;
 
 		try {
 			// Check file size
@@ -1162,39 +1252,38 @@ void XMLReaderFunctions::ReadXMLObjectsFunction(ClientContext &context, TableFun
 					throw InvalidInputException("File %s exceeds maximum size limit (%llu bytes)", filename,
 					                            bind_data.max_file_size);
 				}
-				continue; // Skip this file
-			}
+				// Skip this file (fall through to claim the next)
+			} else {
+				// Read file content
+				string content;
+				content.resize(file_size);
+				ReadFileFully(*file_handle, (char *)content.data(), file_size);
 
-			// Read file content
-			string content;
-			content.resize(file_size);
-			ReadFileFully(*file_handle, (char *)content.data(), file_size);
-
-			// Validate XML
-			auto validity = XMLUtils::CheckXML(content);
-			if (validity == XMLValidity::ResourceError) {
-				ThrowLibxmlOutOfMemory(filename);
-			}
-			if (validity != XMLValidity::Valid) {
-				if (bind_data.ignore_errors) {
-					continue; // Skip this invalid file
+				// Validate XML
+				auto validity = XMLUtils::CheckXML(content);
+				if (validity == XMLValidity::ResourceError) {
+					ThrowLibxmlOutOfMemory(filename);
+				}
+				if (validity != XMLValidity::Valid) {
+					if (!bind_data.ignore_errors) {
+						throw InvalidInputException("File %s contains invalid XML", filename);
+					}
+					// Skip this invalid file
 				} else {
-					throw InvalidInputException("File %s contains invalid XML", filename);
+					// Set output values based on schema
+					idx_t col_idx = 0;
+					if (output.data.size() == 2) {
+						// Both filename and xml columns
+						output.data[col_idx++].SetValue(output_idx, Value(filename));
+						output.data[col_idx++].SetValue(output_idx, Value(content));
+					} else {
+						// Only xml column
+						output.data[col_idx++].SetValue(output_idx, Value(content));
+					}
+					output_idx++;
+					emitted = true;
 				}
 			}
-
-			// Set output values based on schema
-			idx_t col_idx = 0;
-			if (output.data.size() == 2) {
-				// Both filename and xml columns
-				output.data[col_idx++].SetValue(output_idx, Value(filename));
-				output.data[col_idx++].SetValue(output_idx, Value(content));
-			} else {
-				// Only xml column
-				output.data[col_idx++].SetValue(output_idx, Value(content));
-			}
-			output_idx++;
-
 		} catch (const OutOfMemoryException &) {
 			throw;
 		} catch (const Exception &e) {
@@ -1203,6 +1292,14 @@ void XMLReaderFunctions::ReadXMLObjectsFunction(ClientContext &context, TableFun
 			}
 			// Skip this file and continue
 		}
+
+		lstate.have_file = false;
+		if (emitted) {
+			lstate.last_batch_index = (lstate.file_index << XMLReadLocalState::FILE_SHIFT) | lstate.chunk_counter;
+			lstate.chunk_counter++;
+			break; // one file (one row) per chunk keeps batch indices ordered
+		}
+		// Skipped file produced no row: keep claiming without returning an empty chunk.
 	}
 
 	CompatSetOutputCardinality(output, output_idx);
@@ -1246,8 +1343,17 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context,
 	for (const auto &pattern : file_patterns) {
 		auto glob_result = fs.Glob(pattern, nullptr);
 		// Extract file paths from OpenFileInfo results
+		// Sort each glob's matches lexicographically for deterministic, filesystem-independent
+		// order (matching read_csv). This is the order preserved across threads under multi-file
+		// parallelism (issue #72). Explicitly listed paths — each its own single-match pattern —
+		// keep the user-provided order.
+		vector<string> matched;
 		for (const auto &file_info : glob_result) {
-			result->files.push_back(file_info.path);
+			matched.push_back(file_info.path);
+		}
+		std::sort(matched.begin(), matched.end());
+		for (auto &matched_path : matched) {
+			result->files.push_back(std::move(matched_path));
 		}
 	}
 
@@ -2056,6 +2162,8 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_xml_objects_single.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
 	read_xml_objects_single.named_parameters["maximum_file_size"] = LogicalType::BIGINT;
 	read_xml_objects_single.named_parameters["filename"] = LogicalType::BOOLEAN;
+	read_xml_objects_single.init_local = ReadDocumentInitLocal;
+	read_xml_objects_single.get_partition_data = ReadDocumentGetPartitionData;
 	read_xml_objects_set.AddFunction(read_xml_objects_single);
 
 	// Variant 2: Array of strings parameter
@@ -2064,6 +2172,8 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_xml_objects_array.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
 	read_xml_objects_array.named_parameters["maximum_file_size"] = LogicalType::BIGINT;
 	read_xml_objects_array.named_parameters["filename"] = LogicalType::BOOLEAN;
+	read_xml_objects_array.init_local = ReadDocumentInitLocal;
+	read_xml_objects_array.get_partition_data = ReadDocumentGetPartitionData;
 	read_xml_objects_set.AddFunction(read_xml_objects_array);
 
 	loader.RegisterFunction(read_xml_objects_set);
@@ -2100,6 +2210,8 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_xml_single.named_parameters["nullstr"] = LogicalType::ANY;
 	read_xml_single.named_parameters["streaming"] = LogicalType::BOOLEAN;
 	read_xml_single.named_parameters["preserve_whitespace"] = LogicalType::BOOLEAN;
+	read_xml_single.init_local = ReadDocumentInitLocal;
+	read_xml_single.get_partition_data = ReadDocumentGetPartitionData;
 	read_xml_set.AddFunction(read_xml_single);
 
 	// Variant 2: Array of strings parameter
@@ -2132,6 +2244,8 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_xml_array.named_parameters["nullstr"] = LogicalType::ANY;
 	read_xml_array.named_parameters["streaming"] = LogicalType::BOOLEAN;
 	read_xml_array.named_parameters["preserve_whitespace"] = LogicalType::BOOLEAN;
+	read_xml_array.init_local = ReadDocumentInitLocal;
+	read_xml_array.get_partition_data = ReadDocumentGetPartitionData;
 	read_xml_set.AddFunction(read_xml_array);
 
 	loader.RegisterFunction(read_xml_set);
@@ -2167,6 +2281,8 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_html_single.named_parameters["datetime_format"] = LogicalType::ANY; // VARCHAR or LIST(VARCHAR)
 	read_html_single.named_parameters["nullstr"] = LogicalType::ANY;
 	read_html_single.named_parameters["preserve_whitespace"] = LogicalType::BOOLEAN;
+	read_html_single.init_local = ReadDocumentInitLocal;
+	read_html_single.get_partition_data = ReadDocumentGetPartitionData;
 	read_html_set.AddFunction(read_html_single);
 
 	// Variant 2: Array of strings parameter
@@ -2198,6 +2314,8 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_html_array.named_parameters["datetime_format"] = LogicalType::ANY; // VARCHAR or LIST(VARCHAR)
 	read_html_array.named_parameters["nullstr"] = LogicalType::ANY;
 	read_html_array.named_parameters["preserve_whitespace"] = LogicalType::BOOLEAN;
+	read_html_array.init_local = ReadDocumentInitLocal;
+	read_html_array.get_partition_data = ReadDocumentGetPartitionData;
 	read_html_set.AddFunction(read_html_array);
 
 	loader.RegisterFunction(read_html_set);
@@ -2211,6 +2329,8 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_html_objects_single.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
 	read_html_objects_single.named_parameters["maximum_file_size"] = LogicalType::BIGINT;
 	read_html_objects_single.named_parameters["filename"] = LogicalType::BOOLEAN;
+	read_html_objects_single.init_local = ReadDocumentInitLocal;
+	read_html_objects_single.get_partition_data = ReadDocumentGetPartitionData;
 	read_html_objects_set.AddFunction(read_html_objects_single);
 
 	// Variant 2: Array of strings parameter
@@ -2219,6 +2339,8 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_html_objects_array.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
 	read_html_objects_array.named_parameters["maximum_file_size"] = LogicalType::BIGINT;
 	read_html_objects_array.named_parameters["filename"] = LogicalType::BOOLEAN;
+	read_html_objects_array.init_local = ReadDocumentInitLocal;
+	read_html_objects_array.get_partition_data = ReadDocumentGetPartitionData;
 	read_html_objects_set.AddFunction(read_html_objects_array);
 
 	loader.RegisterFunction(read_html_objects_set);

--- a/test/sql/xml_multifile_parallelism.test
+++ b/test/sql/xml_multifile_parallelism.test
@@ -1,0 +1,123 @@
+# name: test/sql/xml_multifile_parallelism.test
+# description: Multi-file read_xml/read_html run across threads, order-preserving (issue #72)
+# group: [sql]
+
+require webbed
+
+# Force the parallel executor so the multi-file path is actually exercised on small inputs,
+# and give it several threads to distribute the files across.
+statement ok
+PRAGMA threads=8;
+
+statement ok
+PRAGMA verify_parallelism;
+
+# preserve_insertion_order is on by default; be explicit — this is the ordering guarantee under test.
+statement ok
+SET preserve_insertion_order=true;
+
+# ---------------------------------------------------------------------------
+# Generate 8 single-line XML files: part_00.xml .. part_07.xml. Each holds three
+# <row> records tagged with its file number (0..7) and a within-file seq (0..2).
+# Glob results are sorted, so the deterministic order is part_00, part_01, ...
+# ---------------------------------------------------------------------------
+statement ok
+COPY (SELECT '<data><row><file>0</file><seq>0</seq></row><row><file>0</file><seq>1</seq></row><row><file>0</file><seq>2</seq></row></data>' AS c) TO '__TEST_DIR__/part_00.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><file>1</file><seq>0</seq></row><row><file>1</file><seq>1</seq></row><row><file>1</file><seq>2</seq></row></data>' AS c) TO '__TEST_DIR__/part_01.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><file>2</file><seq>0</seq></row><row><file>2</file><seq>1</seq></row><row><file>2</file><seq>2</seq></row></data>' AS c) TO '__TEST_DIR__/part_02.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><file>3</file><seq>0</seq></row><row><file>3</file><seq>1</seq></row><row><file>3</file><seq>2</seq></row></data>' AS c) TO '__TEST_DIR__/part_03.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><file>4</file><seq>0</seq></row><row><file>4</file><seq>1</seq></row><row><file>4</file><seq>2</seq></row></data>' AS c) TO '__TEST_DIR__/part_04.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><file>5</file><seq>0</seq></row><row><file>5</file><seq>1</seq></row><row><file>5</file><seq>2</seq></row></data>' AS c) TO '__TEST_DIR__/part_05.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><file>6</file><seq>0</seq></row><row><file>6</file><seq>1</seq></row><row><file>6</file><seq>2</seq></row></data>' AS c) TO '__TEST_DIR__/part_06.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><file>7</file><seq>0</seq></row><row><file>7</file><seq>1</seq></row><row><file>7</file><seq>2</seq></row></data>' AS c) TO '__TEST_DIR__/part_07.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+# ---------------------------------------------------------------------------
+# Multiset parity: the parallel scan returns exactly the rows expected (24 rows;
+# order-independent checksums). Catches dropped/duplicated rows.
+# ---------------------------------------------------------------------------
+query III
+SELECT count(*), sum(file), sum(seq) FROM read_xml('__TEST_DIR__/part_*.xml');
+----
+24	84	24
+
+# ---------------------------------------------------------------------------
+# Order preservation (the #72 guarantee): with the parallel executor forced, the physical
+# result order must still be exact glob order — file 0 rows, then file 1, ... each seq 0,1,2.
+# `nosort` compares rows in returned order (no window operator to muddy it).
+# ---------------------------------------------------------------------------
+query II nosort
+SELECT file, seq FROM read_xml('__TEST_DIR__/part_*.xml');
+----
+0	0
+0	1
+0	2
+1	0
+1	1
+1	2
+2	0
+2	1
+2	2
+3	0
+3	1
+3	2
+4	0
+4	1
+4	2
+5	0
+5	1
+5	2
+6	0
+6	1
+6	2
+7	0
+7	1
+7	2
+
+# The filename pseudo-column must name the file each row actually came from (not the global
+# cursor). Order-independent per-row check — this is the silent-corruption guard.
+query I
+SELECT bool_and(filename LIKE '%part_0' || file || '.xml')
+FROM read_xml('__TEST_DIR__/part_*.xml', filename := true);
+----
+true
+
+# ---------------------------------------------------------------------------
+# read_xml_objects (raw passthrough) also parallelizes order-preserving: one row per file,
+# filenames in glob order.
+# ---------------------------------------------------------------------------
+query I nosort
+SELECT regexp_extract(filename, 'part_0(\d)\.xml', 1)
+FROM read_xml_objects('__TEST_DIR__/part_*.xml', filename := true);
+----
+0
+1
+2
+3
+4
+5
+6
+7
+
+# ---------------------------------------------------------------------------
+# Single-file read is unchanged (one file => one worker => the existing serial path).
+# ---------------------------------------------------------------------------
+query II
+SELECT file, seq FROM read_xml('__TEST_DIR__/part_03.xml') ORDER BY seq;
+----
+3	0
+3	1
+3	2


### PR DESCRIPTION
Closes #72.

`read_xml` / `read_html` (and the `_objects` variants) now process a glob or list of files **across threads — one worker per file** — instead of scanning single-threaded (`MaxThreads()` was hardcoded to 1). Output stays in **file order regardless of thread count**.

## What changed

- **State split.** `XMLReadGlobalState` is now a slim shared state (file list + a mutex-guarded file dispatcher; `MaxThreads() = files.size()`). All per-file cursor state (DOM/SAX resources, record index, `remaining_depth`) moves into a new `XMLReadLocalState`, along with the file each worker owns and its filename. **Per-file values — notably the `filename` pseudo-column — now come from local state, never a shared cursor** (the subtle correctness trap here).
- **Order-preserving via batch index.** All four read functions register `init_local` + `get_partition_data`. Each output chunk carries exactly one file's rows, tagged with a batch index (`file_index << 32 | chunk_within_file`), so DuckDB's batch-index reassembly restores exact glob/file order under parallel execution.
- **Deterministic file order.** Each glob's matches are now sorted lexicographically (matching `read_csv`) — filesystem-independent and stable; this is the order preserved across threads. An explicit list of paths keeps the order you provide.

## Why it's safe

The libxml2 groundwork was already in place: `xmlInitParser()` + the fail-closed entity loader run at extension load, `EnsureSecureParsing()` is `std::call_once`-guarded, and error handling is per-context (#119). So concurrent independent parser contexts are race-free. Single-file reads are unchanged (one file → one worker → the existing serial path, including the 2–4 GiB whole-document path from v2.5.0).

## Verification

- New `test/sql/xml_multifile_parallelism.test` forces the parallel executor (`PRAGMA verify_parallelism`) and asserts **exact glob-order output**, multiset parity, and correct **per-row filename attribution**; plus single-file identity and `_objects` order.
- Full local suite green (**90/90** test files); the parallel test is stable across **25 stress iterations**.
- Empirically confirmed threads=8 output is byte-identical to threads=1.

## Notes / scope

- `parse_*` and `html_extract_tables` operate on single strings and correctly stay `MaxThreads=1` (out of scope).
- `_objects` variants emit one row per file → one chunk per file under multi-file parallelism (correct + order-preserving; I/O-dominated, so the extra chunking is negligible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
