### PR TITLE
ci: canary on main only, apply formatter drift, re-enable the format check

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -12,8 +12,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Forward-compatibility canary: builds against DuckDB main to give advance warning
+  # of upstream API changes. It is EXPECTED to go red whenever main breaks an API this
+  # extension uses -- the shippable build is the stable job below.
+  #
+  # It runs ONLY on pushes to main. Skipping pull_request alone is not enough: pushing
+  # to a branch fires a push run AND a pull_request run against the same commit, and a
+  # PR's check rollup includes both, so the canary would still show red on every PR.
+  #
+  # `if` rather than `continue-on-error`: a job calling a REUSABLE WORKFLOW accepts only
+  # name/needs/if/permissions/uses/with/secrets/strategy/concurrency, and adding
+  # continue-on-error makes the whole workflow fail to PARSE.
+  #
+  # Currently red on the DuckDB main bind-signature change
+  # (unique_ptr<FunctionData> conversions in xml_reader_functions.cpp).
   duckdb-next-build:
-    name: Build extension binaries
+    name: Canary — build against DuckDB main (advisory)
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       duckdb_version: main

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -100,11 +100,18 @@ jobs:
           timeout 240 node load_test.cjs --repo repo --name webbed --platform eh \
             --query "SELECT xml_valid('<a/>') AS ok" --expect '"ok":true'
 
-#  code-quality-check:
-#    name: Code Quality Check
-#    uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
-#    with:
-#      duckdb_version: v1.3.2
-#      ci_tools_version: main
-#      extension_name: webbed
-#      format_checks: 'format;tidy'
+  # Re-enabled: the repo now passes format-check (the drift it would have failed on
+  # was applied separately). Pinned to the same duckdb_version as the stable build --
+  # the commented-out version said v1.3.2, long superseded.
+  #
+  # format only, no tidy: tidy configures CMake without vcpkg, so this extension's
+  # libxml2 dependency is not found and the check cannot even configure. Same reason
+  # the sibling zim extension runs format only.
+  code-quality-check:
+    name: Code Quality Check
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
+    with:
+      duckdb_version: v1.5.4
+      ci_tools_version: main
+      extension_name: webbed
+      format_checks: 'format'

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -54,7 +54,6 @@ inline string CompatMakeIdentifier(string name) {
 }
 #endif
 
-
 #ifdef DUCKDB_HAS_NEW_VECTOR_HEADERS
 
 // --- Bind function signature ---

--- a/src/include/xml_sax_reader.hpp
+++ b/src/include/xml_sax_reader.hpp
@@ -21,12 +21,12 @@ enum class SAXAccumulatorState {
 // A single occurrence of a record field, tagged by payload kind. Occurrences are stored in
 // document order so a field mixing bare-text and nested-XML siblings keeps its original sequence.
 struct FieldOccurrence {
-	bool is_xml;          // true = nested-XML fragment, false = text payload
-	std::string payload;  // serialized XML fragment (is_xml) or cleaned text (!is_xml)
+	bool is_xml;           // true = nested-XML fragment, false = text payload
+	std::string payload;   // serialized XML fragment (is_xml) or cleaned text (!is_xml)
 	std::string own_attrs; // the field element's OWN attributes, pre-serialized and escaped as
-	                        // ` name="value"...` (empty if none), spliced into the reconstructed
-	                        // open tag so a direct child like <CustomFunctionReference id=".."/>
-	                        // keeps its attributes under streaming (DOM parity).
+	                       // ` name="value"...` (empty if none), spliced into the reconstructed
+	                       // open tag so a direct child like <CustomFunctionReference id=".."/>
+	                       // keeps its attributes under streaming (DOM parity).
 };
 
 // Accumulates field data from SAX events for a single XML record

--- a/src/xml_sax_reader.cpp
+++ b/src/xml_sax_reader.cpp
@@ -580,8 +580,8 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 			if (occs.empty()) {
 				value = Value(col_type); // typed NULL
 			} else if (occs.front().is_xml) {
-				value = XMLSchemaInference::ExtractValueFromXmlFragment(
-				    col_name, occs.front().payload, col_type, options, ns_decls, occs.front().own_attrs);
+				value = XMLSchemaInference::ExtractValueFromXmlFragment(col_name, occs.front().payload, col_type,
+				                                                        options, ns_decls, occs.front().own_attrs);
 			} else {
 				// Text-only occurrence: wrap escaped text so the extractor yields a non-NULL struct
 				// shell (fields NULL), matching DOM, rather than a fully-NULL struct.
@@ -621,8 +621,8 @@ std::vector<Value> SAXStreamReader::AccumulatorToRow(const SAXRecordAccumulator 
 			};
 			auto append_xml = [&](const std::string &frag, const std::string &own_attrs) {
 				if (child_is_complex) {
-					list_vals.push_back(XMLSchemaInference::ExtractValueFromXmlFragment(
-					    col_name, frag, child_type, options, ns_decls, own_attrs));
+					list_vals.push_back(XMLSchemaInference::ExtractValueFromXmlFragment(col_name, frag, child_type,
+					                                                                    options, ns_decls, own_attrs));
 				} else if (child_type.id() == LogicalTypeId::VARCHAR) {
 					// Scalar-typed list with an XML item: surface the serialized fragment.
 					list_vals.push_back(Value(frag));

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1242,9 +1242,9 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	ScalarFunctionSet xml_extract_text_functions("xml_extract_text");
 
 	// XML + VARCHAR -> LIST(VARCHAR)
-	add_ns_aware(xml_extract_text_functions, ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR},
-	                                                        LogicalType::LIST(LogicalType::VARCHAR),
-	                                                        XMLExtractTextListFunction));
+	add_ns_aware(xml_extract_text_functions,
+	             ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
+	                            XMLExtractTextListFunction));
 	// XML + STRING_LITERAL -> LIST(VARCHAR)
 	// (no varargs on STRING_LITERAL overloads: varargs + a literal parameter makes DuckDB resolve a
 	//  literal return type and trip an internal error. The named-arg case routes through the VARCHAR
@@ -1253,17 +1253,17 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	    ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
 	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction));
 	// XMLFragment + VARCHAR -> LIST(VARCHAR)
-	add_ns_aware(xml_extract_text_functions, ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR},
-	                                                        LogicalType::LIST(LogicalType::VARCHAR),
-	                                                        XMLExtractTextListFunction));
+	add_ns_aware(xml_extract_text_functions,
+	             ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR},
+	                            LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction));
 	// XMLFragment + STRING_LITERAL -> LIST(VARCHAR)
 	xml_extract_text_functions.AddFunction(
 	    ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
 	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction));
 	// VARCHAR + VARCHAR -> LIST(VARCHAR) (compatibility)
-	add_ns_aware(xml_extract_text_functions, ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                                                        LogicalType::LIST(LogicalType::VARCHAR),
-	                                                        XMLExtractTextListFunction));
+	add_ns_aware(xml_extract_text_functions,
+	             ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
+	                            XMLExtractTextListFunction));
 	// VARCHAR + STRING_LITERAL -> LIST(VARCHAR) (compatibility)
 	xml_extract_text_functions.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
@@ -1305,34 +1305,34 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	ScalarFunctionSet xml_extract_elements_functions("xml_extract_elements");
 
 	// XML + VARCHAR -> LIST(XMLFragment)
-	add_ns_aware(xml_extract_elements_functions, ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR},
-	                                                            LogicalType::LIST(XMLTypes::XMLFragmentType()),
-	                                                            XMLExtractElementsListFunction));
+	add_ns_aware(xml_extract_elements_functions,
+	             ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR},
+	                            LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// XML + STRING_LITERAL -> LIST(XMLFragment)
 	// (STRING_LITERAL overloads stay varargs-free; see note on xml_extract_text above.)
 	xml_extract_elements_functions.AddFunction(
 	    ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
 	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// HTML + VARCHAR -> LIST(XMLFragment)
-	add_ns_aware(xml_extract_elements_functions, ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
-	                                                            LogicalType::LIST(XMLTypes::XMLFragmentType()),
-	                                                            XMLExtractElementsListFunction));
+	add_ns_aware(xml_extract_elements_functions,
+	             ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
+	                            LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// HTML + STRING_LITERAL -> LIST(XMLFragment)
 	xml_extract_elements_functions.AddFunction(
 	    ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
 	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// XMLFragment + VARCHAR -> LIST(XMLFragment) (for nested extraction)
-	add_ns_aware(xml_extract_elements_functions, ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR},
-	                                                            LogicalType::LIST(XMLTypes::XMLFragmentType()),
-	                                                            XMLExtractElementsListFunction));
+	add_ns_aware(xml_extract_elements_functions,
+	             ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR},
+	                            LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// XMLFragment + STRING_LITERAL -> LIST(XMLFragment)
 	xml_extract_elements_functions.AddFunction(
 	    ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
 	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// VARCHAR + VARCHAR -> LIST(XMLFragment) (compatibility)
-	add_ns_aware(xml_extract_elements_functions, ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                                                            LogicalType::LIST(XMLTypes::XMLFragmentType()),
-	                                                            XMLExtractElementsListFunction));
+	add_ns_aware(xml_extract_elements_functions,
+	             ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                            LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// VARCHAR + STRING_LITERAL -> LIST(XMLFragment) (compatibility)
 	xml_extract_elements_functions.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
@@ -1394,15 +1394,15 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	     make_pair("line_number", LogicalType::BIGINT)});
 	// Register xml_extract_attributes function as a function set
 	ScalarFunctionSet xml_extract_attributes_functions("xml_extract_attributes");
-	add_ns_aware(xml_extract_attributes_functions, ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR},
-	                                                              LogicalType::LIST(attr_struct_type),
-	                                                              XMLExtractAttributesFunction));
-	add_ns_aware(xml_extract_attributes_functions, ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
-	                                                              LogicalType::LIST(attr_struct_type),
-	                                                              XMLExtractAttributesFunction));
-	add_ns_aware(xml_extract_attributes_functions, ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                                                              LogicalType::LIST(attr_struct_type),
-	                                                              XMLExtractAttributesFunction));
+	add_ns_aware(xml_extract_attributes_functions,
+	             ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR}, LogicalType::LIST(attr_struct_type),
+	                            XMLExtractAttributesFunction));
+	add_ns_aware(xml_extract_attributes_functions,
+	             ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR}, LogicalType::LIST(attr_struct_type),
+	                            XMLExtractAttributesFunction));
+	add_ns_aware(xml_extract_attributes_functions,
+	             ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::LIST(attr_struct_type),
+	                            XMLExtractAttributesFunction));
 	// Add 3-argument variants with namespace map
 	xml_extract_attributes_functions.AddFunction(
 	    ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type}, LogicalType::LIST(attr_struct_type),
@@ -1484,8 +1484,7 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	// Internal regression self-test for the libxml2 out-of-memory path (see OOMSelfTestFunction).
 	// Returns 'OK' (or 'OK (oom check skipped...)' where the allocator can't be injected); any other
 	// value indicates a regression. Result is deterministic, so default stability is fine.
-	loader.RegisterFunction(
-	    ScalarFunction("xml_oom_selftest", {}, LogicalType::VARCHAR, OOMSelfTestFunction));
+	loader.RegisterFunction(ScalarFunction("xml_oom_selftest", {}, LogicalType::VARCHAR, OOMSelfTestFunction));
 
 	// Register xml_detect_prefixes function (returns LIST<VARCHAR> of namespace prefixes in XPath expression)
 	auto xml_detect_prefixes_function =
@@ -1930,8 +1929,8 @@ static bool IsWhitespacePreservingElement(const xmlChar *name) {
 		return false;
 	}
 	std::string n(reinterpret_cast<const char *>(name));
-	return StringUtil::CIEquals(n, "pre") || StringUtil::CIEquals(n, "textarea") ||
-	       StringUtil::CIEquals(n, "script") || StringUtil::CIEquals(n, "style");
+	return StringUtil::CIEquals(n, "pre") || StringUtil::CIEquals(n, "textarea") || StringUtil::CIEquals(n, "script") ||
+	       StringUtil::CIEquals(n, "style");
 }
 
 // Collapse each run of ASCII whitespace in TEXT nodes to a single space, recursively, operating
@@ -2058,33 +2057,33 @@ void XMLScalarFunctions::ParseHTMLFunction(DataChunk &args, ExpressionState &sta
 void XMLScalarFunctions::ReadHTMLFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &html_content_vector = args.data[0];
 
-	UnaryExecutor::Execute<string_t, string_t>(
-	    html_content_vector, result, args.size(), [&](string_t html_content_str) {
-		    std::string html_content = html_content_str.GetString();
+	UnaryExecutor::Execute<string_t, string_t>(html_content_vector, result, args.size(),
+	                                           [&](string_t html_content_str) {
+		                                           std::string html_content = html_content_str.GetString();
 
-		    // Handle empty HTML content gracefully
-		    if (html_content.empty()) {
-			    return string_t("<html></html>");
-		    }
+		                                           // Handle empty HTML content gracefully
+		                                           if (html_content.empty()) {
+			                                           return string_t("<html></html>");
+		                                           }
 
-		    try {
-			    // Parse the HTML using the HTML parser to normalize it
-			    XMLDocRAII html_doc(html_content, true); // Use HTML parser
-			    if (html_doc.IsValid()) {
-				    std::string minified_html;
-				    if (SerializeMinifiedHTML(html_doc.doc, minified_html)) {
-					    return StringVector::AddString(result, minified_html);
-				    }
-			    }
+		                                           try {
+			                                           // Parse the HTML using the HTML parser to normalize it
+			                                           XMLDocRAII html_doc(html_content, true); // Use HTML parser
+			                                           if (html_doc.IsValid()) {
+				                                           std::string minified_html;
+				                                           if (SerializeMinifiedHTML(html_doc.doc, minified_html)) {
+					                                           return StringVector::AddString(result, minified_html);
+				                                           }
+			                                           }
 
-			    // Fallback to original content if parsing fails
-			    return StringVector::AddString(result, html_content);
+			                                           // Fallback to original content if parsing fails
+			                                           return StringVector::AddString(result, html_content);
 
-		    } catch (const std::exception &e) {
-			    // Return original content if there's an error parsing
-			    return StringVector::AddString(result, html_content);
-		    }
-	    });
+		                                           } catch (const std::exception &e) {
+			                                           // Return original content if there's an error parsing
+			                                           return StringVector::AddString(result, html_content);
+		                                           }
+	                                           });
 }
 
 void XMLScalarFunctions::HTMLUnescapeFunction(DataChunk &args, ExpressionState &state, Vector &result) {

--- a/test/sql/duck_block_robustness.test
+++ b/test/sql/duck_block_robustness.test
@@ -1,6 +1,5 @@
 # name: test/sql/duck_block_robustness.test
-# description: Malformed-input tests for duck_blocks_to_html: invalid heading_level values,
-#              NULL struct fields, and truncated Pandoc table JSON
+# description: Malformed-input tests for duck_blocks_to_html: invalid heading_level values, NULL struct fields, and truncated Pandoc table JSON
 # group: [sql]
 
 require webbed

--- a/test/sql/oom_resource_error.test
+++ b/test/sql/oom_resource_error.test
@@ -1,6 +1,5 @@
 # name: test/sql/oom_resource_error.test
-# description: libxml2 out-of-memory path (#84/#94) — CheckXML must report ResourceError (not
-#              Malformed) under allocation failure, and resource_error must survive XMLDocRAII moves
+# description: libxml2 out-of-memory path (#84/#94) — CheckXML must report ResourceError (not Malformed) under allocation failure, and resource_error must survive XMLDocRAII moves
 # group: [sql]
 
 require webbed

--- a/test/sql/sax_nested_child_attr_parity.test
+++ b/test/sql/sax_nested_child_attr_parity.test
@@ -1,8 +1,5 @@
 # name: test/sql/sax_nested_child_attr_parity.test
-# description: SAX streaming must keep the OWN attributes of repeated nested child elements,
-#             which webbed exposes as LIST<STRUCT(@attrs...)>. Regression for: under streaming
-#             the per-item attributes were dropped, so each list STRUCT came back NULL
-#             ([NULL, NULL]) while the DOM path returned the attribute values.
+# description: SAX streaming must keep the OWN attributes of repeated nested child elements, which webbed exposes as LIST<STRUCT(@attrs...)>. Regression for: under streaming the per-item attributes were dropped, so each list STRUCT came back NULL ([NULL, NULL]) while the DOM path returned the attribute values.
 # group: [sql]
 
 require webbed

--- a/test/sql/sax_serialize_cr_parity.test
+++ b/test/sql/sax_serialize_cr_parity.test
@@ -1,7 +1,5 @@
 # name: test/sql/sax_serialize_cr_parity.test
-# description: SAX streaming must serialize carriage returns in captured raw XML the same
-#             way DOM does (&#13;), so a captured-subtree VARCHAR is byte-identical across
-#             reader modes. Regression for: SAX emitted a raw CR byte where DOM emits &#13;.
+# description: SAX streaming must serialize carriage returns in captured raw XML the same way DOM does (&#13;), so a captured-subtree VARCHAR is byte-identical across reader modes. Regression for: SAX emitted a raw CR byte where DOM emits &#13;.
 # group: [sql]
 
 require webbed

--- a/test/sql/xml_inference_all_siblings.test
+++ b/test/sql/xml_inference_all_siblings.test
@@ -1,9 +1,5 @@
 # name: test/sql/xml_inference_all_siblings.test
-# description: Single-file schema inference for a repeated element (LIST<STRUCT>) must scan
-#             ALL occurrences, not just the first, when building the struct's fields. An
-#             optional grandchild absent from the first occurrence but present in a later
-#             one must appear in the inferred struct (nullable) with its value preserved.
-#             No union_by_name, no multiple files.
+# description: Single-file schema inference for a repeated element (LIST<STRUCT>) must scan ALL occurrences, not just the first, when building the struct's fields. An optional grandchild absent from the first occurrence but present in a later one must appear in the inferred struct (nullable) with its value preserved. No union_by_name, no multiple files.
 # group: [sql]
 
 require webbed

--- a/test/sql/xml_sax_accumulator_parity.test
+++ b/test/sql/xml_sax_accumulator_parity.test
@@ -1,6 +1,5 @@
 # name: test/sql/xml_sax_accumulator_parity.test
-# description: The SAX streaming path produces the same values as DOM for text-only STRUCT
-#             fields and for list-shaped columns that union_by_name widens to VARCHAR.
+# description: The SAX streaming path produces the same values as DOM for text-only STRUCT fields and for list-shaped columns that union_by_name widens to VARCHAR.
 # group: [sql]
 
 require webbed

--- a/test/sql/xml_schema_inference_fixes.test
+++ b/test/sql/xml_schema_inference_fixes.test
@@ -1,7 +1,5 @@
 # name: test/sql/xml_schema_inference_fixes.test
-# description: Regression tests for schema inference fixes: integer widening, prefixed
-#              attributes, deterministic column order, inf/nan handling, and NULL-filling
-#              of fallback schema columns
+# description: Regression tests for schema inference fixes: integer widening, prefixed attributes, deterministic column order, inf/nan handling, and NULL-filling of fallback schema columns
 # group: [sql]
 
 require webbed

--- a/test/sql/xml_union_struct_list_cardinality.test
+++ b/test/sql/xml_union_struct_list_cardinality.test
@@ -1,8 +1,5 @@
 # name: test/sql/xml_union_struct_list_cardinality.test
-# description: union_by_name must reconcile an element that infers as a scalar STRUCT in one
-#             file (single occurrence) with LIST<STRUCT> in another (2+ occurrences) by
-#             promoting the singleton to a one-element list and widening, NOT collapsing to
-#             VARCHAR and dropping data.
+# description: union_by_name must reconcile an element that infers as a scalar STRUCT in one file (single occurrence) with LIST<STRUCT> in another (2+ occurrences) by promoting the singleton to a one-element list and widening, NOT collapsing to VARCHAR and dropping data.
 # group: [sql]
 
 require webbed


### PR DESCRIPTION
Housekeeping that unblocks #133, which has been sitting on two red checks that are neither its fault nor a build problem.

## The two red checks on #133 are a DuckDB-`main` canary

Two jobs were both named **"Build extension binaries"** — one builds against the stable `duckdb_version: v1.5.4`, the other against DuckDB `main`. Nothing in the checks list distinguished them, so the canary's failures read as the extension being broken.

The canary is working correctly. It is red on DuckDB `main`'s bind-signature change (`unique_ptr<FunctionData>` conversions in `xml_reader_functions.cpp`) — genuine advance warning of what a future DuckDB release will require. But a job that is *expected* to be red and is indistinguishable from one that is not teaches everyone to ignore red.

It now runs on pushes to `main` and `workflow_dispatch` only. Skipping `pull_request` alone is not enough: pushing to a branch fires a `push` run **and** a `pull_request` run against the same commit, and a PR's rollup includes both. `if` rather than `continue-on-error`, because a job calling a reusable workflow does not accept that key — adding it makes the workflow fail to **parse**. Both facts are in the comment so neither gets retried.

## The format check has never been running

`code-quality-check` was **commented out entirely**, which is why 11 files had accumulated formatter drift unnoticed.

Re-enabled, with two corrections: `duckdb_version` was `v1.3.2` in the commented-out block (long superseded, now `v1.5.4` matching the stable build), and `format` only rather than `format;tidy` — tidy configures CMake without vcpkg, so libxml2 is not found and the check cannot configure. The sibling `zim` extension runs format-only for the same reason.

## The drift itself

Applied in its own commit so no feature branch carries it.

Three source files take the formatter's output directly. The eight `.test` files needed hand-work: sqllogictest wants `name`/`description`/`group` as consecutive lines, and **`make format-fix` satisfies that by inserting `# group:` into the middle of a multi-line description** — passing the check while splitting a sentence across an unrelated directive:

```
 # description: union_by_name must reconcile an element that infers as a scalar STRUCT in one
+# group: [sql]
+
 #             file (single occurrence) with LIST<STRUCT> in another ...
-# group: [sql]
```

Each description is joined onto its `# description:` line instead, which is what the format wants and reads correctly.

**No test content changed:** 3104 assertions in 91 test cases, before and after. YAML validated with a duplicate-key-strict parse.