### PR TITLE
Accept VARCHAR in html_extract_*; fix table JSON, <tfoot> and escaping (#129, #130, #131, #132)

### DIFF
--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -827,31 +827,9 @@ static int CountBlockquoteAncestors(xmlNodePtr node) {
 	return count;
 }
 
+// Delegates so webbed has exactly one JSON escaper; see XMLUtils::EscapeJSONText.
 static std::string EscapeJsonString(const std::string &str) {
-	std::string result;
-	for (char c : str) {
-		switch (c) {
-		case '"':
-			result += "\\\"";
-			break;
-		case '\\':
-			result += "\\\\";
-			break;
-		case '\n':
-			result += "\\n";
-			break;
-		case '\r':
-			result += "\\r";
-			break;
-		case '\t':
-			result += "\\t";
-			break;
-		default:
-			result += c;
-			break;
-		}
-	}
-	return result;
+	return XMLUtils::EscapeJSONText(str);
 }
 
 static std::string UnescapeJsonString(const std::string &str) {
@@ -874,6 +852,28 @@ static std::string UnescapeJsonString(const std::string &str) {
 				break;
 			case '\\':
 				result += '\\';
+				break;
+			case 'b':
+				result += '\b';
+				break;
+			case 'f':
+				result += '\f';
+				break;
+			case 'u':
+				// \uXXXX. The escaper only emits these for C0 controls, so decoding the
+				// BMP range as-is and taking the low byte round-trips what it produces;
+				// anything above 0xFF is left verbatim rather than mangled.
+				if (i + 5 < str.size()) {
+					char hex[5] = {str[i + 2], str[i + 3], str[i + 4], str[i + 5], '\0'};
+					char *end = nullptr;
+					unsigned long cp = strtoul(hex, &end, 16);
+					if (end == hex + 4 && cp <= 0xFF) {
+						result += static_cast<char>(cp);
+						i += 5;
+						continue;
+					}
+				}
+				result += next;
 				break;
 			default:
 				result += next;
@@ -985,6 +985,68 @@ static std::string TableJsonToHtml(const std::string &json) {
 				}
 			}
 			html << "</tbody>";
+		}
+	}
+
+	// Render footers when the block carries them; absent key means no <tfoot>
+	size_t foot_start = json.find("\"footers\":");
+	if (foot_start != std::string::npos) {
+		size_t arr_start = json.find('[', foot_start);
+		if (arr_start != std::string::npos) {
+			html << "<tfoot>";
+			// Find each row array [...]
+			size_t pos = arr_start + 1;
+			while (pos < json.size()) {
+				// Skip whitespace
+				while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\n' || json[pos] == ',')) {
+					pos++;
+				}
+				if (pos >= json.size() || json[pos] == ']') {
+					break;
+				}
+				if (json[pos] == '[') {
+					// Found row start
+					size_t row_end = pos + 1;
+					int bracket_depth = 1;
+					while (row_end < json.size() && bracket_depth > 0) {
+						if (json[row_end] == '[') {
+							bracket_depth++;
+						} else if (json[row_end] == ']') {
+							bracket_depth--;
+						} else if (json[row_end] == '"') {
+							// Skip string content
+							row_end++;
+							while (row_end < json.size()) {
+								if (json[row_end] == '\\' && row_end + 1 < json.size()) {
+									row_end += 2;
+								} else if (json[row_end] == '"') {
+									break;
+								} else {
+									row_end++;
+								}
+							}
+						}
+						row_end++;
+					}
+					std::string row_str = json.substr(pos + 1, row_end - pos - 2);
+
+					// Extract cells from this row
+					std::regex item_regex("\"([^\"\\\\]*(\\\\.[^\"\\\\]*)*)\"");
+					std::sregex_iterator iter(row_str.begin(), row_str.end(), item_regex);
+					std::sregex_iterator end;
+					html << "<tr>";
+					while (iter != end) {
+						std::string cell = UnescapeJsonString((*iter)[1].str());
+						html << "<td>" << XMLUtils::HTMLEscape(cell) << "</td>";
+						++iter;
+					}
+					html << "</tr>";
+					pos = row_end;
+				} else {
+					pos++;
+				}
+			}
+			html << "</tfoot>";
 		}
 	}
 
@@ -1568,8 +1630,9 @@ static std::string TableToJson(xmlNodePtr node) {
 
 	std::vector<std::string> headers;
 	std::vector<std::vector<std::string>> rows;
+	std::vector<std::vector<std::string>> footers;
 
-	// Look for thead/tbody or direct tr children
+	// Look for thead/tbody/tfoot or direct tr children
 	xmlNodePtr child = node->children;
 	while (child) {
 		if (child->type == XML_ELEMENT_NODE && child->name) {
@@ -1606,6 +1669,27 @@ static std::string TableToJson(xmlNodePtr node) {
 						}
 						if (!row.empty()) {
 							rows.push_back(row);
+						}
+					}
+					tr = tr->next;
+				}
+			} else if (xmlStrcmp(child->name, BAD_CAST "tfoot") == 0) {
+				// Extract rows from tfoot. Kept apart from body rows so a summary row
+				// ("total", "subtotal") stays identifiable downstream.
+				xmlNodePtr tr = child->children;
+				while (tr) {
+					if (tr->type == XML_ELEMENT_NODE && tr->name && xmlStrcmp(tr->name, BAD_CAST "tr") == 0) {
+						std::vector<std::string> row;
+						xmlNodePtr td = tr->children;
+						while (td) {
+							if (td->type == XML_ELEMENT_NODE && td->name &&
+							    (xmlStrcmp(td->name, BAD_CAST "td") == 0 || xmlStrcmp(td->name, BAD_CAST "th") == 0)) {
+								row.push_back(GetNodeTextContent(td));
+							}
+							td = td->next;
+						}
+						if (!row.empty()) {
+							footers.push_back(row);
 						}
 					}
 					tr = tr->next;
@@ -1653,7 +1737,23 @@ static std::string TableToJson(xmlNodePtr node) {
 		}
 		ss << "]";
 	}
-	ss << "]}";
+	ss << "]";
+	if (!footers.empty()) {
+		ss << ",\"footers\":[";
+		for (size_t i = 0; i < footers.size(); i++) {
+			if (i > 0)
+				ss << ",";
+			ss << "[";
+			for (size_t j = 0; j < footers[i].size(); j++) {
+				if (j > 0)
+					ss << ",";
+				ss << "\"" << EscapeJsonString(footers[i][j]) << "\"";
+			}
+			ss << "]";
+		}
+		ss << "]";
+	}
+	ss << "}";
 
 	return ss.str();
 }

--- a/src/include/xml_utils.hpp
+++ b/src/include/xml_utils.hpp
@@ -214,6 +214,8 @@ struct HTMLImage {
 struct HTMLTable {
 	std::vector<std::string> headers;
 	std::vector<std::vector<std::string>> rows;
+	// <tfoot> rows, kept apart from body rows so summary rows stay identifiable.
+	std::vector<std::vector<std::string>> footers;
 	int64_t line_number;
 	int64_t num_columns;
 	int64_t num_rows;
@@ -265,6 +267,10 @@ public:
 
 	// Conversion functions
 	static std::string XMLToJSON(const std::string &xml_str);
+
+	// JSON string escaping, shared so every producer emits the same thing.
+	// Handles the full C0 range: unescaped bytes below 0x20 are invalid JSON.
+	static std::string EscapeJSONText(const std::string &str);
 	static std::string XMLToJSON(const std::string &xml_str, const XMLToJSONOptions &options);
 	static std::string JSONToXML(const std::string &json_str);
 	static std::string ScalarToXML(const std::string &value, const std::string &node_name);

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1591,35 +1591,61 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	// prefixed elements like "svg:circle" are treated as literal names with colons.
 	// Users should use name()="prefix:element" XPath predicates for HTML content.
 
+	// VARCHAR overloads (compatibility): the natural sources of HTML content - read_text(),
+	// httpfs, zim:// entries, ordinary table columns - are all typed VARCHAR, and
+	// VARCHAR -> HTML is registered as an explicit-only cast (see XMLTypes::Register).
+	// Without these, every such pipeline needs a manual ::HTML cast. String literals bind
+	// today only because DuckDB special-cases STRING_LITERAL to reach any type, which hides
+	// the gap in doc examples. Mirrors the VARCHAR overloads xml_extract_text already has.
+	// VARCHAR only (no XPath) -> VARCHAR
+	html_extract_text_functions.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, HTMLExtractTextFunction));
+	// VARCHAR + VARCHAR XPath -> LIST(VARCHAR)
+	html_extract_text_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                                       LogicalType::LIST(LogicalType::VARCHAR),
+	                                                       HTMLExtractTextListFunction));
+	// VARCHAR + STRING_LITERAL XPath -> LIST(VARCHAR)
+	html_extract_text_functions.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(LogicalType::VARCHAR), HTMLExtractTextListFunction));
+
 	loader.RegisterFunction(html_extract_text_functions);
 
-	// Register html_extract_links function
-	auto html_extract_links_function =
-	    ScalarFunction("html_extract_links", {XMLTypes::HTMLType()}, LogicalType::LIST(html_link_struct_type),
-	                   HTMLExtractLinksFunction);
-	PreventStructConstantFolding(html_extract_links_function);
-	loader.RegisterFunction(html_extract_links_function);
+	// Register html_extract_links function (HTML + VARCHAR compatibility overload)
+	ScalarFunctionSet html_extract_links_functions("html_extract_links");
+	html_extract_links_functions.AddFunction(
+	    ScalarFunction({XMLTypes::HTMLType()}, LogicalType::LIST(html_link_struct_type), HTMLExtractLinksFunction));
+	html_extract_links_functions.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR}, LogicalType::LIST(html_link_struct_type), HTMLExtractLinksFunction));
+	PreventStructConstantFolding(html_extract_links_functions);
+	loader.RegisterFunction(html_extract_links_functions);
 
-	// Register html_extract_images function
-	auto html_extract_images_function =
-	    ScalarFunction("html_extract_images", {XMLTypes::HTMLType()}, LogicalType::LIST(html_image_struct_type),
-	                   HTMLExtractImagesFunction);
-	PreventStructConstantFolding(html_extract_images_function);
-	loader.RegisterFunction(html_extract_images_function);
+	// Register html_extract_images function (HTML + VARCHAR compatibility overload)
+	ScalarFunctionSet html_extract_images_functions("html_extract_images");
+	html_extract_images_functions.AddFunction(
+	    ScalarFunction({XMLTypes::HTMLType()}, LogicalType::LIST(html_image_struct_type), HTMLExtractImagesFunction));
+	html_extract_images_functions.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR}, LogicalType::LIST(html_image_struct_type), HTMLExtractImagesFunction));
+	PreventStructConstantFolding(html_extract_images_functions);
+	loader.RegisterFunction(html_extract_images_functions);
 
-	// Register html_extract_table_rows function
-	auto html_extract_table_rows_function =
-	    ScalarFunction("html_extract_table_rows", {XMLTypes::HTMLType()}, LogicalType::LIST(html_table_row_struct_type),
-	                   HTMLExtractTableRowsFunction);
-	PreventStructConstantFolding(html_extract_table_rows_function);
-	loader.RegisterFunction(html_extract_table_rows_function);
+	// Register html_extract_table_rows function (HTML + VARCHAR compatibility overload)
+	ScalarFunctionSet html_extract_table_rows_functions("html_extract_table_rows");
+	html_extract_table_rows_functions.AddFunction(ScalarFunction(
+	    {XMLTypes::HTMLType()}, LogicalType::LIST(html_table_row_struct_type), HTMLExtractTableRowsFunction));
+	html_extract_table_rows_functions.AddFunction(ScalarFunction(
+	    {LogicalType::VARCHAR}, LogicalType::LIST(html_table_row_struct_type), HTMLExtractTableRowsFunction));
+	PreventStructConstantFolding(html_extract_table_rows_functions);
+	loader.RegisterFunction(html_extract_table_rows_functions);
 
-	// Register html_extract_tables_json function
-	auto html_extract_tables_json_function =
-	    ScalarFunction("html_extract_tables_json", {XMLTypes::HTMLType()},
-	                   LogicalType::LIST(html_table_json_struct_type), HTMLExtractTablesJSONFunction);
-	PreventStructConstantFolding(html_extract_tables_json_function);
-	loader.RegisterFunction(html_extract_tables_json_function);
+	// Register html_extract_tables_json function (HTML + VARCHAR compatibility overload)
+	ScalarFunctionSet html_extract_tables_json_functions("html_extract_tables_json");
+	html_extract_tables_json_functions.AddFunction(ScalarFunction(
+	    {XMLTypes::HTMLType()}, LogicalType::LIST(html_table_json_struct_type), HTMLExtractTablesJSONFunction));
+	html_extract_tables_json_functions.AddFunction(ScalarFunction(
+	    {LogicalType::VARCHAR}, LogicalType::LIST(html_table_json_struct_type), HTMLExtractTablesJSONFunction));
+	PreventStructConstantFolding(html_extract_tables_json_functions);
+	loader.RegisterFunction(html_extract_tables_json_functions);
 
 	// Register parse_html scalar function for parsing HTML content directly
 	auto parse_html_function =

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1242,9 +1242,9 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	ScalarFunctionSet xml_extract_text_functions("xml_extract_text");
 
 	// XML + VARCHAR -> LIST(VARCHAR)
-	add_ns_aware(xml_extract_text_functions, ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR},
-	                                                        LogicalType::LIST(LogicalType::VARCHAR),
-	                                                        XMLExtractTextListFunction));
+	add_ns_aware(xml_extract_text_functions,
+	             ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
+	                            XMLExtractTextListFunction));
 	// XML + STRING_LITERAL -> LIST(VARCHAR)
 	// (no varargs on STRING_LITERAL overloads: varargs + a literal parameter makes DuckDB resolve a
 	//  literal return type and trip an internal error. The named-arg case routes through the VARCHAR
@@ -1253,17 +1253,17 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	    ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
 	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction));
 	// XMLFragment + VARCHAR -> LIST(VARCHAR)
-	add_ns_aware(xml_extract_text_functions, ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR},
-	                                                        LogicalType::LIST(LogicalType::VARCHAR),
-	                                                        XMLExtractTextListFunction));
+	add_ns_aware(xml_extract_text_functions,
+	             ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR},
+	                            LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction));
 	// XMLFragment + STRING_LITERAL -> LIST(VARCHAR)
 	xml_extract_text_functions.AddFunction(
 	    ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
 	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction));
 	// VARCHAR + VARCHAR -> LIST(VARCHAR) (compatibility)
-	add_ns_aware(xml_extract_text_functions, ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                                                        LogicalType::LIST(LogicalType::VARCHAR),
-	                                                        XMLExtractTextListFunction));
+	add_ns_aware(xml_extract_text_functions,
+	             ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
+	                            XMLExtractTextListFunction));
 	// VARCHAR + STRING_LITERAL -> LIST(VARCHAR) (compatibility)
 	xml_extract_text_functions.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
@@ -1305,34 +1305,34 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	ScalarFunctionSet xml_extract_elements_functions("xml_extract_elements");
 
 	// XML + VARCHAR -> LIST(XMLFragment)
-	add_ns_aware(xml_extract_elements_functions, ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR},
-	                                                            LogicalType::LIST(XMLTypes::XMLFragmentType()),
-	                                                            XMLExtractElementsListFunction));
+	add_ns_aware(xml_extract_elements_functions,
+	             ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR},
+	                            LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// XML + STRING_LITERAL -> LIST(XMLFragment)
 	// (STRING_LITERAL overloads stay varargs-free; see note on xml_extract_text above.)
 	xml_extract_elements_functions.AddFunction(
 	    ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
 	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// HTML + VARCHAR -> LIST(XMLFragment)
-	add_ns_aware(xml_extract_elements_functions, ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
-	                                                            LogicalType::LIST(XMLTypes::XMLFragmentType()),
-	                                                            XMLExtractElementsListFunction));
+	add_ns_aware(xml_extract_elements_functions,
+	             ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
+	                            LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// HTML + STRING_LITERAL -> LIST(XMLFragment)
 	xml_extract_elements_functions.AddFunction(
 	    ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
 	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// XMLFragment + VARCHAR -> LIST(XMLFragment) (for nested extraction)
-	add_ns_aware(xml_extract_elements_functions, ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR},
-	                                                            LogicalType::LIST(XMLTypes::XMLFragmentType()),
-	                                                            XMLExtractElementsListFunction));
+	add_ns_aware(xml_extract_elements_functions,
+	             ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR},
+	                            LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// XMLFragment + STRING_LITERAL -> LIST(XMLFragment)
 	xml_extract_elements_functions.AddFunction(
 	    ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
 	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// VARCHAR + VARCHAR -> LIST(XMLFragment) (compatibility)
-	add_ns_aware(xml_extract_elements_functions, ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                                                            LogicalType::LIST(XMLTypes::XMLFragmentType()),
-	                                                            XMLExtractElementsListFunction));
+	add_ns_aware(xml_extract_elements_functions,
+	             ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                            LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// VARCHAR + STRING_LITERAL -> LIST(XMLFragment) (compatibility)
 	xml_extract_elements_functions.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
@@ -1394,15 +1394,15 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	     make_pair("line_number", LogicalType::BIGINT)});
 	// Register xml_extract_attributes function as a function set
 	ScalarFunctionSet xml_extract_attributes_functions("xml_extract_attributes");
-	add_ns_aware(xml_extract_attributes_functions, ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR},
-	                                                              LogicalType::LIST(attr_struct_type),
-	                                                              XMLExtractAttributesFunction));
-	add_ns_aware(xml_extract_attributes_functions, ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
-	                                                              LogicalType::LIST(attr_struct_type),
-	                                                              XMLExtractAttributesFunction));
-	add_ns_aware(xml_extract_attributes_functions, ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                                                              LogicalType::LIST(attr_struct_type),
-	                                                              XMLExtractAttributesFunction));
+	add_ns_aware(xml_extract_attributes_functions,
+	             ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR}, LogicalType::LIST(attr_struct_type),
+	                            XMLExtractAttributesFunction));
+	add_ns_aware(xml_extract_attributes_functions,
+	             ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR}, LogicalType::LIST(attr_struct_type),
+	                            XMLExtractAttributesFunction));
+	add_ns_aware(xml_extract_attributes_functions,
+	             ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::LIST(attr_struct_type),
+	                            XMLExtractAttributesFunction));
 	// Add 3-argument variants with namespace map
 	xml_extract_attributes_functions.AddFunction(
 	    ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type}, LogicalType::LIST(attr_struct_type),
@@ -1484,8 +1484,7 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	// Internal regression self-test for the libxml2 out-of-memory path (see OOMSelfTestFunction).
 	// Returns 'OK' (or 'OK (oom check skipped...)' where the allocator can't be injected); any other
 	// value indicates a regression. Result is deterministic, so default stability is fine.
-	loader.RegisterFunction(
-	    ScalarFunction("xml_oom_selftest", {}, LogicalType::VARCHAR, OOMSelfTestFunction));
+	loader.RegisterFunction(ScalarFunction("xml_oom_selftest", {}, LogicalType::VARCHAR, OOMSelfTestFunction));
 
 	// Register xml_detect_prefixes function (returns LIST<VARCHAR> of namespace prefixes in XPath expression)
 	auto xml_detect_prefixes_function =
@@ -1558,16 +1557,15 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	                                                       {"num_columns", LogicalType(LogicalTypeId::BIGINT)},
 	                                                       {"num_rows", LogicalType(LogicalTypeId::BIGINT)}});
 
-	auto html_table_json_struct_type = LogicalType::STRUCT({
-	    {"table_index", LogicalType(LogicalTypeId::BIGINT)},
-	    {"line_number", LogicalType(LogicalTypeId::BIGINT)},
-	    {"num_columns", LogicalType(LogicalTypeId::BIGINT)},
-	    {"num_rows", LogicalType(LogicalTypeId::BIGINT)},
-	    {"headers", LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR))},
-	    {"table_data", LogicalType::LIST(LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR)))},
-	    {"table_json", LogicalType::STRUCT({})},    // Complex nested struct
-	    {"json_structure", LogicalType::STRUCT({})} // Complex nested struct
-	});
+	auto html_table_json_struct_type =
+	    LogicalType::STRUCT({{"table_index", LogicalType(LogicalTypeId::BIGINT)},
+	                         {"line_number", LogicalType(LogicalTypeId::BIGINT)},
+	                         {"num_columns", LogicalType(LogicalTypeId::BIGINT)},
+	                         {"num_rows", LogicalType(LogicalTypeId::BIGINT)},
+	                         {"headers", LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR))},
+	                         {"table_data", LogicalType::LIST(LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR)))},
+	                         {"table_json", LogicalType::JSON()}, // shape follows the document
+	                         {"json_structure", LogicalType::JSON()}});
 
 	// Register html_extract_text function with XPath support
 	// With XPath: returns LIST(VARCHAR) (PostgreSQL-compatible) - use list[1] to get single value
@@ -1830,6 +1828,26 @@ void XMLScalarFunctions::HTMLExtractTableRowsFunction(DataChunk &args, Expressio
 					row_values.emplace_back(Value::STRUCT(row_children));
 				}
 			}
+
+			// Output footer rows. Previously <tfoot> rows arrived here indistinguishable
+			// from body rows; they now carry row_type='footer' and continue the row_index
+			// sequence after the body.
+			for (size_t f_idx = 0; f_idx < table.footers.size(); f_idx++) {
+				const auto &row = table.footers[f_idx];
+				for (size_t col_idx = 0; col_idx < row.size(); col_idx++) {
+					child_list_t<Value> row_children;
+					row_children.emplace_back("table_index", Value::BIGINT(static_cast<int64_t>(table_idx)));
+					row_children.emplace_back("row_type", Value("footer"));
+					row_children.emplace_back("row_index",
+					                          Value::BIGINT(static_cast<int64_t>(table.rows.size() + f_idx + 1)));
+					row_children.emplace_back("column_index", Value::BIGINT(static_cast<int64_t>(col_idx)));
+					row_children.emplace_back("cell_value", Value(row[col_idx]));
+					row_children.emplace_back("line_number", Value::BIGINT(table.line_number));
+					row_children.emplace_back("num_columns", Value::BIGINT(table.num_columns));
+					row_children.emplace_back("num_rows", Value::BIGINT(table.num_rows));
+					row_values.emplace_back(Value::STRUCT(row_children));
+				}
+			}
 		}
 
 		auto table_row_struct_type = LogicalType::STRUCT(
@@ -1864,62 +1882,74 @@ void XMLScalarFunctions::HTMLExtractTablesJSONFunction(DataChunk &args, Expressi
 				header_values.push_back(Value(header));
 			}
 
-			// Create data rows as list of lists
+			// Create data rows as list of lists. Value::LIST(values) asserts on an empty
+			// vector, and a table with no cells in a row is ordinary input, so every list
+			// here is built with the typed overload.
 			vector<Value> row_values;
 			for (const auto &row : rows) {
 				vector<Value> cell_values;
 				for (const auto &cell : row) {
 					cell_values.push_back(Value(cell));
 				}
-				row_values.push_back(Value::LIST(cell_values));
+				row_values.push_back(Value::LIST(LogicalType::VARCHAR, cell_values));
 			}
 
-			// Build JSON using DuckDB's native JSON construction
-			child_list_t<Value> json_children;
-
-			// Headers array
-			json_children.push_back({"headers", Value::LIST(header_values)});
-
-			// Data array (2D)
-			json_children.push_back({"data", Value::LIST(row_values)});
-
-			// Rows as objects
-			vector<Value> object_rows;
-			for (const auto &row : rows) {
-				child_list_t<Value> row_obj;
-				for (size_t j = 0; j < headers.size() && j < row.size(); j++) {
-					row_obj.push_back({CompatMakeIdentifier(headers[j]), Value(row[j])});
+			// table_json's shape follows the table's own headers, so it cannot be a fixed
+			// STRUCT type. Serialize it as JSON text, which is what the function name says.
+			//
+			// Key names follow duck_block_utils' table encoding — {"headers": [...],
+			// "rows": [[...]]} with rows as positional cells — so this value drops straight
+			// into a duck_block table's content and into db_render_table_json, which ignores
+			// the extra keys. The header-keyed objects live under "records" rather than
+			// "rows"; naming those "rows" would collide with that convention and silently
+			// render wrong.
+			std::string tj = "{\"headers\":[";
+			for (size_t j = 0; j < headers.size(); j++) {
+				tj += (j ? "," : "") + std::string("\"") + XMLUtils::EscapeJSONText(headers[j]) + "\"";
+			}
+			tj += "],\"rows\":[";
+			for (size_t r = 0; r < rows.size(); r++) {
+				tj += (r ? ",[" : "[");
+				for (size_t c = 0; c < rows[r].size(); c++) {
+					tj += (c ? "," : "") + std::string("\"") + XMLUtils::EscapeJSONText(rows[r][c]) + "\"";
 				}
-				object_rows.push_back(Value::STRUCT(row_obj));
+				tj += "]";
 			}
-			json_children.push_back({"rows", Value::LIST(object_rows)});
-
-			// Metadata
-			child_list_t<Value> metadata_children;
-			metadata_children.push_back({"line_number", Value::BIGINT(table.line_number)});
-			metadata_children.push_back({"num_columns", Value::BIGINT(table.num_columns)});
-			metadata_children.push_back({"num_rows", Value::BIGINT(table.num_rows)});
-			json_children.push_back({"metadata", Value::STRUCT(metadata_children)});
-
-			Value json_value = Value::STRUCT(json_children);
-
-			// Build structure description
-			child_list_t<Value> structure_children;
-			structure_children.push_back({"table_name", Value("table_" + std::to_string(table_idx))});
-
-			vector<Value> column_info;
-			for (size_t col_idx = 0; col_idx < headers.size(); col_idx++) {
-				child_list_t<Value> col_children;
-				col_children.push_back({"name", Value(headers[col_idx])});
-				col_children.push_back({"index", Value::BIGINT(static_cast<int64_t>(col_idx))});
-				col_children.push_back({"type", Value("string")});
-				column_info.push_back(Value::STRUCT(col_children));
+			tj += "],\"records\":[";
+			for (size_t r = 0; r < rows.size(); r++) {
+				tj += (r ? ",{" : "{");
+				for (size_t c = 0; c < headers.size() && c < rows[r].size(); c++) {
+					tj += (c ? "," : "") + std::string("\"") + XMLUtils::EscapeJSONText(headers[c]) + "\":\"" +
+					      XMLUtils::EscapeJSONText(rows[r][c]) + "\"";
+				}
+				tj += "}";
 			}
-			structure_children.push_back({"columns", Value::LIST(column_info)});
-			structure_children.push_back({"row_count", Value::BIGINT(static_cast<int64_t>(rows.size()))});
-			structure_children.push_back({"source_line", Value::BIGINT(table.line_number)});
+			tj += "]";
+			if (!table.footers.empty()) {
+				tj += ",\"footers\":[";
+				for (size_t r = 0; r < table.footers.size(); r++) {
+					tj += (r ? ",[" : "[");
+					for (size_t c = 0; c < table.footers[r].size(); c++) {
+						tj += (c ? "," : "") + std::string("\"") + XMLUtils::EscapeJSONText(table.footers[r][c]) + "\"";
+					}
+					tj += "]";
+				}
+				tj += "]";
+			}
+			tj += ",\"metadata\":{\"line_number\":" + std::to_string(table.line_number) +
+			      ",\"num_columns\":" + std::to_string(table.num_columns) +
+			      ",\"num_rows\":" + std::to_string(table.num_rows) + "}}";
+			Value json_value(tj);
 
-			Value structure_value = Value::STRUCT(structure_children);
+			// Same for the structure description.
+			std::string js = "{\"table_name\":\"table_" + std::to_string(table_idx) + "\",\"columns\":[";
+			for (size_t c = 0; c < headers.size(); c++) {
+				js += (c ? "," : "") + std::string("{\"name\":\"") + XMLUtils::EscapeJSONText(headers[c]) +
+				      "\",\"index\":" + std::to_string(c) + ",\"type\":\"string\"}";
+			}
+			js += "],\"row_count\":" + std::to_string(rows.size()) +
+			      ",\"source_line\":" + std::to_string(table.line_number) + "}";
+			Value structure_value(js);
 
 			// Create struct for this table
 			child_list_t<Value> table_struct_children;
@@ -1927,22 +1957,22 @@ void XMLScalarFunctions::HTMLExtractTablesJSONFunction(DataChunk &args, Expressi
 			table_struct_children.push_back({"line_number", Value::BIGINT(table.line_number)});
 			table_struct_children.push_back({"num_columns", Value::BIGINT(static_cast<int64_t>(headers.size()))});
 			table_struct_children.push_back({"num_rows", Value::BIGINT(static_cast<int64_t>(rows.size()))});
-			table_struct_children.push_back({"headers", Value::LIST(header_values)});
-			table_struct_children.push_back({"table_data", Value::LIST(row_values)});
+			table_struct_children.push_back({"headers", Value::LIST(LogicalType::VARCHAR, header_values)});
+			table_struct_children.push_back(
+			    {"table_data", Value::LIST(LogicalType::LIST(LogicalType::VARCHAR), row_values)});
 			table_struct_children.push_back({"table_json", json_value});
 			table_struct_children.push_back({"json_structure", structure_value});
 
 			table_values.push_back(Value::STRUCT(table_struct_children));
 		}
 
-		auto table_json_struct_type = LogicalType::STRUCT({
-		    make_pair("table_index", LogicalType::BIGINT), make_pair("line_number", LogicalType::BIGINT),
-		    make_pair("num_columns", LogicalType::BIGINT), make_pair("num_rows", LogicalType::BIGINT),
-		    make_pair("headers", LogicalType::LIST(LogicalType::VARCHAR)),
-		    make_pair("table_data", LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR))),
-		    make_pair("table_json", LogicalType::STRUCT({})),    // Complex nested struct
-		    make_pair("json_structure", LogicalType::STRUCT({})) // Complex nested struct
-		});
+		auto table_json_struct_type = LogicalType::STRUCT(
+		    {make_pair("table_index", LogicalType::BIGINT), make_pair("line_number", LogicalType::BIGINT),
+		     make_pair("num_columns", LogicalType::BIGINT), make_pair("num_rows", LogicalType::BIGINT),
+		     make_pair("headers", LogicalType::LIST(LogicalType::VARCHAR)),
+		     make_pair("table_data", LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR))),
+		     make_pair("table_json", LogicalType::JSON()), // shape follows the document
+		     make_pair("json_structure", LogicalType::JSON())});
 
 		Value list_value = Value::LIST(table_json_struct_type, table_values);
 		result.SetValue(i, list_value);
@@ -1956,8 +1986,8 @@ static bool IsWhitespacePreservingElement(const xmlChar *name) {
 		return false;
 	}
 	std::string n(reinterpret_cast<const char *>(name));
-	return StringUtil::CIEquals(n, "pre") || StringUtil::CIEquals(n, "textarea") ||
-	       StringUtil::CIEquals(n, "script") || StringUtil::CIEquals(n, "style");
+	return StringUtil::CIEquals(n, "pre") || StringUtil::CIEquals(n, "textarea") || StringUtil::CIEquals(n, "script") ||
+	       StringUtil::CIEquals(n, "style");
 }
 
 // Collapse each run of ASCII whitespace in TEXT nodes to a single space, recursively, operating
@@ -2084,33 +2114,33 @@ void XMLScalarFunctions::ParseHTMLFunction(DataChunk &args, ExpressionState &sta
 void XMLScalarFunctions::ReadHTMLFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &html_content_vector = args.data[0];
 
-	UnaryExecutor::Execute<string_t, string_t>(
-	    html_content_vector, result, args.size(), [&](string_t html_content_str) {
-		    std::string html_content = html_content_str.GetString();
+	UnaryExecutor::Execute<string_t, string_t>(html_content_vector, result, args.size(),
+	                                           [&](string_t html_content_str) {
+		                                           std::string html_content = html_content_str.GetString();
 
-		    // Handle empty HTML content gracefully
-		    if (html_content.empty()) {
-			    return string_t("<html></html>");
-		    }
+		                                           // Handle empty HTML content gracefully
+		                                           if (html_content.empty()) {
+			                                           return string_t("<html></html>");
+		                                           }
 
-		    try {
-			    // Parse the HTML using the HTML parser to normalize it
-			    XMLDocRAII html_doc(html_content, true); // Use HTML parser
-			    if (html_doc.IsValid()) {
-				    std::string minified_html;
-				    if (SerializeMinifiedHTML(html_doc.doc, minified_html)) {
-					    return StringVector::AddString(result, minified_html);
-				    }
-			    }
+		                                           try {
+			                                           // Parse the HTML using the HTML parser to normalize it
+			                                           XMLDocRAII html_doc(html_content, true); // Use HTML parser
+			                                           if (html_doc.IsValid()) {
+				                                           std::string minified_html;
+				                                           if (SerializeMinifiedHTML(html_doc.doc, minified_html)) {
+					                                           return StringVector::AddString(result, minified_html);
+				                                           }
+			                                           }
 
-			    // Fallback to original content if parsing fails
-			    return StringVector::AddString(result, html_content);
+			                                           // Fallback to original content if parsing fails
+			                                           return StringVector::AddString(result, html_content);
 
-		    } catch (const std::exception &e) {
-			    // Return original content if there's an error parsing
-			    return StringVector::AddString(result, html_content);
-		    }
-	    });
+		                                           } catch (const std::exception &e) {
+			                                           // Return original content if there's an error parsing
+			                                           return StringVector::AddString(result, html_content);
+		                                           }
+	                                           });
 }
 
 void XMLScalarFunctions::HTMLUnescapeFunction(DataChunk &args, ExpressionState &state, Vector &result) {

--- a/src/xml_utils.cpp
+++ b/src/xml_utils.cpp
@@ -1011,6 +1011,47 @@ XMLStats XMLUtils::GetXMLStats(const std::string &xml_str) {
 	return stats;
 }
 
+std::string XMLUtils::EscapeJSONText(const std::string &str) {
+	std::string out;
+	out.reserve(str.size() + 8);
+	// Iterate as unsigned char: with a signed char, bytes above 0x7F compare as negative
+	// and the < 0x20 test below would be implementation-defined.
+	for (unsigned char c : str) {
+		switch (c) {
+		case '"':
+			out += "\\\"";
+			break;
+		case '\\':
+			out += "\\\\";
+			break;
+		case '\n':
+			out += "\\n";
+			break;
+		case '\r':
+			out += "\\r";
+			break;
+		case '\t':
+			out += "\\t";
+			break;
+		case '\b':
+			out += "\\b";
+			break;
+		case '\f':
+			out += "\\f";
+			break;
+		default:
+			if (c < 0x20) {
+				char buf[7];
+				snprintf(buf, sizeof(buf), "\\u%04x", c);
+				out += buf;
+			} else {
+				out += static_cast<char>(c);
+			}
+		}
+	}
+	return out;
+}
+
 std::string XMLUtils::XMLToJSON(const std::string &xml_str) {
 	XMLDocRAII xml_doc(xml_str);
 	if (!xml_doc.IsValid()) {
@@ -2751,7 +2792,12 @@ std::vector<HTMLTable> XMLUtils::ExtractHTMLTables(const std::string &html_str) 
 
 				// Extract data rows (all rows for tables without th headers)
 				bool has_th_headers = !table.headers.empty();
-				std::string data_xpath = has_th_headers ? ".//tbody//tr | .//tr[not(th)]" : ".//tbody//tr | .//tr";
+				// tfoot rows are excluded here and collected separately below; without the
+				// filter they land in the body as ordinary data rows.
+				std::string data_xpath = has_th_headers ? ".//tbody//tr[not(ancestor::tfoot)] | "
+				                                          ".//tr[not(th)][not(ancestor::tfoot)]"
+				                                        : ".//tbody//tr[not(ancestor::tfoot)] | "
+				                                          ".//tr[not(ancestor::tfoot)]";
 
 				xmlXPathObjectPtr rows_obj = xmlXPathEvalExpression(BAD_CAST data_xpath.c_str(), local_ctx);
 
@@ -2791,6 +2837,36 @@ std::vector<HTMLTable> XMLUtils::ExtractHTMLTables(const std::string &html_str) 
 
 				if (rows_obj)
 					xmlXPathFreeObject(rows_obj);
+
+				// <tfoot> rows, gathered the same way as body rows
+				xmlXPathObjectPtr foot_obj = xmlXPathEvalExpression(BAD_CAST ".//tfoot//tr", local_ctx);
+				if (foot_obj && foot_obj->nodesetval) {
+					for (int j = 0; j < foot_obj->nodesetval->nodeNr; j++) {
+						xmlNodePtr row_node = foot_obj->nodesetval->nodeTab[j];
+						std::vector<std::string> row_data;
+						xmlXPathContextPtr row_ctx = xmlXPathNewContext(html_doc.doc);
+						if (row_ctx) {
+							row_ctx->node = row_node;
+							xmlXPathObjectPtr cells_obj = xmlXPathEvalExpression(BAD_CAST ".//td | .//th", row_ctx);
+							if (cells_obj && cells_obj->nodesetval) {
+								for (int k = 0; k < cells_obj->nodesetval->nodeNr; k++) {
+									XMLCharPtr text(xmlNodeGetContent(cells_obj->nodesetval->nodeTab[k]));
+									row_data.push_back(text ? std::string(reinterpret_cast<const char *>(text.get()))
+									                        : "");
+								}
+							}
+							if (cells_obj)
+								xmlXPathFreeObject(cells_obj);
+							xmlXPathFreeContext(row_ctx);
+						}
+						if (!row_data.empty()) {
+							table.footers.push_back(row_data);
+						}
+					}
+				}
+				if (foot_obj)
+					xmlXPathFreeObject(foot_obj);
+
 				xmlXPathFreeContext(local_ctx);
 			}
 
@@ -2799,7 +2875,7 @@ std::vector<HTMLTable> XMLUtils::ExtractHTMLTables(const std::string &html_str) 
 			table.num_rows = static_cast<int64_t>(table.rows.size());
 
 			// Only add table if it has content
-			if (table.num_columns > 0 || table.num_rows > 0) {
+			if (table.num_columns > 0 || table.num_rows > 0 || !table.footers.empty()) {
 				tables.push_back(table);
 			}
 		}

--- a/test/sql/github_issue_129_html_varchar_overloads.test
+++ b/test/sql/github_issue_129_html_varchar_overloads.test
@@ -1,0 +1,155 @@
+# name: test/sql/github_issue_129_html_varchar_overloads.test
+# description: html_* functions accept plain VARCHAR without an explicit ::HTML cast
+# group: [sql]
+
+#
+# GitHub Issue #129: html_extract_* functions reject VARCHAR input
+# https://github.com/teaguesterling/duckdb_webbed/issues/129
+#
+# The natural sources of HTML content (read_text(), httpfs, zim:// entries, plain
+# table columns) are all typed VARCHAR, but the html_* functions were registered
+# only on the HTML type, and VARCHAR -> HTML is an explicit-only cast. String
+# literals bound anyway because DuckDB special-cases STRING_LITERAL to reach any
+# type, which hid the gap in every doc example.
+#
+# Fix: register VARCHAR overloads alongside the HTML ones, matching what
+# xml_extract_text and html_to_duck_blocks already do.
+#
+
+require webbed
+
+# ============================================================================
+# PART 1: The reported failure - VARCHAR values bind without a cast
+# ============================================================================
+
+# 1.1: explicitly-typed VARCHAR, with XPath (the exact repro from the issue)
+query I
+SELECT html_extract_text('<h1>Hi</h1>'::VARCHAR, '//h1');
+----
+[Hi]
+
+# 1.2: explicitly-typed VARCHAR, no XPath
+query I
+SELECT html_extract_text('<html><body><h1>Title</h1><p>Body</p></body></html>'::VARCHAR);
+----
+TitleBody
+
+# 1.3: a real VARCHAR column, which is what read_text() and friends produce
+statement ok
+CREATE TABLE pages AS SELECT '<html><body><h1>Title</h1><p>Body</p></body></html>'::VARCHAR AS content;
+
+query I
+SELECT html_extract_text(content, '//h1')[1] FROM pages;
+----
+Title
+
+query I
+SELECT html_extract_text(content) FROM pages;
+----
+TitleBody
+
+# 1.4: XPath supplied as a VARCHAR column too (not a STRING_LITERAL)
+statement ok
+CREATE TABLE q AS SELECT '<h1>Hi</h1>'::VARCHAR AS doc, '//h1'::VARCHAR AS xpath;
+
+query I
+SELECT html_extract_text(doc, xpath) FROM q;
+----
+[Hi]
+
+# ============================================================================
+# PART 2: The other html_extract_* functions
+# ============================================================================
+
+query I
+SELECT html_extract_links('<a href="/x" title="T">L</a>'::VARCHAR)[1].href;
+----
+/x
+
+query I
+SELECT html_extract_links('<a href="/x" title="T">L</a>'::VARCHAR)[1].text;
+----
+L
+
+query I
+SELECT html_extract_images('<img src="/i.png" alt="A">'::VARCHAR)[1].src;
+----
+/i.png
+
+query I
+SELECT html_extract_images('<img src="/i.png" alt="A">'::VARCHAR)[1].alt;
+----
+A
+
+query I
+SELECT html_extract_table_rows('<table><tr><td>a</td></tr></table>'::VARCHAR)[1].cell_value;
+----
+a
+
+query I
+SELECT html_extract_tables_json('<table><tr><td>a</td></tr></table>'::VARCHAR)[1].num_rows;
+----
+1
+
+# html_to_duck_blocks already had a VARCHAR overload - guard against regression
+query I
+SELECT html_to_duck_blocks('<h1>Title</h1>'::VARCHAR)[1].element_type;
+----
+heading
+
+# ============================================================================
+# PART 3: The HTML-typed path is unchanged
+# ============================================================================
+
+# 3.1: explicit ::HTML casts still work
+query I
+SELECT html_extract_text('<h1>Hi</h1>'::HTML, '//h1');
+----
+[Hi]
+
+query I
+SELECT html_extract_text('<html><body><h1>Title</h1><p>Body</p></body></html>'::HTML);
+----
+TitleBody
+
+query I
+SELECT html_extract_links('<a href="/x">L</a>'::HTML)[1].href;
+----
+/x
+
+# 3.2: parse_html() still returns the HTML type, and the HTML overload binds
+query I
+SELECT html_extract_text(parse_html('<h1>Hi</h1>'), '//h1');
+----
+[Hi]
+
+# 3.3: bare string literals still bind (they always did, via STRING_LITERAL)
+query I
+SELECT html_extract_text('<h1>Hi</h1>', '//h1');
+----
+[Hi]
+
+query I
+SELECT html_extract_text('<html><body><h1>Title</h1></body></html>');
+----
+Title
+
+# 3.4: both overloads are registered and neither is ambiguous
+query I
+SELECT count(*) FROM duckdb_functions()
+WHERE function_name = 'html_extract_text' AND parameter_types = ['HTML'];
+----
+1
+
+query I
+SELECT count(*) FROM duckdb_functions()
+WHERE function_name = 'html_extract_text' AND parameter_types = ['VARCHAR'];
+----
+1
+
+# 3.5: the VARCHAR -> HTML cast remains explicit-only (this fix does not change
+# cast policy, it only widens the function signatures)
+query I
+SELECT '<h1>Hi</h1>'::VARCHAR::HTML IS NOT NULL;
+----
+true

--- a/test/sql/github_issue_130_table_json_and_footers.test
+++ b/test/sql/github_issue_130_table_json_and_footers.test
@@ -1,0 +1,167 @@
+# name: test/sql/github_issue_130_table_json_and_footers.test
+# description: html_extract_tables_json returns readable JSON; <tfoot> survives; JSON escaping is valid
+# group: [sql]
+
+#
+# GitHub Issue #130: html_extract_tables_json was unusable in either direction
+# https://github.com/teaguesterling/duckdb_webbed/issues/130
+#
+# Its table_json / json_structure fields were declared LogicalType::STRUCT({}) — an
+# empty placeholder — while the runtime value was a populated struct whose `rows`
+# element type came from the document's own headers. A scalar function's return type
+# is fixed at bind time, so a per-document struct type is not expressible: every call
+# failed with "Cannot cast STRUCTs of different size". Separately, a table with no
+# <th> built Value::LIST() from an empty vector, which is a DuckDB assertion.
+#
+# Fix: those two fields carry JSON text, whose keys follow duck_block_utils' table
+# encoding, and every list is built with the typed Value::LIST(type, values) overload.
+#
+# GitHub Issue #131: <tfoot> rows were dropped or relabelled as data
+# https://github.com/teaguesterling/duckdb_webbed/issues/131
+#
+# GitHub Issue #132: EscapeJsonString emitted invalid JSON for control characters
+# https://github.com/teaguesterling/duckdb_webbed/issues/132
+#
+
+require webbed
+
+require json
+
+# ==============================================================================
+# #130: a table with no <th> must not raise an INTERNAL error
+# ==============================================================================
+
+query I
+SELECT html_extract_tables_json('<table><tr><td>a</td></tr></table>'::HTML)[1].num_rows;
+----
+1
+
+# the same through the VARCHAR overload
+query I
+SELECT html_extract_tables_json('<table><tr><td>a</td></tr></table>'::VARCHAR)[1].num_rows;
+----
+1
+
+# a table with neither headers nor body rows is still not a crash
+query I
+SELECT len(html_extract_tables_json('<table><tfoot><tr><td>only</td></tr></tfoot></table>'::HTML));
+----
+1
+
+# ==============================================================================
+# #130: the returned value is readable, and is valid JSON
+# ==============================================================================
+
+query I
+SELECT json_valid(html_extract_tables_json(
+    '<table><tr><th>h</th></tr><tr><td>a</td></tr></table>'::HTML)[1].table_json);
+----
+true
+
+query I
+SELECT json_valid(html_extract_tables_json(
+    '<table><tr><th>h</th></tr><tr><td>a</td></tr></table>'::HTML)[1].json_structure);
+----
+true
+
+# ==============================================================================
+# #130: key names match duck_block_utils' table encoding, so the value drops
+# straight into a duck_block table's content. "rows" must be positional arrays;
+# the header-keyed objects live under "records". Swapping those two would render
+# wrong rather than error.
+# ==============================================================================
+
+query I
+SELECT html_extract_tables_json(
+    '<table><tr><th>item</th><th>qty</th></tr><tr><td>apples</td><td>3</td></tr></table>'::HTML
+)[1].table_json ->> '$.rows[0][0]';
+----
+apples
+
+query I
+SELECT html_extract_tables_json(
+    '<table><tr><th>item</th><th>qty</th></tr><tr><td>apples</td><td>3</td></tr></table>'::HTML
+)[1].table_json ->> '$.records[0].item';
+----
+apples
+
+# ==============================================================================
+# #131: <tfoot> rows are kept, and kept distinct from body rows
+# ==============================================================================
+
+# the duck_blocks table encoding carries them under "footers"
+query I
+SELECT b.content FROM (SELECT unnest(html_to_duck_blocks(
+  '<table><thead><tr><th>item</th><th>qty</th></tr></thead>'
+  '<tbody><tr><td>apples</td><td>3</td></tr></tbody>'
+  '<tfoot><tr><td>total</td><td>3</td></tr></tfoot></table>')) AS b)
+WHERE b.element_type = 'table';
+----
+{"headers":["item","qty"],"rows":[["apples","3"]],"footers":[["total","3"]]}
+
+# a footer row must not appear among the body rows
+query I
+SELECT b.content ->> '$.rows[0][0]' FROM (SELECT unnest(html_to_duck_blocks(
+  '<table><thead><tr><th>item</th></tr></thead><tbody><tr><td>apples</td></tr></tbody>'
+  '<tfoot><tr><td>total</td></tr></tfoot></table>')) AS b)
+WHERE b.element_type = 'table';
+----
+apples
+
+# no <tfoot> means no "footers" key at all, so existing readers are unaffected
+query I
+SELECT b.content FROM (SELECT unnest(html_to_duck_blocks(
+  '<table><tr><th>h</th></tr><tr><td>a</td></tr></table>')) AS b)
+WHERE b.element_type = 'table';
+----
+{"headers":["h"],"rows":[["a"]]}
+
+# html_extract_table_rows labels them rather than calling them data
+query I
+SELECT string_agg(r.row_type || ':' || r.cell_value, ' ') FROM (SELECT unnest(html_extract_table_rows(
+  '<table><thead><tr><th>item</th></tr></thead><tbody><tr><td>apples</td></tr></tbody>'
+  '<tfoot><tr><td>total</td></tr></tfoot></table>'::HTML)) AS r);
+----
+header:item data:apples footer:total
+
+# footers reach html_extract_tables_json too
+query I
+SELECT html_extract_tables_json(
+  '<table><thead><tr><th>item</th></tr></thead><tbody><tr><td>apples</td></tr></tbody>'
+  '<tfoot><tr><td>total</td></tr></tfoot></table>'::HTML)[1].table_json ->> '$.footers[0][0]';
+----
+total
+
+# and survive a round trip back to HTML
+query I
+SELECT duck_blocks_to_html(html_to_duck_blocks(
+  '<table><thead><tr><th>item</th></tr></thead><tbody><tr><td>apples</td></tr></tbody>'
+  '<tfoot><tr><td>total</td></tr></tfoot></table>'));
+----
+<table><thead><tr><th>item</th></tr></thead><tbody><tr><td>apples</td></tr></tbody><tfoot><tr><td>total</td></tr></tfoot></table>
+
+# ==============================================================================
+# #132: control characters below 0x20 must be escaped, or the content is not JSON
+# ==============================================================================
+
+query I
+SELECT json_valid(b.content) FROM (SELECT unnest(html_to_duck_blocks(
+  '<table><tr><th>a' || chr(11) || 'b</th></tr><tr><td>x</td></tr></table>')) AS b)
+WHERE b.element_type = 'table';
+----
+true
+
+query I
+SELECT b.content FROM (SELECT unnest(html_to_duck_blocks(
+  '<table><tr><th>a' || chr(11) || 'b</th></tr><tr><td>x</td></tr></table>')) AS b)
+WHERE b.element_type = 'table';
+----
+{"headers":["a\u000bb"],"rows":[["x"]]}
+
+# the characters that already worked must keep working
+query I
+SELECT json_valid(b.content) FROM (SELECT unnest(html_to_duck_blocks(
+  '<table><tr><th>q"' || chr(9) || chr(10) || 'z</th></tr><tr><td>x</td></tr></table>')) AS b)
+WHERE b.element_type = 'table';
+----
+true


### PR DESCRIPTION
Fixes #129, #130, #131 and #132.

## #129 — `html_extract_*` rejected VARCHAR

The functions were registered only on the `HTML` type, and `VARCHAR -> HTML` is an explicit-only cast. String literals bound anyway, because DuckDB special-cases `STRING_LITERAL` to reach any type for cost 20 — which is why every doc example worked and every real column did not:

```sql
SELECT html_extract_text(content, '//h1') FROM read_text('zim://archive.zim/Entry');
-- Binder Error: No function matches ... 'html_extract_text(VARCHAR, STRING_LITERAL)'
```

`docs/functions/html_extraction.rst:20` already documented the parameter as ``(VARCHAR or HTML)``, so the implementation never matched its own docs.

Fixed with VARCHAR overloads, matching what `xml_extract_text` ("compatibility") and `html_to_duck_blocks` already do — not by making `VARCHAR -> HTML` implicitly castable. `HTML` is an alias of `VARCHAR` and `HTML -> VARCHAR` is already implicit at cost 1; making the reverse implicit too would change binding globally, including `CASE` branches, `UNION` resolution, and the sets that carry both overloads.

## #130 — `html_extract_tables_json` was unusable in either direction

`table_json` and `json_structure` were declared `LogicalType::STRUCT({})` — an empty placeholder — while the runtime value was a populated struct whose `rows` element type came from the document's own headers (`STRUCT(h VARCHAR)[]` for a column named `h`). A scalar function's return type is fixed at bind time, so a per-document struct type cannot be expressed, and every call failed with *Cannot cast STRUCTs of different size*. Separately, a table with no `<th>` built `Value::LIST()` from an empty vector, which is a DuckDB assertion, not a user-facing error.

Both fields now carry JSON text — what the function name promised — and every list uses the typed `Value::LIST(type, values)` overload.

The keys follow duck_block_utils' table encoding, `{"headers": [...], "rows": [[...]]}` with `rows` as positional cells, so the value drops straight into a duck_block table's content and into `db_render_table_json`. Header-keyed objects moved to `records`; leaving them under `rows` would have collided with that convention and rendered wrong rather than errored. This also settles an inconsistency inside webbed itself, whose duck_blocks table encoder already used `rows` for positional cells.

## #131 — `<tfoot>` rows were dropped or relabelled

`html_to_duck_blocks` discarded them; `html_extract_table_rows` kept them but called them `row_type='data'`, so a summary row was indistinguishable from data.

`HTMLTable` gains a `footers` member, the extractor collects `<tfoot>` and excludes those rows from the body via `not(ancestor::tfoot)`, the duck_blocks encoding gains an optional `"footers"` key **omitted entirely when there is no footer** so existing readers are unaffected, `html_extract_table_rows` reports `row_type='footer'`, and `duck_blocks_to_html` writes `<tfoot>` back out so footers round-trip.

Rendering footers distinctly is a duck_block_utils question and is not addressed here.

## #132 — `EscapeJsonString` emitted invalid JSON

It escaped only `"` `\` `\n` `\r` `\t` and copied every other control character through verbatim. An HTML cell containing a vertical tab produced block content that `json_valid()` rejects.

There is now one escaper, `XMLUtils::EscapeJSONText`, covering `\b`, `\f` and `\uXXXX` for the rest of the C0 range and iterating as `unsigned char`; both former copies delegate to it. `UnescapeJsonString` learned `\uXXXX` so the pair round-trips.

## Verification

```
All tests passed (3143 assertions in 93 test cases)
```

Up from 3117 in 92. Every `duckdb-stable-build` (v1.5.4) CI target is green: Linux amd64/arm64, macOS x2, Windows, Wasm x3, WASM load test.

## Known-failing job, unrelated to this branch

`duckdb-next-build` `linux_arm64` fails at *Build extension*, not at tests, in `src/xml_reader_functions.cpp:2175` — a file this branch does not touch:

```
error: invalid conversion from '... vector<std::string>&)' to 'duckdb::table_function_bind_t'
       {aka '... vector<duckdb::Identifier>&)'}
```

DuckDB `main` changed `table_function_bind_t`'s last parameter. `main` last ran green on 2026-07-27, so upstream moved underneath it; this will reproduce on `main` too. The fix is extending the `DUCKDB_HAS_IDENTIFIER` shim already in `src/include/duckdb_compat.hpp` to cover the bind signature — a separate change.