### PR TITLE
feat: sample multiple files for schema inference on multi-file reads (#124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,7 +650,8 @@ read_xml('pattern',
 - **`text_key`**: Key name for text content when elements have mixed content (text + child elements) (default: `'#text'`)
 - **`empty_elements`**: How to handle empty elements: `'object'` (default) returns empty struct, `'null'` returns NULL, `'string'` returns empty string
 - **`namespaces`**: Namespace handling mode: `'strip'` (default) removes namespace prefixes, `'expand'` replaces prefixes with full URIs, `'keep'` preserves prefixes as-is
-- **`union_by_name`**: When reading multiple files, combine columns by name (like DuckDB's `union_by_name` for other formats). Useful when XML files have different schemas (default: false)
+- **`union_by_name`**: When reading multiple files, combine columns by name (like DuckDB's `union_by_name` for other formats). Scans **all** files to build the schema. Useful when files have different schemas and you want every column regardless of how many files there are (default: false)
+- **`sample_files`**: Number of files sampled for schema inference on a multi-file read (default: 8). Sampling a bounded handful — rather than only the first file — makes the inferred schema robust to columns/types that a leading file happens not to exhibit, without opening an entire glob. `sample_files := 1` restores first-file-only inference; `sample_files := -1` samples every file (like `union_by_name`). Ignored when `union_by_name = true` (which always scans all files) or when `columns` is given
 - **`streaming`**: Enable SAX-based streaming for files exceeding `maximum_file_size`. When true (default), oversized files are parsed using SAX instead of raising an error. SAX processes XML as a stream without building a DOM tree, reducing peak memory to proportional to a single record. Set to false to error on oversized files (original behavior). Only supports simple tag names for `record_element`. Not available for HTML (default: true)
 
 ### 🔍 **XPath Support**

--- a/src/include/xml_reader_functions.hpp
+++ b/src/include/xml_reader_functions.hpp
@@ -127,6 +127,12 @@ struct XMLReadFunctionData : public TableFunctionData {
 
 	// Union by name - combine files with different schemas
 	bool union_by_name = false;
+
+	// Number of files sampled for schema inference on the default (non-union_by_name) multi-file
+	// path. Sampling a bounded handful — rather than only the first file — makes the inferred
+	// schema robust to columns/types a leading file happens not to exhibit, without the cost of
+	// opening an entire glob. `sample_files := -1` samples every file; values < 1 are treated as 1.
+	int64_t schema_sample_files = 8;
 };
 
 // Shared, read-only-after-init state plus a mutex-guarded file dispatcher. All per-file

--- a/src/xml_reader_functions.cpp
+++ b/src/xml_reader_functions.cpp
@@ -408,6 +408,8 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 			result->include_filename = kv.second.GetValue<bool>();
 		} else if (kv.first == "union_by_name") {
 			result->union_by_name = kv.second.GetValue<bool>();
+		} else if (kv.first == "sample_files") {
+			result->schema_sample_files = kv.second.GetValue<int64_t>();
 		} else if (kv.first == "maximum_file_size") {
 			result->max_file_size = kv.second.GetValue<idx_t>();
 			schema_options.maximum_file_size = result->max_file_size;
@@ -581,12 +583,17 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 		try {
 			// Determine which files to scan for schema inference
 			std::vector<std::string> files_to_scan;
-			if (result->union_by_name) {
-				// Scan all files to build union schema
+			if (result->union_by_name || result->schema_sample_files < 0) {
+				// union_by_name (or sample_files := -1): sample every file for a full union schema
 				files_to_scan = result->files;
 			} else {
-				// Scan only first file
-				files_to_scan.push_back(result->files[0]);
+				// Sample a bounded number of files (default schema_sample_files) so the inferred
+				// schema reflects columns/types beyond the first file, without opening the whole glob.
+				idx_t limit = result->schema_sample_files < 1 ? 1 : static_cast<idx_t>(result->schema_sample_files);
+				idx_t n = MinValue<idx_t>(result->files.size(), limit);
+				for (idx_t i = 0; i < n; i++) {
+					files_to_scan.push_back(result->files[i]);
+				}
 			}
 
 			// Map to track all unique columns and their types across files
@@ -1376,6 +1383,8 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context,
 			result->include_filename = kv.second.GetValue<bool>();
 		} else if (kv.first == "union_by_name") {
 			result->union_by_name = kv.second.GetValue<bool>();
+		} else if (kv.first == "sample_files") {
+			result->schema_sample_files = kv.second.GetValue<int64_t>();
 		} else if (kv.first == "maximum_file_size") {
 			result->max_file_size = kv.second.GetValue<idx_t>();
 			schema_options.maximum_file_size = result->max_file_size;
@@ -1547,12 +1556,17 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context,
 		try {
 			// Determine which files to scan for schema inference
 			std::vector<std::string> files_to_scan;
-			if (result->union_by_name) {
-				// Scan all files to build union schema
+			if (result->union_by_name || result->schema_sample_files < 0) {
+				// union_by_name (or sample_files := -1): sample every file for a full union schema
 				files_to_scan = result->files;
 			} else {
-				// Scan only first file
-				files_to_scan.push_back(result->files[0]);
+				// Sample a bounded number of files (default schema_sample_files) so the inferred
+				// schema reflects columns/types beyond the first file, without opening the whole glob.
+				idx_t limit = result->schema_sample_files < 1 ? 1 : static_cast<idx_t>(result->schema_sample_files);
+				idx_t n = MinValue<idx_t>(result->files.size(), limit);
+				for (idx_t i = 0; i < n; i++) {
+					files_to_scan.push_back(result->files[i]);
+				}
 			}
 
 			// Map to track all unique columns and their types across files
@@ -2198,6 +2212,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_xml_single.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
 	read_xml_single.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_xml_single.named_parameters["sample_size"] = LogicalType::INTEGER;
+	read_xml_single.named_parameters["sample_files"] = LogicalType::BIGINT;
 	read_xml_single.named_parameters["unnest_as"] = LogicalType::VARCHAR; // 'columns' (default) or 'struct' (future)
 	read_xml_single.named_parameters["record_element"] =
 	    LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
@@ -2232,6 +2247,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_xml_array.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
 	read_xml_array.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_xml_array.named_parameters["sample_size"] = LogicalType::INTEGER;
+	read_xml_array.named_parameters["sample_files"] = LogicalType::BIGINT;
 	read_xml_array.named_parameters["unnest_as"] = LogicalType::VARCHAR; // 'columns' (default) or 'struct' (future)
 	read_xml_array.named_parameters["record_element"] =
 	    LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
@@ -2270,6 +2286,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_html_single.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
 	read_html_single.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_html_single.named_parameters["sample_size"] = LogicalType::INTEGER;
+	read_html_single.named_parameters["sample_files"] = LogicalType::BIGINT;
 	read_html_single.named_parameters["unnest_as"] = LogicalType::VARCHAR; // 'columns' (default) or 'struct' (future)
 	read_html_single.named_parameters["record_element"] =
 	    LogicalType::VARCHAR; // XPath or tag name for elements that should be rows
@@ -2303,6 +2320,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 	read_html_array.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
 	read_html_array.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_html_array.named_parameters["sample_size"] = LogicalType::INTEGER;
+	read_html_array.named_parameters["sample_files"] = LogicalType::BIGINT;
 	read_html_array.named_parameters["unnest_as"] = LogicalType::VARCHAR; // 'columns' (default) or 'struct' (future)
 	read_html_array.named_parameters["record_element"] =
 	    LogicalType::VARCHAR; // XPath or tag name for elements that should be rows

--- a/test/sql/html_union_by_name.test
+++ b/test/sql/html_union_by_name.test
@@ -4,10 +4,10 @@
 
 require webbed
 
-# Test 1: Without union_by_name - should get only common columns (intersection)
-# Note: Column order is non-deterministic, so we order by column name
+# Test 1: sample_files:=1 samples only the first file, so the schema is file 1's columns
+# (the pre-sampling default). The multi-file default and union_by_name both see field-c too.
 query TTTTTT
-SELECT * FROM (DESCRIBE SELECT * FROM read_html(['test/html/union_file1.html', 'test/html/union_file2.html'], record_element:='data-item')) ORDER BY column_name;
+SELECT * FROM (DESCRIBE SELECT * FROM read_html(['test/html/union_file1.html', 'test/html/union_file2.html'], record_element:='data-item', sample_files:=1)) ORDER BY column_name;
 ----
 field-a	VARCHAR	YES	NULL	NULL	NULL
 field-b	INTEGER	YES	NULL	NULL	NULL

--- a/test/sql/xml_multifile_schema_inference.test
+++ b/test/sql/xml_multifile_schema_inference.test
@@ -1,0 +1,45 @@
+# name: test/sql/xml_multifile_schema_inference.test
+# description: read_xml/read_html default schema inference should sample multiple files, not just the first
+# group: [sql]
+
+require webbed
+
+# Two files, sorted so doc_0.xml is inferred first. The FIRST file lacks the 'extra' column and
+# types 'val' as an integer; the SECOND introduces 'extra' and a fractional 'val'. With
+# first-file-only inference (the bug) the default read misses 'extra' and mis-types 'val'.
+statement ok
+COPY (SELECT '<data><row><val>1</val></row></data>' AS c) TO '__TEST_DIR__/doc_0.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><val>2.5</val><extra>hi</extra></row></data>' AS c) TO '__TEST_DIR__/doc_1.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+# EXPECTED: the default (non-union_by_name) read samples multiple files, so the inferred schema
+# contains BOTH 'val' and 'extra'. (Currently BUGGED: only doc_0.xml is sampled → no 'extra'.)
+query I
+SELECT list_contains(cols, 'val') AND list_contains(cols, 'extra') AS has_both_columns
+FROM (SELECT list(column_name) AS cols FROM (DESCRIBE SELECT * FROM read_xml('__TEST_DIR__/doc_*.xml')));
+----
+true
+
+# EXPECTED: 'val' widens to a fractional type because doc_1 has 2.5 — not integer from doc_0's 1.
+# (Currently BUGGED: 'val' is inferred as an integer type from doc_0 alone.)
+query I
+SELECT typeof(val) NOT IN ('BIGINT', 'INTEGER', 'HUGEINT', 'SMALLINT', 'TINYINT') AS val_is_fractional
+FROM read_xml('__TEST_DIR__/doc_*.xml')
+LIMIT 1;
+----
+true
+
+# EXPECTED: the 'extra' value from doc_1 is readable; doc_0's row is NULL for it.
+# (Currently BUGGED: 'extra' is not a column at all → this query fails to bind.)
+query I
+SELECT count(*) FILTER (WHERE extra = 'hi') AS extra_rows
+FROM read_xml('__TEST_DIR__/doc_*.xml');
+----
+1
+
+# Control: an explicit sample_files := 1 must reproduce the old first-file-only behavior
+# (schema from doc_0 only → no 'extra' column, so the reference to it is unknown).
+statement error
+SELECT extra FROM read_xml('__TEST_DIR__/doc_*.xml', sample_files := 1);
+----

--- a/test/sql/xml_schema_inference_fixes.test
+++ b/test/sql/xml_schema_inference_fixes.test
@@ -114,13 +114,23 @@ inf	nan
 
 # -----------------------------------------------------------------------------
 # Fallback schema must NULL-fill output columns instead of leaving them
-# uninitialized (invalid first file with ignore_errors yields the simple
-# 'xml' fallback schema, then rows from the valid file carry no values)
+# uninitialized. sample_files:=1 samples only the invalid first file, so inference
+# fails and yields the simple 'xml' fallback schema; rows from the valid file then
+# carry no values. (With the multi-file-sampling default the schema is instead
+# recovered from the valid second file — asserted below.)
 # -----------------------------------------------------------------------------
 
 query I
 SELECT xml IS NULL
-FROM read_xml(['test/invalid/invalid.xml', 'test/xml/schema_inference/attr_prefixed.xml'], ignore_errors := true);
+FROM read_xml(['test/invalid/invalid.xml', 'test/xml/schema_inference/attr_prefixed.xml'], ignore_errors := true, sample_files := 1);
 ----
 true
 true
+
+# Multi-file sampling (the default) skips the invalid first file and recovers a real schema
+# from the valid second file — so 'id' is a proper column, not the 'xml' fallback.
+query I
+SELECT COUNT(*) FILTER (WHERE column_name = 'id')
+FROM (DESCRIBE SELECT * FROM read_xml(['test/invalid/invalid.xml', 'test/xml/schema_inference/attr_prefixed.xml'], ignore_errors := true));
+----
+1

--- a/test/sql/xml_union_by_name.test
+++ b/test/sql/xml_union_by_name.test
@@ -93,10 +93,13 @@ WHERE name IN ('title', 'link', 'company', 'description', 'location');
 ----
 5
 
-# Test 10: Verify that union_by_name=false gives different column count than union_by_name=true
+# Test 10: multi-file schema sampling. The default now samples several files, so it already
+# picks up columns from both files — matching union_by_name for this small set. The narrow
+# baseline is sample_files := 1 (first file only, the pre-sampling behavior), which sees fewer
+# columns. So union_by_name (all files) has MORE columns than a single-file sample.
 statement ok
 CREATE TEMP TABLE without_union AS
-  SELECT * FROM read_xml(['test/xml/union_test_file1.xml', 'test/xml/union_test_file2.xml']);
+  SELECT * FROM read_xml(['test/xml/union_test_file1.xml', 'test/xml/union_test_file2.xml'], sample_files := 1);
 
 statement ok
 CREATE TEMP TABLE with_union AS
@@ -104,6 +107,17 @@ CREATE TEMP TABLE with_union AS
 
 query I
 SELECT (SELECT COUNT(*) FROM pragma_table_info('with_union')) > (SELECT COUNT(*) FROM pragma_table_info('without_union'));
+----
+true
+
+# And the default (multi-file sampling) now matches union_by_name for this 2-file set —
+# it no longer misses file 2's columns.
+statement ok
+CREATE TEMP TABLE default_sample AS
+  SELECT * FROM read_xml(['test/xml/union_test_file1.xml', 'test/xml/union_test_file2.xml']);
+
+query I
+SELECT (SELECT COUNT(*) FROM pragma_table_info('default_sample')) = (SELECT COUNT(*) FROM pragma_table_info('with_union'));
 ----
 true
 


### PR DESCRIPTION
Closes #124.

`read_xml` / `read_html` **without** `union_by_name` previously inferred the schema from only the **first file**. A column — or a value that widens a type (an integer column that has a decimal in file 3) — that first appears in a later file was silently missed: columns absent, or a runtime type too narrow. This is the cross-file analogue of the within-file out-of-sample fix from #102 / v2.4.0.

## What changed

- New **`sample_files`** parameter (default **8**): number of files sampled for schema inference on the default path.
  - `sample_files := 1` restores first-file-only inference (previous behavior).
  - `sample_files := -1` samples every file (like `union_by_name`).
  - Ignored under `union_by_name = true` (always scans all files) or when `columns` is given.
- Reuses the existing **`MergeInferredColumns`** machinery — the same merge `union_by_name` uses — so runtime extraction (by-name, NULL-filling missing columns) already handles the merged schema correctly. `union_by_name` remains the unbounded "scan all files" form, still distinct for globs larger than the sample.

## Behavior change (intended)

- The default now picks up columns/types from the first 8 files.
- Reading `[invalid.xml, valid.xml]` with `ignore_errors` now **recovers a real schema from the valid file** instead of falling back to the raw `xml`/`html` column.
- Glob matches are sorted (#72), so "first N" is deterministic; explicit path lists keep their order.

## Tests (written first)

- **`test/sql/xml_multifile_schema_inference.test`** was written *before* the fix to pin the expected behavior and demonstrate the prior bug (missing column + un-widened `val`) — it failed on the old code, passes now.
- Three existing tests encoded the old first-file-only behavior and now assert the improved behavior, using `sample_files := 1` as the narrow baseline where a first-file contrast is still wanted: `xml_union_by_name`, `html_union_by_name`, `xml_schema_inference_fixes`.
- Full local suite green (**91/91**).

## Note on `union_by_name`

For file sets **≤ `sample_files`**, the default now yields the same columns as `union_by_name` (it no longer misses later-file columns). `union_by_name` stays meaningful as the explicit, unbounded "scan every file" guarantee — the difference shows for globs larger than the sample bound. This was a deliberate call (default should "just work" for typical multi-file reads); the `sample_files` knob and `union_by_name` cover the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
