### PR TITLE
test: cover read_html multi-file paths + sample_files edge cases

### DIFF
--- a/test/sql/xml_multifile_parallelism.test
+++ b/test/sql/xml_multifile_parallelism.test
@@ -121,3 +121,108 @@ SELECT file, seq FROM read_xml('__TEST_DIR__/part_03.xml') ORDER BY seq;
 3	0
 3	1
 3	2
+
+# ---------------------------------------------------------------------------
+# (Glob sorting is already proven by the `file, seq` ordering above: file value K lives in
+#  part_0K.xml, so a 0..7 ordered result only happens when the glob is sorted.)
+#
+# An explicit list of paths keeps the caller's order (NOT sorted) — here reversed. Each file's
+# three rows stay contiguous (one file per chunk), so the file column runs 5,5,5,1,1,1,3,3,3.
+# (nosort compares in returned order; no DISTINCT, which would hash-reorder.)
+# ---------------------------------------------------------------------------
+query I nosort
+SELECT file FROM read_xml(['__TEST_DIR__/part_05.xml', '__TEST_DIR__/part_01.xml', '__TEST_DIR__/part_03.xml']);
+----
+5
+5
+5
+1
+1
+1
+3
+3
+3
+
+# ===========================================================================
+# read_html / read_html_objects parallelize the same way (separate _objects code path).
+# 8 HTML files, each with three <data-item> records tagged file (0..7) and seq (0..2).
+# ===========================================================================
+statement ok
+COPY (SELECT '<html><body><data-item><file>0</file><seq>0</seq></data-item><data-item><file>0</file><seq>1</seq></data-item><data-item><file>0</file><seq>2</seq></data-item></body></html>' AS c) TO '__TEST_DIR__/h_00.html' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<html><body><data-item><file>1</file><seq>0</seq></data-item><data-item><file>1</file><seq>1</seq></data-item><data-item><file>1</file><seq>2</seq></data-item></body></html>' AS c) TO '__TEST_DIR__/h_01.html' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<html><body><data-item><file>2</file><seq>0</seq></data-item><data-item><file>2</file><seq>1</seq></data-item><data-item><file>2</file><seq>2</seq></data-item></body></html>' AS c) TO '__TEST_DIR__/h_02.html' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<html><body><data-item><file>3</file><seq>0</seq></data-item><data-item><file>3</file><seq>1</seq></data-item><data-item><file>3</file><seq>2</seq></data-item></body></html>' AS c) TO '__TEST_DIR__/h_03.html' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<html><body><data-item><file>4</file><seq>0</seq></data-item><data-item><file>4</file><seq>1</seq></data-item><data-item><file>4</file><seq>2</seq></data-item></body></html>' AS c) TO '__TEST_DIR__/h_04.html' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<html><body><data-item><file>5</file><seq>0</seq></data-item><data-item><file>5</file><seq>1</seq></data-item><data-item><file>5</file><seq>2</seq></data-item></body></html>' AS c) TO '__TEST_DIR__/h_05.html' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<html><body><data-item><file>6</file><seq>0</seq></data-item><data-item><file>6</file><seq>1</seq></data-item><data-item><file>6</file><seq>2</seq></data-item></body></html>' AS c) TO '__TEST_DIR__/h_06.html' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<html><body><data-item><file>7</file><seq>0</seq></data-item><data-item><file>7</file><seq>1</seq></data-item><data-item><file>7</file><seq>2</seq></data-item></body></html>' AS c) TO '__TEST_DIR__/h_07.html' (FORMAT csv, HEADER false, QUOTE '');
+
+# Multiset parity for read_html.
+query III
+SELECT count(*), sum(file), sum(seq) FROM read_html('__TEST_DIR__/h_*.html', record_element := 'data-item');
+----
+24	84	24
+
+# Order preservation for read_html: exact glob order under the forced parallel executor.
+query II nosort
+SELECT file, seq FROM read_html('__TEST_DIR__/h_*.html', record_element := 'data-item');
+----
+0	0
+0	1
+0	2
+1	0
+1	1
+1	2
+2	0
+2	1
+2	2
+3	0
+3	1
+3	2
+4	0
+4	1
+4	2
+5	0
+5	1
+5	2
+6	0
+6	1
+6	2
+7	0
+7	1
+7	2
+
+# read_html filename attribution is per-row-correct.
+query I
+SELECT bool_and(filename LIKE '%h_0' || file || '.html')
+FROM read_html('__TEST_DIR__/h_*.html', record_element := 'data-item', filename := true);
+----
+true
+
+# read_html_objects: one row per file, filenames in glob order.
+query I nosort
+SELECT regexp_extract(filename, 'h_0(\d)\.html', 1)
+FROM read_html_objects('__TEST_DIR__/h_*.html', filename := true);
+----
+0
+1
+2
+3
+4
+5
+6
+7

--- a/test/sql/xml_multifile_schema_inference.test
+++ b/test/sql/xml_multifile_schema_inference.test
@@ -43,3 +43,75 @@ FROM read_xml('__TEST_DIR__/doc_*.xml');
 statement error
 SELECT extra FROM read_xml('__TEST_DIR__/doc_*.xml', sample_files := 1);
 ----
+
+# ---------------------------------------------------------------------------
+# read_html goes through a SEPARATE bind path from read_xml — verify multi-file sampling
+# works there too. hdoc_0 has only <val>; hdoc_1 adds <extra>.
+# ---------------------------------------------------------------------------
+statement ok
+COPY (SELECT '<html><body><rec><val>1</val></rec></body></html>' AS c) TO '__TEST_DIR__/hdoc_0.html' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<html><body><rec><val>2</val><extra>hi</extra></rec></body></html>' AS c) TO '__TEST_DIR__/hdoc_1.html' (FORMAT csv, HEADER false, QUOTE '');
+
+query I
+SELECT list_contains(cols, 'val') AND list_contains(cols, 'extra') AS has_both
+FROM (SELECT list(column_name) AS cols FROM (DESCRIBE SELECT * FROM read_html('__TEST_DIR__/hdoc_*.html', record_element := 'rec')));
+----
+true
+
+# read_html with sample_files := 1 restores first-file-only inference (no 'extra').
+query I
+SELECT list_contains(list(column_name), 'extra') AS has_extra
+FROM (DESCRIBE SELECT * FROM read_html('__TEST_DIR__/hdoc_*.html', record_element := 'rec', sample_files := 1));
+----
+false
+
+# ---------------------------------------------------------------------------
+# Bound vs sample_files := -1. Ten files (esf_00..esf_09); the 'extra' column first appears in
+# the 10th file — beyond the default sample bound of 8. The default MISSES it; -1 samples all
+# and finds it. Pins both the default bound and the "all files" mode.
+# ---------------------------------------------------------------------------
+statement ok
+COPY (SELECT '<data><row><val>0</val></row></data>' AS c) TO '__TEST_DIR__/esf_00.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><val>1</val></row></data>' AS c) TO '__TEST_DIR__/esf_01.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><val>2</val></row></data>' AS c) TO '__TEST_DIR__/esf_02.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><val>3</val></row></data>' AS c) TO '__TEST_DIR__/esf_03.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><val>4</val></row></data>' AS c) TO '__TEST_DIR__/esf_04.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><val>5</val></row></data>' AS c) TO '__TEST_DIR__/esf_05.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><val>6</val></row></data>' AS c) TO '__TEST_DIR__/esf_06.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><val>7</val></row></data>' AS c) TO '__TEST_DIR__/esf_07.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><val>8</val></row></data>' AS c) TO '__TEST_DIR__/esf_08.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+statement ok
+COPY (SELECT '<data><row><val>9</val><extra>late</extra></row></data>' AS c) TO '__TEST_DIR__/esf_09.xml' (FORMAT csv, HEADER false, QUOTE '');
+
+# Default (samples the first 8 of 10 sorted files) does NOT see esf_09's 'extra'.
+query I
+SELECT list_contains(list(column_name), 'extra') AS has_extra
+FROM (DESCRIBE SELECT * FROM read_xml('__TEST_DIR__/esf_*.xml'));
+----
+false
+
+# sample_files := -1 samples every file and picks up esf_09's 'extra'.
+query I
+SELECT list_contains(list(column_name), 'extra') AS has_extra
+FROM (DESCRIBE SELECT * FROM read_xml('__TEST_DIR__/esf_*.xml', sample_files := -1));
+----
+true


### PR DESCRIPTION
Closes coverage gaps for the v2.6.0 multi-file features (#72, #124). Test-only — validates already-shipped code (all pass, no code change needed).

- **read_html / read_html_objects parallelism** (separate `_objects` path): multiset parity, exact glob-order output under `verify_parallelism`, per-row filename attribution.
- **read_html schema sampling** — read_html binds via a **separate function** from read_xml, so `sample_files` was previously unexercised there. Confirms it picks up a later file's column; `sample_files := 1` restores first-file-only.
- **`sample_files` bound vs `-1`**: a column first appearing in the 10th file is missed by the default (samples 8) and found by `sample_files := -1`.
- **Explicit list order** preserved (not sorted).

The one issue found while writing these was a *test* bug (`SELECT DISTINCT` hash-reorders, breaking a `nosort` check), not a code bug — fixed here. Full local suite green (91/91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)