### PR TITLE
fix: raise on syntactically invalid XPath instead of silently returning empty (#134)

### DIFF
--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -305,7 +305,7 @@ void DuckBlockFunctions::HtmlToDuckBlocksFunction(DataChunk &args, ExpressionSta
 		int32_t block_order = 0;
 
 		// First, extract frontmatter script blocks
-		xmlXPathObjectPtr frontmatter_obj = xmlXPathEvalExpression(BAD_CAST FRONTMATTER_XPATH, xpath_ctx);
+		xmlXPathObjectPtr frontmatter_obj = EvalXPathChecked(xpath_ctx, FRONTMATTER_XPATH);
 		if (frontmatter_obj && frontmatter_obj->nodesetval) {
 			for (int j = 0; j < frontmatter_obj->nodesetval->nodeNr; j++) {
 				xmlNodePtr node = frontmatter_obj->nodesetval->nodeTab[j];
@@ -331,7 +331,7 @@ void DuckBlockFunctions::HtmlToDuckBlocksFunction(DataChunk &args, ExpressionSta
 		}
 
 		// Execute XPath query for block-level elements
-		xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST BLOCK_XPATH, xpath_ctx);
+		xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xpath_ctx, BLOCK_XPATH);
 
 		if (xpath_obj && xpath_obj->nodesetval) {
 			for (int j = 0; j < xpath_obj->nodesetval->nodeNr; j++) {

--- a/src/include/xml_utils.hpp
+++ b/src/include/xml_utils.hpp
@@ -188,6 +188,21 @@ std::string TransformXPathForUndeclaredPrefixes(const std::string &xpath,
 std::string InjectNamespaceDeclarations(const std::string &xml_str,
                                         const case_insensitive_map_t<string> &namespaces_to_inject);
 
+// Evaluate an XPath expression, raising on a syntactically invalid one (issue #134).
+//
+// xmlXPathEvalExpression returns NULL for two very different reasons: the expression
+// failed to parse, and the expression parsed but could not be evaluated (most commonly
+// an undefined namespace prefix). Collapsing both into an empty result makes a typo
+// indistinguishable from a query that legitimately matched nothing.
+//
+// Compiling first separates them. A compile failure is a malformed expression and
+// throws InvalidInputException naming the expression. An expression that compiles but
+// evaluates to NULL returns nullptr, which callers continue to treat as "no matches" --
+// so an undeclared namespace prefix keeps its existing empty result.
+//
+// Returns a node-set object the caller owns and must xmlXPathFreeObject, or nullptr.
+xmlXPathObjectPtr EvalXPathChecked(xmlXPathContextPtr xpath_ctx, const std::string &xpath);
+
 // Detect namespace prefixes used in an XML document (scans for prefix:name patterns)
 std::set<std::string> DetectDocumentPrefixes(const std::string &xml_str);
 

--- a/src/xml_schema_inference.cpp
+++ b/src/xml_schema_inference.cpp
@@ -188,7 +188,7 @@ std::vector<xmlNodePtr> XMLSchemaInference::IdentifyRecordElements(XMLDocRAII &d
 			}
 		}
 
-		xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath_expr.c_str(), doc.xpath_ctx);
+		xmlXPathObjectPtr xpath_obj = EvalXPathChecked(doc.xpath_ctx, xpath_expr);
 
 		if (xpath_obj && xpath_obj->nodesetval) {
 			for (int i = 0; i < xpath_obj->nodesetval->nodeNr; i++) {
@@ -201,7 +201,7 @@ std::vector<xmlNodePtr> XMLSchemaInference::IdentifyRecordElements(XMLDocRAII &d
 	// If a specific root element is specified, find it
 	else if (!options.root_element.empty()) {
 		std::string xpath = "//" + options.root_element;
-		xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), doc.xpath_ctx);
+		xmlXPathObjectPtr xpath_obj = EvalXPathChecked(doc.xpath_ctx, xpath);
 
 		if (xpath_obj && xpath_obj->nodesetval && xpath_obj->nodesetval->nodeNr > 0) {
 			root = xpath_obj->nodesetval->nodeTab[0];
@@ -716,7 +716,7 @@ std::vector<ElementPattern> XMLSchemaInference::AnalyzeDocumentStructure(const s
 			}
 		}
 
-		xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath_expr.c_str(), xml_doc.xpath_ctx);
+		xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath_expr);
 
 		if (xpath_obj && xpath_obj->nodesetval) {
 			for (int i = 0; i < xpath_obj->nodesetval->nodeNr; i++) {
@@ -732,7 +732,7 @@ std::vector<ElementPattern> XMLSchemaInference::AnalyzeDocumentStructure(const s
 		// Use XPath to find the specified root element
 		std::string xpath = "//" + options.root_element;
 
-		xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+		xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 		if (xpath_obj && xpath_obj->nodesetval && xpath_obj->nodesetval->nodeNr > 0) {
 			root = xpath_obj->nodesetval->nodeTab[0];

--- a/src/xml_utils.cpp
+++ b/src/xml_utils.cpp
@@ -127,6 +127,20 @@ void XMLSilentXPathErrorHandler(void *ctx, const xmlError *error) {
 	// This is thread-safe because it's set per-context, not globally
 }
 
+// See xml_utils.hpp for why this compiles before evaluating.
+xmlXPathObjectPtr EvalXPathChecked(xmlXPathContextPtr xpath_ctx, const std::string &xpath) {
+	if (!xpath_ctx) {
+		return nullptr;
+	}
+	xmlXPathCompExprPtr compiled = xmlXPathCtxtCompile(xpath_ctx, BAD_CAST xpath.c_str());
+	if (!compiled) {
+		throw InvalidInputException("Invalid XPath expression: '%s'", xpath);
+	}
+	xmlXPathObjectPtr result = xmlXPathCompiledEval(compiled, xpath_ctx);
+	xmlXPathFreeCompExpr(compiled);
+	return result;
+}
+
 // Helper function to register all namespace declarations from the document into the XPath context.
 // This enables XPath expressions like "//gml:posList" to work when xmlns:gml="..." is declared.
 // Without this, libxml2's XPath engine requires manual registration of each namespace prefix.
@@ -460,7 +474,7 @@ std::vector<XMLElement> XMLUtils::ExtractByXPath(const std::string &xml_str, con
 	}
 
 	// XPath evaluation (errors already suppressed during document parsing)
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	if (xpath_obj && xpath_obj->nodesetval) {
 		for (int i = 0; i < xpath_obj->nodesetval->nodeNr; i++) {
@@ -490,7 +504,7 @@ std::vector<XMLElement> XMLUtils::ExtractByXPath(const std::string &xml_str, con
 	// Register custom namespaces
 	xml_doc.RegisterCustomNamespaces(namespaces);
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	if (xpath_obj && xpath_obj->nodesetval) {
 		for (int i = 0; i < xpath_obj->nodesetval->nodeNr; i++) {
@@ -558,7 +572,7 @@ std::vector<XMLElement> XMLUtils::ExtractByXPath(const std::string &xml_str, con
 
 	xml_doc.RegisterCustomNamespaces(ns_config.custom_namespaces);
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	if (xpath_obj && xpath_obj->nodesetval) {
 		for (int i = 0; i < xpath_obj->nodesetval->nodeNr; i++) {
@@ -583,7 +597,7 @@ std::string XMLUtils::ExtractTextByXPath(const std::string &xml_str, const std::
 	}
 
 	// XPath evaluation (errors already suppressed during document parsing)
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	std::string result;
 	if (xpath_obj) {
@@ -612,7 +626,7 @@ std::string XMLUtils::ExtractTextByXPath(const std::string &xml_str, const std::
 
 	xml_doc.RegisterCustomNamespaces(namespaces);
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	std::string result;
 	if (xpath_obj) {
@@ -640,7 +654,7 @@ std::vector<std::string> XMLUtils::ExtractAllTextByXPath(const std::string &xml_
 		return results;
 	}
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	if (xpath_obj) {
 		if (xpath_obj->nodesetval) {
@@ -672,7 +686,7 @@ std::vector<std::string> XMLUtils::ExtractAllTextByXPath(const std::string &xml_
 
 	xml_doc.RegisterCustomNamespaces(namespaces);
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	if (xpath_obj) {
 		if (xpath_obj->nodesetval) {
@@ -757,7 +771,7 @@ std::vector<std::string> XMLUtils::ExtractAllTextByXPath(const std::string &xml_
 	xml_doc.RegisterCustomNamespaces(ns_config.custom_namespaces);
 
 	// Evaluate XPath
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	if (xpath_obj) {
 		if (xpath_obj->nodesetval) {
@@ -1659,7 +1673,7 @@ std::string XMLUtils::ExtractXMLFragment(const std::string &xml_str, const std::
 		return "";
 	}
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	if (!xpath_obj || !xpath_obj->nodesetval) {
 		if (xpath_obj)
@@ -1730,7 +1744,7 @@ std::string XMLUtils::ExtractXMLFragment(const std::string &xml_str, const std::
 
 	xml_doc.RegisterCustomNamespaces(namespaces);
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	if (!xpath_obj || !xpath_obj->nodesetval) {
 		if (xpath_obj)
@@ -1791,7 +1805,7 @@ std::string XMLUtils::ExtractXMLFragmentAll(const std::string &xml_str, const st
 		return "";
 	}
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	if (!xpath_obj || !xpath_obj->nodesetval) {
 		if (xpath_obj)
@@ -1871,7 +1885,7 @@ std::string XMLUtils::ExtractXMLFragmentAll(const std::string &xml_str, const st
 
 	xml_doc.RegisterCustomNamespaces(namespaces);
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	if (!xpath_obj || !xpath_obj->nodesetval) {
 		if (xpath_obj)
@@ -1982,7 +1996,7 @@ std::string XMLUtils::ExtractXMLFragmentAll(const std::string &xml_str, const st
 
 	xml_doc.RegisterCustomNamespaces(ns_config.custom_namespaces);
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	if (!xpath_obj || !xpath_obj->nodesetval) {
 		if (xpath_obj)
@@ -2053,7 +2067,7 @@ std::vector<std::string> XMLUtils::ExtractXMLFragmentList(const std::string &xml
 		return results;
 	}
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	if (!xpath_obj || !xpath_obj->nodesetval) {
 		if (xpath_obj)
@@ -2123,7 +2137,7 @@ std::vector<std::string> XMLUtils::ExtractXMLFragmentList(const std::string &xml
 
 	xml_doc.RegisterCustomNamespaces(namespaces);
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	if (!xpath_obj || !xpath_obj->nodesetval) {
 		if (xpath_obj)
@@ -2226,7 +2240,7 @@ std::vector<std::string> XMLUtils::ExtractXMLFragmentList(const std::string &xml
 
 	xml_doc.RegisterCustomNamespaces(ns_config.custom_namespaces);
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), xml_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(xml_doc.xpath_ctx, xpath);
 
 	if (!xpath_obj || !xpath_obj->nodesetval) {
 		if (xpath_obj)
@@ -2632,7 +2646,7 @@ std::vector<HTMLLink> XMLUtils::ExtractHTMLLinks(const std::string &html_str) {
 	}
 
 	// Find all <a> elements with href attributes
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST "//a[@href]", html_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(html_doc.xpath_ctx, "//a[@href]");
 
 	if (!xpath_obj || !xpath_obj->nodesetval) {
 		if (xpath_obj)
@@ -2681,7 +2695,7 @@ std::vector<HTMLImage> XMLUtils::ExtractHTMLImages(const std::string &html_str) 
 	}
 
 	// Find all <img> elements
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST "//img", html_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(html_doc.xpath_ctx, "//img");
 
 	if (!xpath_obj || !xpath_obj->nodesetval) {
 		if (xpath_obj)
@@ -2750,7 +2764,7 @@ std::vector<HTMLTable> XMLUtils::ExtractHTMLTables(const std::string &html_str) 
 	}
 
 	// Find all <table> elements
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST "//table", html_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(html_doc.xpath_ctx, "//table");
 
 	if (!xpath_obj || !xpath_obj->nodesetval) {
 		if (xpath_obj)
@@ -2771,8 +2785,7 @@ std::vector<HTMLTable> XMLUtils::ExtractHTMLTables(const std::string &html_str) 
 				local_ctx->node = table_node;
 
 				// Look for header cells (th elements)
-				xmlXPathObjectPtr header_obj =
-				    xmlXPathEvalExpression(BAD_CAST ".//thead//th | .//tr[1]//th", local_ctx);
+				xmlXPathObjectPtr header_obj = EvalXPathChecked(local_ctx, ".//thead//th | .//tr[1]//th");
 
 				if (header_obj && header_obj->nodesetval && header_obj->nodesetval->nodeNr > 0) {
 					// Found th elements - use as headers
@@ -2799,7 +2812,7 @@ std::vector<HTMLTable> XMLUtils::ExtractHTMLTables(const std::string &html_str) 
 				                                        : ".//tbody//tr[not(ancestor::tfoot)] | "
 				                                          ".//tr[not(ancestor::tfoot)]";
 
-				xmlXPathObjectPtr rows_obj = xmlXPathEvalExpression(BAD_CAST data_xpath.c_str(), local_ctx);
+				xmlXPathObjectPtr rows_obj = EvalXPathChecked(local_ctx, data_xpath);
 
 				if (rows_obj && rows_obj->nodesetval) {
 					for (int j = 0; j < rows_obj->nodesetval->nodeNr; j++) {
@@ -2810,7 +2823,7 @@ std::vector<HTMLTable> XMLUtils::ExtractHTMLTables(const std::string &html_str) 
 						xmlXPathContextPtr row_ctx = xmlXPathNewContext(html_doc.doc);
 						if (row_ctx) {
 							row_ctx->node = row_node;
-							xmlXPathObjectPtr cells_obj = xmlXPathEvalExpression(BAD_CAST ".//td", row_ctx);
+							xmlXPathObjectPtr cells_obj = EvalXPathChecked(row_ctx, ".//td");
 
 							if (cells_obj && cells_obj->nodesetval) {
 								for (int k = 0; k < cells_obj->nodesetval->nodeNr; k++) {
@@ -2839,7 +2852,7 @@ std::vector<HTMLTable> XMLUtils::ExtractHTMLTables(const std::string &html_str) 
 					xmlXPathFreeObject(rows_obj);
 
 				// <tfoot> rows, gathered the same way as body rows
-				xmlXPathObjectPtr foot_obj = xmlXPathEvalExpression(BAD_CAST ".//tfoot//tr", local_ctx);
+				xmlXPathObjectPtr foot_obj = EvalXPathChecked(local_ctx, ".//tfoot//tr");
 				if (foot_obj && foot_obj->nodesetval) {
 					for (int j = 0; j < foot_obj->nodesetval->nodeNr; j++) {
 						xmlNodePtr row_node = foot_obj->nodesetval->nodeTab[j];
@@ -2847,7 +2860,7 @@ std::vector<HTMLTable> XMLUtils::ExtractHTMLTables(const std::string &html_str) 
 						xmlXPathContextPtr row_ctx = xmlXPathNewContext(html_doc.doc);
 						if (row_ctx) {
 							row_ctx->node = row_node;
-							xmlXPathObjectPtr cells_obj = xmlXPathEvalExpression(BAD_CAST ".//td | .//th", row_ctx);
+							xmlXPathObjectPtr cells_obj = EvalXPathChecked(row_ctx, ".//td | .//th");
 							if (cells_obj && cells_obj->nodesetval) {
 								for (int k = 0; k < cells_obj->nodesetval->nodeNr; k++) {
 									XMLCharPtr text(xmlNodeGetContent(cells_obj->nodesetval->nodeTab[k]));
@@ -2893,7 +2906,7 @@ std::string XMLUtils::ExtractHTMLText(const std::string &html_str, const std::st
 
 	std::string xpath = selector.empty() ? "//text()" : selector;
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), html_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(html_doc.xpath_ctx, xpath);
 
 	if (!xpath_obj || !xpath_obj->nodesetval) {
 		if (xpath_obj)
@@ -2922,7 +2935,7 @@ std::string XMLUtils::ExtractHTMLTextByXPath(const std::string &html_str, const 
 		return "";
 	}
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), html_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(html_doc.xpath_ctx, xpath);
 
 	if (!xpath_obj || !xpath_obj->nodesetval) {
 		if (xpath_obj)
@@ -2954,7 +2967,7 @@ std::vector<std::string> XMLUtils::ExtractHTMLAllTextByXPath(const std::string &
 		return results;
 	}
 
-	xmlXPathObjectPtr xpath_obj = xmlXPathEvalExpression(BAD_CAST xpath.c_str(), html_doc.xpath_ctx);
+	xmlXPathObjectPtr xpath_obj = EvalXPathChecked(html_doc.xpath_ctx, xpath);
 
 	if (!xpath_obj || !xpath_obj->nodesetval) {
 		if (xpath_obj)

--- a/test/sql/github_issue_134_xpath_errors.test
+++ b/test/sql/github_issue_134_xpath_errors.test
@@ -1,0 +1,94 @@
+# name: test/sql/github_issue_134_xpath_errors.test
+# description: Issue 134 - a syntactically invalid XPath raises instead of silently returning empty, while valid-but-unmatched expressions keep returning empty
+# group: [sql]
+
+require webbed
+
+# ============================================================================
+# A malformed expression must raise, not return empty.
+# Before this fix every one of these returned [] -- indistinguishable from a
+# valid expression that legitimately matched nothing.
+# ============================================================================
+
+statement error
+SELECT xml_extract_text('<r><a>x</a></r>', '//a[');
+----
+Invalid XPath expression
+
+statement error
+SELECT xml_extract_text('<r><a>x</a></r>', 'this is not xpath');
+----
+Invalid XPath expression
+
+statement error
+SELECT xml_extract_elements('<r><a>x</a></r>', '//a[');
+----
+Invalid XPath expression
+
+statement error
+SELECT xml_extract_attributes('<r><a id="1"/></r>', '//a[');
+----
+Invalid XPath expression
+
+statement error
+SELECT html_extract_text('<html><body><h2>Two</h2></body></html>'::HTML, '//h2[');
+----
+Invalid XPath expression
+
+# The error names the offending expression so the user can see what was rejected.
+statement error
+SELECT xml_extract_text('<r><a>x</a></r>', '//a[');
+----
+//a[
+
+# ============================================================================
+# Valid expressions that match nothing must still return empty, unchanged.
+# ============================================================================
+
+# 'h2' is a valid relative path from the document node; it matches nothing here.
+query I
+SELECT html_extract_text('<html><body><h2>Two</h2></body></html>'::HTML, 'h2') = [];
+----
+true
+
+query I
+SELECT xml_extract_text('<r><a>x</a></r>', '//nonexistent') = [];
+----
+true
+
+# A valid expression that does match is untouched.
+query I
+SELECT xml_extract_text('<r><a>x</a></r>', '//a');
+----
+[x]
+
+# ============================================================================
+# Regression guard for github_issue_4_namespace_extraction.test 10.1.
+# An undeclared namespace prefix is a *runtime* resolution failure, not a parse
+# failure: it compiles fine and fails at evaluation. That case keeps returning
+# empty, so this fix does not change it.
+# ============================================================================
+
+query I
+SELECT xml_extract_text('<root>
+  <gml:posList>1 2 3</gml:posList>
+</root>', '//gml:posList') = [];
+----
+true
+
+# The local-name() workaround for the same document still works.
+query I
+SELECT xml_extract_text('<root>
+  <gml:posList>1 2 3</gml:posList>
+</root>', '//*[local-name()="gml:posList"]');
+----
+[1 2 3]
+
+# ============================================================================
+# NULL handling is unaffected -- a NULL xpath is not an invalid xpath.
+# ============================================================================
+
+query I
+SELECT xml_extract_text('<r><a>x</a></r>', NULL) IS NULL;
+----
+true

--- a/test/sql/html_schema_errors.test
+++ b/test/sql/html_schema_errors.test
@@ -33,12 +33,13 @@ SELECT * FROM read_html('test/html/does_not_exist.html', record_element:='item')
 ----
 No files found
 
-# Test 5: Invalid XPath in record_element should provide clear error
-# TODO: Invalid XPath currently returns 0 rows instead of erroring
-query I
+# Test 5: Invalid XPath in record_element provides a clear error (issue #134)
+# Previously returned 0 rows, which was indistinguishable from a valid
+# record_element that matched nothing.
+statement error
 SELECT count(*) FROM read_html('test/html/invalid_html.html', record_element:='[[[invalid xpath');
 ----
-0
+Invalid XPath expression
 
 # Test 6: Conflicting parameters (columns + all_varchar) should error
 statement error


### PR DESCRIPTION
Closes #134.

## The bug

`xmlXPathEvalExpression` returns NULL for two unrelated reasons — the expression failed to *parse*, and the expression parsed but could not be *evaluated*. All 33 call sites guarded with `if (xpath_obj)` and fell through to an empty result, so a typo was indistinguishable from a query that legitimately matched nothing.

As #134 puts it: *"An empty result that means 'your query is wrong' and an empty result that means 'no matches' are different facts, and collapsing them makes a wrong query look like a real measurement."*

## The constraint that shaped the fix

A uniform throw-on-NULL would have been wrong. `github_issue_4_namespace_extraction.test` **Test 10.1 explicitly asserts** that an undeclared namespace prefix returns `[]`, and an undefined prefix also makes eval return NULL.

Compiling before evaluating separates the two cleanly. Verified against the vendored libxml2 before writing the fix:

| expression | compile | eval | |
|---|---|---|---|
| `//gml:posList` (undefined prefix) | OK | NULL | stays empty |
| `//h2[` | **NULL** | — | now raises |
| `this is not xpath` | **NULL** | — | now raises |
| `//h2` | OK | OK | unchanged |

So a compile failure raises `InvalidInputException` naming the expression; an expression that compiles but evaluates to NULL still returns `nullptr` and callers keep treating it as "no matches".

## Result — the table from the issue

```
//h2                 [Two]
//h2[                Invalid Input Error: Invalid XPath expression: '//h2['
this is not xpath    Invalid Input Error: Invalid XPath expression: 'this is not xpath'
h2                   []          <- valid, correctly matches nothing
```

## Notes

- All 33 sites route through one `EvalXPathChecked` helper, which compiles once and evaluates the compiled form rather than re-parsing inside `xmlXPathEvalExpression` — **no more work than before**.
- `html_schema_errors.test` Test 5 asserted `0` rows directly beneath the comment `TODO: Invalid XPath currently returns 0 rows instead of erroring`. It was pinning known-wrong behaviour; it now asserts the error that TODO asked for. That is the only changed expectation.
- The new test pins the malformed-vs-undefined-prefix distinction so a later uniform throw-on-NULL cannot silently regress Test 10.1.
- **Not addressed:** the issue's closing note that `count(//h2)` returns `[]` because the result is a number rather than a node-set — a separate question about what a text-extraction function should do with non-node-set results.

## Testing

`All tests passed (3155 assertions in 94 test cases)`, `Passed format-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjgU52vGS3mpSAwwgJD5C4