### PR TITLE
compat: build against DuckDB v2.0 as well as the pinned v1.5

### DIFF
--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -1850,7 +1850,7 @@ struct HTMLBlocksReadLocalState : public LocalTableFunctionState {
 
 unique_ptr<FunctionData> DuckBlockFunctions::ReadHTMLBlocksBind(ClientContext &context, TableFunctionBindInput &input,
                                                                 vector<LogicalType> &return_types,
-                                                                vector<string> &names) {
+                                                                vector<CompatName> &names) {
 	auto result = make_uniq<HTMLBlocksReadFunctionData>();
 
 	if (input.inputs.empty()) {
@@ -2063,7 +2063,7 @@ struct HTMLBlocksParseLocalState : public LocalTableFunctionState {
 
 unique_ptr<FunctionData> DuckBlockFunctions::ParseHTMLBlocksBind(ClientContext &context, TableFunctionBindInput &input,
                                                                  vector<LogicalType> &return_types,
-                                                                 vector<string> &names) {
+                                                                 vector<CompatName> &names) {
 	auto result = make_uniq<HTMLBlocksParseFunctionData>();
 
 	if (input.inputs.empty()) {
@@ -2177,11 +2177,12 @@ void DuckBlockFunctions::ParseHTMLBlocksFunction(ClientContext &context, TableFu
 void DuckBlockFunctions::Register(ExtensionLoader &loader) {
 	// html_to_duck_blocks(html HTML) -> LIST(duck_block)
 	ScalarFunctionSet html_to_duck_blocks_set("html_to_duck_blocks");
-	html_to_duck_blocks_set.AddFunction(
+	PreventStructConstantFoldingAndAdd(
+	    html_to_duck_blocks_set,
 	    ScalarFunction({XMLTypes::HTMLType()}, DuckBlockTypes::DuckBlockListType(), HtmlToDuckBlocksFunction));
-	html_to_duck_blocks_set.AddFunction(
+	PreventStructConstantFoldingAndAdd(
+	    html_to_duck_blocks_set,
 	    ScalarFunction({LogicalType::VARCHAR}, DuckBlockTypes::DuckBlockListType(), HtmlToDuckBlocksFunction));
-	PreventStructConstantFolding(html_to_duck_blocks_set);
 	loader.RegisterFunction(html_to_duck_blocks_set);
 
 	// duck_blocks_to_html(blocks LIST(duck_block)) -> HTML

--- a/src/include/duck_block_functions.hpp
+++ b/src/include/duck_block_functions.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include "duckdb_compat.hpp"
 
 namespace duckdb {
 
@@ -30,7 +31,7 @@ private:
 
 	// read_html_blocks(path VARCHAR / LIST(VARCHAR) [, filename=false, ignore_errors=false, maximum_file_size=...])
 	static unique_ptr<FunctionData> ReadHTMLBlocksBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                   vector<LogicalType> &return_types, vector<string> &names);
+	                                                   vector<LogicalType> &return_types, vector<CompatName> &names);
 	static unique_ptr<GlobalTableFunctionState> ReadHTMLBlocksInit(ClientContext &context,
 	                                                               TableFunctionInitInput &input);
 	static unique_ptr<LocalTableFunctionState> ReadHTMLBlocksInitLocal(ExecutionContext &context,
@@ -42,7 +43,7 @@ private:
 
 	// parse_html_blocks(html VARCHAR / HTML / LIST(VARCHAR) / LIST(HTML) [, ignore_errors=false])
 	static unique_ptr<FunctionData> ParseHTMLBlocksBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                    vector<LogicalType> &return_types, vector<string> &names);
+	                                                    vector<LogicalType> &return_types, vector<CompatName> &names);
 	static unique_ptr<GlobalTableFunctionState> ParseHTMLBlocksInit(ClientContext &context,
 	                                                                TableFunctionInitInput &input);
 	static unique_ptr<LocalTableFunctionState> ParseHTMLBlocksInitLocal(ExecutionContext &context,

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include <type_traits>
+#include <utility>
 
 // Detect new DuckDB API (post v1.4) by checking for moved headers.
 // When ListVector/StructVector moved to duckdb/common/vector/, the bind
@@ -54,6 +56,70 @@ inline string CompatMakeIdentifier(string name) {
 }
 #endif
 
+// --- bind-signature name type ---
+// The SAME Identifier change also moved the column-name vector handed to table-function and
+// COPY bind callbacks from vector<string> to vector<Identifier>. Spell that parameter
+// vector<CompatName> in every bind DECLARATION and DEFINITION.
+//
+// Only the signatures move. Identifier's constructor from `const char *` is IMPLICIT (a literal
+// is an identifier by intent) while its constructor from `string` is EXPLICIT (promoting a
+// runtime string is a deliberate act), so `names.push_back("filename")` compiles unchanged and
+// only the places a *runtime* string crosses the boundary need CompatMakeIdentifier /
+// CompatIdentifierName. Deliberately NOT an implicit conversion -- the explicitness is the point
+// of the upstream change.
+#ifdef DUCKDB_HAS_IDENTIFIER
+using CompatName = Identifier;
+#else
+using CompatName = string;
+#endif
+
+// Bulk form of CompatIdentifierName, for the places a bind function copies its whole `names`
+// vector into a plain vector<string> held in bind data. `assign`/`=` no longer compiles once
+// CompatName is Identifier, so the copy is element-wise.
+inline vector<string> CompatNamesToStrings(const vector<CompatName> &names) {
+	vector<string> result;
+	result.reserve(names.size());
+	for (auto &name : names) {
+		result.push_back(CompatIdentifierName(name));
+	}
+	return result;
+}
+
+// --- LogicalType alias ---
+// v1.5: void SetAlias(string)                -- mutates in place
+// v2.0: LogicalType WithAlias(string) const  -- returns a copy, so a type whose type-info is
+//       shared is never mutated behind another holder's back. SetAlias is REMOVED, not
+//       deprecated.
+//
+// Probed for the MEMBER rather than keyed off DUCKDB_HAS_IDENTIFIER: these are independent
+// upstream changes, and tying one to the other would silently pick the wrong branch if they ever
+// land in different releases.
+//
+// TAG DISPATCH, NOT `if constexpr`. This extension compiles at C++11 on Linux ON PURPOSE (see the
+// comment on the MSVC-only /std:c++17 block in CMakeLists.txt: forcing C++17 here makes
+// static-const data members in duckdb's headers acquire implicit inline linkage in our TUs but
+// not in libduckdb's C++11-built ones, which is a multiple-definition link error). Two overloaded
+// function TEMPLATES give the same "only the taken branch is instantiated" property without it.
+template <class T, class = void>
+struct CompatHasWithAlias : std::false_type {};
+template <class T>
+struct CompatHasWithAlias<T, decltype(void(std::declval<const T &>().WithAlias(string())))> : std::true_type {};
+
+template <class TYPE>
+inline LogicalType CompatWithAliasImpl(TYPE type, string alias, std::true_type) {
+	return type.WithAlias(std::move(alias)); // v2.0: returns a copy
+}
+template <class TYPE>
+inline LogicalType CompatWithAliasImpl(TYPE type, string alias, std::false_type) {
+	type.SetAlias(std::move(alias)); // v1.5: mutates in place
+	return type;
+}
+
+template <class TYPE>
+inline LogicalType CompatWithAlias(TYPE type, string alias) {
+	return CompatWithAliasImpl(std::move(type), std::move(alias), CompatHasWithAlias<TYPE>());
+}
+
 #ifdef DUCKDB_HAS_NEW_VECTOR_HEADERS
 
 // --- Bind function signature ---
@@ -94,14 +160,18 @@ inline void CompatSetOutputCardinality(DataChunk &chunk, idx_t count) {
 // DuckDB main's VectorStructBuffer::SetVectorType throws InternalException when
 // the optimizer constant-folds functions returning STRUCT-containing types
 // (LIST(STRUCT), STRUCT, MAP). Mark them VOLATILE to skip constant folding.
+//
+// There is deliberately NO FunctionSet overload. DuckDB v2.0's FunctionSet<T>::functions yields
+// shared_ptr<const T>, so a set cannot hand out a mutable member to configure after the fact:
+//
+//   error: 'class duckdb::shared_ptr<const duckdb::ScalarFunction>' has no member
+//          named 'SetStability'
+//
+// Shimming that would be wrong rather than merely awkward -- the supported shape is to finish
+// configuring each ScalarFunction BEFORE it goes into the set. Call this on the function, then
+// AddFunction it.
 inline void PreventStructConstantFolding(ScalarFunction &func) {
 	func.SetStability(FunctionStability::VOLATILE);
-}
-template <typename T>
-inline void PreventStructConstantFolding(FunctionSet<T> &func_set) {
-	for (auto &func : func_set.functions) {
-		func.SetStability(FunctionStability::VOLATILE);
-	}
 }
 
 // --- Type promotion ---
@@ -143,14 +213,22 @@ inline void CompatSetOutputCardinality(DataChunk &chunk, idx_t count) {
 // No-op on old API — constant folding works fine for complex types
 inline void PreventStructConstantFolding(ScalarFunction &) {
 }
-template <typename T>
-inline void PreventStructConstantFolding(FunctionSet<T> &) {
-}
 
 inline LogicalType CompatForceMaxLogicalType(const LogicalType &left, const LogicalType &right) {
 	return LogicalType::ForceMaxLogicalType(left, right);
 }
 
 #endif
+
+// Add a function to a function set with the VOLATILE marking applied to the function FIRST.
+// This is the only order that works on DuckDB v2.0, where FunctionSet<T>::functions yields
+// shared_ptr<const T> and a set member can no longer be configured after it has been added.
+// Defined outside the #ifdef because it delegates to whichever PreventStructConstantFolding
+// overload the branch above selected (a no-op on the old API).
+template <typename T>
+inline void PreventStructConstantFoldingAndAdd(FunctionSet<T> &func_set, T func) {
+	PreventStructConstantFolding(func);
+	func_set.AddFunction(std::move(func));
+}
 
 } // namespace duckdb

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -21,57 +21,91 @@
 #include "duckdb/function/function_set.hpp"
 #endif
 
-// Detect the duckdb::Identifier type (newer DuckDB main), which replaced std::string as the key
-// of child_list_t (STRUCT/UNION field names) and several name-typed fields (e.g. table alias,
-// Expression::GetAlias). Identifier does not implicitly convert to/from std::string, so reads and
-// constructions at the boundary must go through the helpers below. Detected by header presence so
-// it stays orthogonal to DUCKDB_HAS_NEW_VECTOR_HEADERS.
+// duckdb::Identifier is a name type that, on DuckDB main, replaced std::string as the key of
+// child_list_t (STRUCT/UNION field names), as the element of table-function bind name vectors,
+// and as several name-typed fields (table alias, Expression::GetAlias). It does not implicitly
+// convert to/from std::string, so every read and construction at those boundaries goes through a
+// helper below.
+//
+// DO NOT use this macro to decide WHICH name type a boundary uses. The header's existence is a
+// PROXY for the change, not the change itself, and the two have already come apart upstream:
+//
+//   v1.5-variegata @ b155d6f63c (our pin)  no identifier.hpp   bind/keys/alias: string
+//   v1.5-variegata @ tip f3be2750f5        HAS identifier.hpp  bind/keys/alias: STILL string
+//   main (v2.0)                            HAS identifier.hpp  bind/keys/alias: Identifier
+//
+// identifier.hpp was backported to the stable branch WITHOUT the signature changes. Anything
+// keyed on __has_include therefore flips to Identifier on a DuckDB that still wants string, and
+// the whole extension stops compiling on the next submodule bump. Each boundary below instead
+// asks DuckDB what type its OWN container holds, which cannot drift because it IS the thing
+// that changes.
+//
+// This macro's only remaining job is to gate whether an Identifier overload can EXIST.
 #if __has_include("duckdb/common/identifier.hpp")
 #define DUCKDB_HAS_IDENTIFIER 1
 #include "duckdb/common/identifier.hpp"
 #endif
 
+#if __has_include("duckdb/function/table_function.hpp")
+#include "duckdb/function/table_function.hpp"
+#endif
+#if __has_include("duckdb/parser/tableref.hpp")
+#include "duckdb/parser/tableref.hpp"
+#endif
+
 namespace duckdb {
 
+// --- name types, each derived from the container that actually holds it ---
+// These are three INDEPENDENT boundaries. They happen to move together on main and to be string
+// on both v1.5 refs, but they are separate declarations upstream and are probed separately here,
+// for the same reason the macro above must not decide any of them.
+
+//! child_list_t key: STRUCT/UNION field names.
+using CompatFieldName = typename child_list_t<int>::value_type::first_type;
+
+//! Element of the `names` out-parameter of a table-function bind callback. Spell that parameter
+//! vector<CompatName> in every bind DECLARATION and DEFINITION.
+using CompatName = typename std::remove_reference<decltype(
+    std::declval<TableFunctionBindInput &>().input_table_names)>::type::value_type;
+
+//! Type of TableRef::alias, set by a bind_replace callback.
+using CompatAliasName = decltype(TableRef::alias);
+
 // --- Identifier <-> string boundary helpers ---
-// CompatIdentifierName: read the raw string name from a child_list_t key / aliased name.
-// CompatMakeIdentifier: build a child_list_t key (or name-typed field) from a runtime string.
-// On older DuckDB these are pass-throughs (the key already is a std::string).
+// CompatIdentifierName: read the raw string name back out of any of the above.
+// CompatMakeIdentifier / CompatMakeName / CompatMakeAlias: build one from a runtime string.
+//
+// Only the READ side needs the macro, and only so an Identifier overload can exist at all. The
+// string overload is always present: on a DuckDB that has Identifier but still types these
+// boundaries as string, BOTH overloads are needed and they are unambiguous because the argument
+// types are distinct.
 #ifdef DUCKDB_HAS_IDENTIFIER
 inline const string &CompatIdentifierName(const Identifier &id) {
 	return id.GetIdentifierName();
 }
-inline const string &CompatIdentifierName(const string &name) {
-	return name;
-}
-inline Identifier CompatMakeIdentifier(string name) {
-	return Identifier(std::move(name));
-}
-#else
-inline const string &CompatIdentifierName(const string &name) {
-	return name;
-}
-inline string CompatMakeIdentifier(string name) {
-	return name;
-}
 #endif
+inline const string &CompatIdentifierName(const string &name) {
+	return name;
+}
 
-// --- bind-signature name type ---
-// The SAME Identifier change also moved the column-name vector handed to table-function and
-// COPY bind callbacks from vector<string> to vector<Identifier>. Spell that parameter
-// vector<CompatName> in every bind DECLARATION and DEFINITION.
-//
-// Only the signatures move. Identifier's constructor from `const char *` is IMPLICIT (a literal
-// is an identifier by intent) while its constructor from `string` is EXPLICIT (promoting a
-// runtime string is a deliberate act), so `names.push_back("filename")` compiles unchanged and
-// only the places a *runtime* string crosses the boundary need CompatMakeIdentifier /
-// CompatIdentifierName. Deliberately NOT an implicit conversion -- the explicitness is the point
-// of the upstream change.
-#ifdef DUCKDB_HAS_IDENTIFIER
-using CompatName = Identifier;
-#else
-using CompatName = string;
-#endif
+// The WRITE side needs no macro at all: each helper names its own boundary's type, so it yields
+// a string or an Identifier according to what that boundary actually holds. Both spellings work
+// as a constructor call -- Identifier(string) is the explicit ctor, string(string) is the copy.
+inline CompatFieldName CompatMakeIdentifier(string name) {
+	return CompatFieldName(std::move(name));
+}
+inline CompatName CompatMakeName(string name) {
+	return CompatName(std::move(name));
+}
+inline CompatAliasName CompatMakeAlias(string name) {
+	return CompatAliasName(std::move(name));
+}
+
+// Only the bind SIGNATURES move. Identifier's constructor from `const char *` is IMPLICIT (a
+// literal is an identifier by intent) while its constructor from `string` is EXPLICIT (promoting
+// a runtime string is a deliberate act), so `names.push_back("filename")` compiles unchanged and
+// only the places a *runtime* string crosses the boundary need CompatMakeName. Deliberately NOT
+// an implicit conversion -- the explicitness is the point of the upstream change.
 
 // Bulk form of CompatIdentifierName, for the places a bind function copies its whole `names`
 // vector into a plain vector<string> held in bind data. `assign`/`=` no longer compiles once

--- a/src/include/xml_reader_functions.hpp
+++ b/src/include/xml_reader_functions.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include "duckdb_compat.hpp"
 #include "xml_sax_reader.hpp"
 #include "xml_schema_inference.hpp"
 
@@ -25,10 +26,10 @@ public:
 private:
 	// Internal unified functions (used by both XML and HTML)
 	static unique_ptr<FunctionData> ReadDocumentObjectsBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                        vector<LogicalType> &return_types, vector<string> &names,
-	                                                        ParseMode mode);
+	                                                        vector<LogicalType> &return_types,
+	                                                        vector<CompatName> &names, ParseMode mode);
 	static unique_ptr<FunctionData> ReadDocumentBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                 vector<LogicalType> &return_types, vector<string> &names,
+	                                                 vector<LogicalType> &return_types, vector<CompatName> &names,
 	                                                 ParseMode mode);
 	static void ReadDocumentObjectsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static void ReadDocumentFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
@@ -44,61 +45,61 @@ private:
 	// Public XML functions (delegate to internal functions)
 	static void ReadXMLObjectsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static unique_ptr<FunctionData> ReadXMLObjectsBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                   vector<LogicalType> &return_types, vector<string> &names);
+	                                                   vector<LogicalType> &return_types, vector<CompatName> &names);
 	static unique_ptr<GlobalTableFunctionState> ReadXMLObjectsInit(ClientContext &context,
 	                                                               TableFunctionInitInput &input);
 
 	static void ReadXMLFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static unique_ptr<FunctionData> ReadXMLBind(ClientContext &context, TableFunctionBindInput &input,
-	                                            vector<LogicalType> &return_types, vector<string> &names);
+	                                            vector<LogicalType> &return_types, vector<CompatName> &names);
 	static unique_ptr<GlobalTableFunctionState> ReadXMLInit(ClientContext &context, TableFunctionInitInput &input);
 
 	// Public HTML functions (delegate to internal functions)
 	static void ReadHTMLObjectsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static unique_ptr<FunctionData> ReadHTMLObjectsBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                    vector<LogicalType> &return_types, vector<string> &names);
+	                                                    vector<LogicalType> &return_types, vector<CompatName> &names);
 	static unique_ptr<GlobalTableFunctionState> ReadHTMLObjectsInit(ClientContext &context,
 	                                                                TableFunctionInitInput &input);
 
 	static void ReadHTMLFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static unique_ptr<FunctionData> ReadHTMLBind(ClientContext &context, TableFunctionBindInput &input,
-	                                             vector<LogicalType> &return_types, vector<string> &names);
+	                                             vector<LogicalType> &return_types, vector<CompatName> &names);
 	static unique_ptr<GlobalTableFunctionState> ReadHTMLInit(ClientContext &context, TableFunctionInitInput &input);
 
 	// HTML table extraction functions
 	static void HTMLExtractTablesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static unique_ptr<FunctionData> HTMLExtractTablesBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                      vector<LogicalType> &return_types, vector<string> &names);
+	                                                      vector<LogicalType> &return_types, vector<CompatName> &names);
 	static unique_ptr<GlobalTableFunctionState> HTMLExtractTablesInit(ClientContext &context,
 	                                                                  TableFunctionInitInput &input);
 
 	// parse_xml_objects / parse_html_objects - parse XML/HTML strings and return raw content
 	static void ParseDocumentObjectsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static unique_ptr<FunctionData> ParseDocumentObjectsBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                         vector<LogicalType> &return_types, vector<string> &names,
-	                                                         ParseMode mode);
+	                                                         vector<LogicalType> &return_types,
+	                                                         vector<CompatName> &names, ParseMode mode);
 	static unique_ptr<GlobalTableFunctionState> ParseDocumentObjectsInit(ClientContext &context,
 	                                                                     TableFunctionInitInput &input);
 
 	// parse_xml / parse_html - parse XML/HTML strings with schema inference
 	static void ParseDocumentFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 	static unique_ptr<FunctionData> ParseDocumentBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                  vector<LogicalType> &return_types, vector<string> &names,
+	                                                  vector<LogicalType> &return_types, vector<CompatName> &names,
 	                                                  ParseMode mode);
 	static unique_ptr<GlobalTableFunctionState> ParseDocumentInit(ClientContext &context,
 	                                                              TableFunctionInitInput &input);
 
 	// Public parse_xml functions (delegate to internal functions)
 	static unique_ptr<FunctionData> ParseXMLObjectsBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                    vector<LogicalType> &return_types, vector<string> &names);
+	                                                    vector<LogicalType> &return_types, vector<CompatName> &names);
 	static unique_ptr<FunctionData> ParseXMLBind(ClientContext &context, TableFunctionBindInput &input,
-	                                             vector<LogicalType> &return_types, vector<string> &names);
+	                                             vector<LogicalType> &return_types, vector<CompatName> &names);
 
 	// Public parse_html functions (delegate to internal functions)
 	static unique_ptr<FunctionData> ParseHTMLObjectsBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                     vector<LogicalType> &return_types, vector<string> &names);
+	                                                     vector<LogicalType> &return_types, vector<CompatName> &names);
 	static unique_ptr<FunctionData> ParseHTMLBind(ClientContext &context, TableFunctionBindInput &input,
-	                                              vector<LogicalType> &return_types, vector<string> &names);
+	                                              vector<LogicalType> &return_types, vector<CompatName> &names);
 };
 
 // Function data structures

--- a/src/xml_reader_functions.cpp
+++ b/src/xml_reader_functions.cpp
@@ -220,7 +220,7 @@ static void MergeInferredColumns(const std::vector<XMLColumnInfo> &inferred_colu
 unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentObjectsBind(ClientContext &context,
                                                                      TableFunctionBindInput &input,
                                                                      vector<LogicalType> &return_types,
-                                                                     vector<string> &names, ParseMode mode) {
+                                                                     vector<CompatName> &names, ParseMode mode) {
 	auto result = make_uniq<XMLReadFunctionData>();
 	result->parse_mode = mode;
 
@@ -334,8 +334,8 @@ OperatorPartitionData XMLReaderFunctions::ReadDocumentGetPartitionData(ClientCon
 }
 
 unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &context, TableFunctionBindInput &input,
-                                                              vector<LogicalType> &return_types, vector<string> &names,
-                                                              ParseMode mode) {
+                                                              vector<LogicalType> &return_types,
+                                                              vector<CompatName> &names, ParseMode mode) {
 	auto result = make_uniq<XMLReadFunctionData>();
 	result->parse_mode = mode;
 
@@ -552,7 +552,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 				auto logical_type = TransformStringToLogicalType(StringValue::Get(val), context);
 
 				return_types.push_back(logical_type);
-				names.push_back(CompatIdentifierName(name));
+				names.push_back(CompatMakeIdentifier(CompatIdentifierName(name)));
 			}
 
 			if (return_types.empty()) {
@@ -561,7 +561,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 
 			// Store explicit schema in function data
 			result->has_explicit_schema = true;
-			result->column_names = names;
+			result->column_names = CompatNamesToStrings(names);
 			result->column_types = return_types;
 
 			has_explicit_columns = true;
@@ -671,19 +671,19 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 			// Convert union schema to return types
 			if (!union_schema.empty()) {
 				for (const auto &col_name : column_order) {
-					names.push_back(col_name);
+					names.push_back(CompatMakeIdentifier(col_name));
 					return_types.push_back(union_schema[col_name]);
 				}
 
 				// Always store schema for execution to ensure consistent column ordering
 				// across multiple files (fixes non-determinism from unordered_map iteration)
 				result->has_explicit_schema = true;
-				result->column_names = names;
+				result->column_names = CompatNamesToStrings(names);
 				result->column_types = return_types;
 				// Store per-column datetime formats for use during extraction
 				result->column_datetime_formats.resize(names.size());
 				for (size_t i = 0; i < names.size(); i++) {
-					auto fmt_it = union_formats.find(names[i]);
+					auto fmt_it = union_formats.find(CompatIdentifierName(names[i]));
 					result->column_datetime_formats[i] = (fmt_it != union_formats.end()) ? fmt_it->second : "";
 				}
 			} else {
@@ -1134,7 +1134,7 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 
 unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLObjectsBind(ClientContext &context, TableFunctionBindInput &input,
                                                                 vector<LogicalType> &return_types,
-                                                                vector<string> &names) {
+                                                                vector<CompatName> &names) {
 	auto result = make_uniq<XMLReadFunctionData>();
 
 	// Get file pattern(s) from first argument
@@ -1313,7 +1313,7 @@ void XMLReaderFunctions::ReadXMLObjectsFunction(ClientContext &context, TableFun
 }
 
 unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context, TableFunctionBindInput &input,
-                                                         vector<LogicalType> &return_types, vector<string> &names) {
+                                                         vector<LogicalType> &return_types, vector<CompatName> &names) {
 	auto result = make_uniq<XMLReadFunctionData>();
 	result->parse_mode = ParseMode::XML;
 
@@ -1526,7 +1526,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context,
 				auto logical_type = TransformStringToLogicalType(StringValue::Get(val), context);
 
 				return_types.push_back(logical_type);
-				names.push_back(CompatIdentifierName(name));
+				names.push_back(CompatMakeIdentifier(CompatIdentifierName(name)));
 			}
 
 			if (return_types.empty()) {
@@ -1535,7 +1535,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context,
 
 			// Store explicit schema in function data
 			result->has_explicit_schema = true;
-			result->column_names = names;
+			result->column_names = CompatNamesToStrings(names);
 			result->column_types = return_types;
 
 			has_explicit_columns = true;
@@ -1635,19 +1635,19 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context,
 			// Convert union schema to return types
 			if (!union_schema.empty()) {
 				for (const auto &col_name : column_order) {
-					names.push_back(col_name);
+					names.push_back(CompatMakeIdentifier(col_name));
 					return_types.push_back(union_schema[col_name]);
 				}
 
 				// Always store schema for execution to ensure consistent column ordering
 				// across multiple files (fixes non-determinism from unordered_map iteration)
 				result->has_explicit_schema = true;
-				result->column_names = names;
+				result->column_names = CompatNamesToStrings(names);
 				result->column_types = return_types;
 				// Store per-column datetime formats for use during extraction
 				result->column_datetime_formats.resize(names.size());
 				for (size_t i = 0; i < names.size(); i++) {
-					auto fmt_it = union_formats.find(names[i]);
+					auto fmt_it = union_formats.find(CompatIdentifierName(names[i]));
 					result->column_datetime_formats[i] = (fmt_it != union_formats.end()) ? fmt_it->second : "";
 				}
 			} else {
@@ -1724,7 +1724,7 @@ unique_ptr<TableRef> XMLReaderFunctions::ReadXMLReplacement(ClientContext &conte
 
 unique_ptr<FunctionData> XMLReaderFunctions::ReadHTMLObjectsBind(ClientContext &context, TableFunctionBindInput &input,
                                                                  vector<LogicalType> &return_types,
-                                                                 vector<string> &names) {
+                                                                 vector<CompatName> &names) {
 	return ReadDocumentObjectsBind(context, input, return_types, names, ParseMode::HTML);
 }
 
@@ -1739,7 +1739,8 @@ void XMLReaderFunctions::ReadHTMLObjectsFunction(ClientContext &context, TableFu
 }
 
 unique_ptr<FunctionData> XMLReaderFunctions::ReadHTMLBind(ClientContext &context, TableFunctionBindInput &input,
-                                                          vector<LogicalType> &return_types, vector<string> &names) {
+                                                          vector<LogicalType> &return_types,
+                                                          vector<CompatName> &names) {
 	return ReadDocumentBind(context, input, return_types, names, ParseMode::HTML);
 }
 
@@ -1759,7 +1760,7 @@ void XMLReaderFunctions::ReadHTMLFunction(ClientContext &context, TableFunctionI
 unique_ptr<FunctionData> XMLReaderFunctions::ParseDocumentObjectsBind(ClientContext &context,
                                                                       TableFunctionBindInput &input,
                                                                       vector<LogicalType> &return_types,
-                                                                      vector<string> &names, ParseMode mode) {
+                                                                      vector<CompatName> &names, ParseMode mode) {
 	auto result = make_uniq<XMLParseData>();
 	result->parse_mode = mode;
 
@@ -1848,8 +1849,8 @@ void XMLReaderFunctions::ParseDocumentObjectsFunction(ClientContext &context, Ta
 }
 
 unique_ptr<FunctionData> XMLReaderFunctions::ParseDocumentBind(ClientContext &context, TableFunctionBindInput &input,
-                                                               vector<LogicalType> &return_types, vector<string> &names,
-                                                               ParseMode mode) {
+                                                               vector<LogicalType> &return_types,
+                                                               vector<CompatName> &names, ParseMode mode) {
 	auto result = make_uniq<XMLParseData>();
 	result->parse_mode = mode;
 
@@ -1995,7 +1996,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ParseDocumentBind(ClientContext &co
 
 				auto logical_type = TransformStringToLogicalType(StringValue::Get(val), context);
 				return_types.push_back(logical_type);
-				names.push_back(CompatIdentifierName(name));
+				names.push_back(CompatMakeIdentifier(CompatIdentifierName(name)));
 			}
 
 			if (return_types.empty()) {
@@ -2003,7 +2004,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ParseDocumentBind(ClientContext &co
 			}
 
 			result->has_explicit_schema = true;
-			result->column_names = names;
+			result->column_names = CompatNamesToStrings(names);
 			result->column_types = return_types;
 			has_explicit_columns = true;
 		}
@@ -2040,12 +2041,12 @@ unique_ptr<FunctionData> XMLReaderFunctions::ParseDocumentBind(ClientContext &co
 
 			if (!inferred_columns.empty()) {
 				for (const auto &col_info : inferred_columns) {
-					names.push_back(col_info.name);
+					names.push_back(CompatMakeIdentifier(col_info.name));
 					return_types.push_back(col_info.type);
 				}
 
 				result->has_explicit_schema = true;
-				result->column_names = names;
+				result->column_names = CompatNamesToStrings(names);
 				result->column_types = return_types;
 				// Store per-column datetime formats for use during extraction
 				result->column_datetime_formats.resize(inferred_columns.size());
@@ -2145,24 +2146,26 @@ void XMLReaderFunctions::ParseDocumentFunction(ClientContext &context, TableFunc
 // Public parse_xml functions (delegate to internal functions)
 unique_ptr<FunctionData> XMLReaderFunctions::ParseXMLObjectsBind(ClientContext &context, TableFunctionBindInput &input,
                                                                  vector<LogicalType> &return_types,
-                                                                 vector<string> &names) {
+                                                                 vector<CompatName> &names) {
 	return ParseDocumentObjectsBind(context, input, return_types, names, ParseMode::XML);
 }
 
 unique_ptr<FunctionData> XMLReaderFunctions::ParseXMLBind(ClientContext &context, TableFunctionBindInput &input,
-                                                          vector<LogicalType> &return_types, vector<string> &names) {
+                                                          vector<LogicalType> &return_types,
+                                                          vector<CompatName> &names) {
 	return ParseDocumentBind(context, input, return_types, names, ParseMode::XML);
 }
 
 // Public parse_html functions (delegate to internal functions)
 unique_ptr<FunctionData> XMLReaderFunctions::ParseHTMLObjectsBind(ClientContext &context, TableFunctionBindInput &input,
                                                                   vector<LogicalType> &return_types,
-                                                                  vector<string> &names) {
+                                                                  vector<CompatName> &names) {
 	return ParseDocumentObjectsBind(context, input, return_types, names, ParseMode::HTML);
 }
 
 unique_ptr<FunctionData> XMLReaderFunctions::ParseHTMLBind(ClientContext &context, TableFunctionBindInput &input,
-                                                           vector<LogicalType> &return_types, vector<string> &names) {
+                                                           vector<LogicalType> &return_types,
+                                                           vector<CompatName> &names) {
 	return ParseDocumentBind(context, input, return_types, names, ParseMode::HTML);
 }
 
@@ -2438,7 +2441,7 @@ void XMLReaderFunctions::Register(ExtensionLoader &loader) {
 unique_ptr<FunctionData> XMLReaderFunctions::HTMLExtractTablesBind(ClientContext &context,
                                                                    TableFunctionBindInput &input,
                                                                    vector<LogicalType> &return_types,
-                                                                   vector<string> &names) {
+                                                                   vector<CompatName> &names) {
 	auto result = make_uniq<HTMLTableExtractionData>();
 
 	// Get HTML content from first argument

--- a/src/xml_reader_functions.cpp
+++ b/src/xml_reader_functions.cpp
@@ -552,7 +552,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 				auto logical_type = TransformStringToLogicalType(StringValue::Get(val), context);
 
 				return_types.push_back(logical_type);
-				names.push_back(CompatMakeIdentifier(CompatIdentifierName(name)));
+				names.push_back(CompatMakeName(CompatIdentifierName(name)));
 			}
 
 			if (return_types.empty()) {
@@ -671,7 +671,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadDocumentBind(ClientContext &con
 			// Convert union schema to return types
 			if (!union_schema.empty()) {
 				for (const auto &col_name : column_order) {
-					names.push_back(CompatMakeIdentifier(col_name));
+					names.push_back(CompatMakeName(col_name));
 					return_types.push_back(union_schema[col_name]);
 				}
 
@@ -1526,7 +1526,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context,
 				auto logical_type = TransformStringToLogicalType(StringValue::Get(val), context);
 
 				return_types.push_back(logical_type);
-				names.push_back(CompatMakeIdentifier(CompatIdentifierName(name)));
+				names.push_back(CompatMakeName(CompatIdentifierName(name)));
 			}
 
 			if (return_types.empty()) {
@@ -1635,7 +1635,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ReadXMLBind(ClientContext &context,
 			// Convert union schema to return types
 			if (!union_schema.empty()) {
 				for (const auto &col_name : column_order) {
-					names.push_back(CompatMakeIdentifier(col_name));
+					names.push_back(CompatMakeName(col_name));
 					return_types.push_back(union_schema[col_name]);
 				}
 
@@ -1712,7 +1712,7 @@ unique_ptr<TableRef> XMLReaderFunctions::ReadXMLReplacement(ClientContext &conte
 	// Set alias for non-glob patterns
 	if (!FileSystem::HasGlob(table_name)) {
 		auto &fs = FileSystem::GetFileSystem(context);
-		table_function->alias = CompatMakeIdentifier(fs.ExtractBaseName(table_name));
+		table_function->alias = CompatMakeAlias(fs.ExtractBaseName(table_name));
 	}
 
 	return std::move(table_function);
@@ -1996,7 +1996,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ParseDocumentBind(ClientContext &co
 
 				auto logical_type = TransformStringToLogicalType(StringValue::Get(val), context);
 				return_types.push_back(logical_type);
-				names.push_back(CompatMakeIdentifier(CompatIdentifierName(name)));
+				names.push_back(CompatMakeName(CompatIdentifierName(name)));
 			}
 
 			if (return_types.empty()) {
@@ -2041,7 +2041,7 @@ unique_ptr<FunctionData> XMLReaderFunctions::ParseDocumentBind(ClientContext &co
 
 			if (!inferred_columns.empty()) {
 				for (const auto &col_info : inferred_columns) {
-					names.push_back(CompatMakeIdentifier(col_info.name));
+					names.push_back(CompatMakeName(col_info.name));
 					return_types.push_back(col_info.type);
 				}
 

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1195,6 +1195,15 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 		SetScalarFunctionVarArgs(fn, LogicalType::ANY);
 		set.AddFunction(std::move(fn));
 	};
+	// Same, for sets whose functions return a STRUCT-containing type and therefore have to be
+	// VOLATILE (see PreventStructConstantFolding). The stability must be set BEFORE the function
+	// enters the set -- DuckDB v2.0's FunctionSet::functions yields shared_ptr<const T>, so there
+	// is no longer any way to configure a member after the fact.
+	auto add_ns_aware_volatile = [](ScalarFunctionSet &set, ScalarFunction fn) {
+		SetScalarFunctionVarArgs(fn, LogicalType::ANY);
+		PreventStructConstantFolding(fn);
+		set.AddFunction(std::move(fn));
+	};
 
 	// Register xml function (same as to_xml for now) - using VARCHAR for now, will enhance type system later
 	auto xml_function = ScalarFunction("xml", {LogicalType::VARCHAR}, LogicalType::VARCHAR, ValueToXMLFunction);
@@ -1394,36 +1403,41 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	     make_pair("line_number", LogicalType::BIGINT)});
 	// Register xml_extract_attributes function as a function set
 	ScalarFunctionSet xml_extract_attributes_functions("xml_extract_attributes");
-	add_ns_aware(xml_extract_attributes_functions,
-	             ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR}, LogicalType::LIST(attr_struct_type),
-	                            XMLExtractAttributesFunction));
-	add_ns_aware(xml_extract_attributes_functions,
-	             ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR}, LogicalType::LIST(attr_struct_type),
-	                            XMLExtractAttributesFunction));
-	add_ns_aware(xml_extract_attributes_functions,
-	             ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::LIST(attr_struct_type),
-	                            XMLExtractAttributesFunction));
+	add_ns_aware_volatile(xml_extract_attributes_functions,
+	                      ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR},
+	                                     LogicalType::LIST(attr_struct_type), XMLExtractAttributesFunction));
+	add_ns_aware_volatile(xml_extract_attributes_functions,
+	                      ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
+	                                     LogicalType::LIST(attr_struct_type), XMLExtractAttributesFunction));
+	add_ns_aware_volatile(xml_extract_attributes_functions,
+	                      ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                     LogicalType::LIST(attr_struct_type), XMLExtractAttributesFunction));
 	// Add 3-argument variants with namespace map
-	xml_extract_attributes_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type}, LogicalType::LIST(attr_struct_type),
-	                   XMLExtractAttributesWithNamespacesFunction));
-	xml_extract_attributes_functions.AddFunction(
-	    ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR, ns_map_type}, LogicalType::LIST(attr_struct_type),
-	                   XMLExtractAttributesWithNamespacesFunction));
-	xml_extract_attributes_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type}, LogicalType::LIST(attr_struct_type),
-	                   XMLExtractAttributesWithNamespacesFunction));
+	PreventStructConstantFoldingAndAdd(xml_extract_attributes_functions,
+	                                   ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type},
+	                                                  LogicalType::LIST(attr_struct_type),
+	                                                  XMLExtractAttributesWithNamespacesFunction));
+	PreventStructConstantFoldingAndAdd(xml_extract_attributes_functions,
+	                                   ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR, ns_map_type},
+	                                                  LogicalType::LIST(attr_struct_type),
+	                                                  XMLExtractAttributesWithNamespacesFunction));
+	PreventStructConstantFoldingAndAdd(xml_extract_attributes_functions,
+	                                   ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type},
+	                                                  LogicalType::LIST(attr_struct_type),
+	                                                  XMLExtractAttributesWithNamespacesFunction));
 	// Add 3-argument variants with namespace mode VARCHAR
-	xml_extract_attributes_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(attr_struct_type), XMLExtractAttributesWithNamespacesFunction));
-	xml_extract_attributes_functions.AddFunction(
+	PreventStructConstantFoldingAndAdd(xml_extract_attributes_functions,
+	                                   ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                                  LogicalType::LIST(attr_struct_type),
+	                                                  XMLExtractAttributesWithNamespacesFunction));
+	PreventStructConstantFoldingAndAdd(
+	    xml_extract_attributes_functions,
 	    ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                   LogicalType::LIST(attr_struct_type), XMLExtractAttributesWithNamespacesFunction));
-	xml_extract_attributes_functions.AddFunction(
+	PreventStructConstantFoldingAndAdd(
+	    xml_extract_attributes_functions,
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                   LogicalType::LIST(attr_struct_type), XMLExtractAttributesWithNamespacesFunction));
-	PreventStructConstantFolding(xml_extract_attributes_functions);
 	loader.RegisterFunction(xml_extract_attributes_functions);
 
 	// Register xml_pretty_print function
@@ -1611,38 +1625,46 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 
 	// Register html_extract_links function (HTML + VARCHAR compatibility overload)
 	ScalarFunctionSet html_extract_links_functions("html_extract_links");
-	html_extract_links_functions.AddFunction(
+	PreventStructConstantFoldingAndAdd(
+	    html_extract_links_functions,
 	    ScalarFunction({XMLTypes::HTMLType()}, LogicalType::LIST(html_link_struct_type), HTMLExtractLinksFunction));
-	html_extract_links_functions.AddFunction(
+	PreventStructConstantFoldingAndAdd(
+	    html_extract_links_functions,
 	    ScalarFunction({LogicalType::VARCHAR}, LogicalType::LIST(html_link_struct_type), HTMLExtractLinksFunction));
-	PreventStructConstantFolding(html_extract_links_functions);
 	loader.RegisterFunction(html_extract_links_functions);
 
 	// Register html_extract_images function (HTML + VARCHAR compatibility overload)
 	ScalarFunctionSet html_extract_images_functions("html_extract_images");
-	html_extract_images_functions.AddFunction(
+	PreventStructConstantFoldingAndAdd(
+	    html_extract_images_functions,
 	    ScalarFunction({XMLTypes::HTMLType()}, LogicalType::LIST(html_image_struct_type), HTMLExtractImagesFunction));
-	html_extract_images_functions.AddFunction(
+	PreventStructConstantFoldingAndAdd(
+	    html_extract_images_functions,
 	    ScalarFunction({LogicalType::VARCHAR}, LogicalType::LIST(html_image_struct_type), HTMLExtractImagesFunction));
-	PreventStructConstantFolding(html_extract_images_functions);
 	loader.RegisterFunction(html_extract_images_functions);
 
 	// Register html_extract_table_rows function (HTML + VARCHAR compatibility overload)
 	ScalarFunctionSet html_extract_table_rows_functions("html_extract_table_rows");
-	html_extract_table_rows_functions.AddFunction(ScalarFunction(
-	    {XMLTypes::HTMLType()}, LogicalType::LIST(html_table_row_struct_type), HTMLExtractTableRowsFunction));
-	html_extract_table_rows_functions.AddFunction(ScalarFunction(
-	    {LogicalType::VARCHAR}, LogicalType::LIST(html_table_row_struct_type), HTMLExtractTableRowsFunction));
-	PreventStructConstantFolding(html_extract_table_rows_functions);
+	PreventStructConstantFoldingAndAdd(html_extract_table_rows_functions,
+	                                   ScalarFunction({XMLTypes::HTMLType()},
+	                                                  LogicalType::LIST(html_table_row_struct_type),
+	                                                  HTMLExtractTableRowsFunction));
+	PreventStructConstantFoldingAndAdd(html_extract_table_rows_functions,
+	                                   ScalarFunction({LogicalType::VARCHAR},
+	                                                  LogicalType::LIST(html_table_row_struct_type),
+	                                                  HTMLExtractTableRowsFunction));
 	loader.RegisterFunction(html_extract_table_rows_functions);
 
 	// Register html_extract_tables_json function (HTML + VARCHAR compatibility overload)
 	ScalarFunctionSet html_extract_tables_json_functions("html_extract_tables_json");
-	html_extract_tables_json_functions.AddFunction(ScalarFunction(
-	    {XMLTypes::HTMLType()}, LogicalType::LIST(html_table_json_struct_type), HTMLExtractTablesJSONFunction));
-	html_extract_tables_json_functions.AddFunction(ScalarFunction(
-	    {LogicalType::VARCHAR}, LogicalType::LIST(html_table_json_struct_type), HTMLExtractTablesJSONFunction));
-	PreventStructConstantFolding(html_extract_tables_json_functions);
+	PreventStructConstantFoldingAndAdd(html_extract_tables_json_functions,
+	                                   ScalarFunction({XMLTypes::HTMLType()},
+	                                                  LogicalType::LIST(html_table_json_struct_type),
+	                                                  HTMLExtractTablesJSONFunction));
+	PreventStructConstantFoldingAndAdd(html_extract_tables_json_functions,
+	                                   ScalarFunction({LogicalType::VARCHAR},
+	                                                  LogicalType::LIST(html_table_json_struct_type),
+	                                                  HTMLExtractTablesJSONFunction));
 	loader.RegisterFunction(html_extract_tables_json_functions);
 
 	// Register parse_html scalar function for parsing HTML content directly

--- a/src/xml_types.cpp
+++ b/src/xml_types.cpp
@@ -1,4 +1,5 @@
 #include "xml_types.hpp"
+#include "duckdb_compat.hpp"
 #include "xml_utils.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
@@ -12,21 +13,19 @@
 namespace duckdb {
 
 LogicalType XMLTypes::XMLType() {
-	auto xml_type = LogicalType(LogicalTypeId::VARCHAR);
-	xml_type.SetAlias("XML");
-	return xml_type;
+	return CompatWithAlias(LogicalType(LogicalTypeId::VARCHAR), "XML");
 }
 
 LogicalType XMLTypes::XMLFragmentType() {
-	auto xml_frag_type = LogicalType(LogicalTypeId::VARCHAR);
-	xml_frag_type.SetAlias("xmlfragment");
-	return xml_frag_type;
+	// Alias spelled lowercase here but "XMLFragment" where the type is REGISTERED (see
+	// Register() below). Left as-is: IsXMLFragmentType() compares GetAlias() to this exact
+	// lowercase string, so changing either spelling changes which values that predicate
+	// accepts. Reconciling them is a behaviour decision, not part of the v2.0 port.
+	return CompatWithAlias(LogicalType(LogicalTypeId::VARCHAR), "xmlfragment");
 }
 
 LogicalType XMLTypes::HTMLType() {
-	auto html_type = LogicalType(LogicalTypeId::VARCHAR);
-	html_type.SetAlias("HTML");
-	return html_type;
+	return CompatWithAlias(LogicalType(LogicalTypeId::VARCHAR), "HTML");
 }
 
 LogicalType XMLTypes::OpaqueType(const std::string &type_name) {
@@ -114,20 +113,17 @@ void XMLTypes::Register(ExtensionLoader &loader) {
 	// For now, register XML as a simple type alias
 	// This creates a user-defined type that acts like VARCHAR but with the name "XML"
 
-	auto xml_type = LogicalType(LogicalType::VARCHAR);
-	xml_type.SetAlias("XML");
+	auto xml_type = CompatWithAlias(LogicalType(LogicalType::VARCHAR), "XML");
 
 	// Register the XML type through the extension utility
 	loader.RegisterType("XML", xml_type);
 
 	// Register XMLFragment type
-	auto xml_fragment_type = LogicalType(LogicalType::VARCHAR);
-	xml_fragment_type.SetAlias("XMLFragment");
+	auto xml_fragment_type = CompatWithAlias(LogicalType(LogicalType::VARCHAR), "XMLFragment");
 	loader.RegisterType("XMLFragment", xml_fragment_type);
 
 	// Register HTML type
-	auto html_type = LogicalType(LogicalType::VARCHAR);
-	html_type.SetAlias("HTML");
+	auto html_type = CompatWithAlias(LogicalType(LogicalType::VARCHAR), "HTML");
 	loader.RegisterType("HTML", html_type);
 
 	// Register cast functions for XML type conversion


### PR DESCRIPTION
## Why

`duckdb/community-extensions` builds **every release PR** against DuckDB main (`v2.0-cyanoptera`) via `build_next.yml`, whose trigger is a `description.yml` change — i.e. exactly a release PR — and there is **no per-extension opt-out**. An extension that does not compile there shows a red check on every release.

This is source compatibility, not a migration: webbed keeps shipping against its pinned **v1.5.4**. Feature *probes*, not version macros, throughout — a version macro says *when* something changed, a probe says whether it changed *here*, which keeps working if a change is backported or reverted.

The canary on `main` was red on exactly this. It is now green on the build.

## What changed

**1. `LogicalType::SetAlias` → `WithAlias`** (`xml_types.cpp`, 6 sites)
`SetAlias` is *removed* on v2.0, not deprecated; `WithAlias` returns a copy rather than mutating a type whose type-info may be shared. New `CompatWithAlias` shim, member-probed independently of the Identifier probe.

**2. Bind signatures take `vector<Identifier>`, not `vector<string>`**
New `CompatName` alias, used in every bind declaration and definition in `xml_reader_functions` and `duck_block_functions`. Only the *signatures* move: `Identifier`'s constructor from `const char *` is implicit, so `names.push_back("xml")` is unchanged; only the handful of places a **runtime** string crosses the boundary need `CompatMakeIdentifier` / `CompatIdentifierName`. New `CompatNamesToStrings` for the bind-data copies, which are still `vector<string>`.

**3. `FunctionSet<T>::functions` now yields `shared_ptr<const T>`**
The `PreventStructConstantFolding(FunctionSet<T> &)` overload could no longer mutate members. It has been **removed rather than shimmed** — the supported shape is to finish configuring a function *before* it enters the set. The six call sites now mark each `ScalarFunction` VOLATILE before `AddFunction`, via a new `PreventStructConstantFoldingAndAdd` and an `add_ns_aware_volatile` sibling of the existing `add_ns_aware` lambda.

This is the only change that touches real code on **both** versions, so the VOLATILE coverage was compared rather than reasoned about: the same **19** set-member functions and the same **6** standalone functions are marked before and after, and no bare `AddFunction` remains on any of the six affected sets. On v1.5 the marking is inert in both spellings, since it is gated on the newer API.

**4. Name types are derived from DuckDB's own containers, not from `__has_include`** *(second commit — a latent breakage found in review, not part of the original port)*

The header's original `__has_include("duckdb/common/identifier.hpp")` probe was a time bomb, and it was already armed:

| ref | `identifier.hpp` | bind names / `child_list_t` keys / `TableRef::alias` |
|---|---|---|
| `v1.5-variegata` @ `b155d6f63c` (our pin) | absent | `string` |
| `v1.5-variegata` @ tip `f3be2750f5` (today) | **present** | **still `string`** |
| `main` (v2.0) | present | `Identifier` |

`identifier.hpp` was backported to the stable branch *without* the signature changes. Our pin predates the backport, which is the only reason `__has_include` gives the right answer today. **On the next submodule bump to the branch tip, every name type would have flipped to `Identifier` on a DuckDB that still wants `string`** — and that breaks the pre-existing v1.4-era helpers too, not just the bind vectors added here.

Each boundary now asks DuckDB what its own container holds, which cannot drift because it *is* the thing that changes:

```cpp
using CompatFieldName = typename child_list_t<int>::value_type::first_type;
using CompatName      = typename std::remove_reference<decltype(
    std::declval<TableFunctionBindInput &>().input_table_names)>::type::value_type;
using CompatAliasName = decltype(TableRef::alias);
```

These are three *independent* upstream declarations. They move together on main and are all `string` on both v1.5 refs, but they are probed separately for exactly the reason the macro must not decide any of them. Call sites are routed to their own boundary's helper. `__has_include` is kept for one narrow job: gating whether an `Identifier` overload of the *read* helper can exist.

**Verified, not argued.** Simulating the branch-tip state — the pin's headers plus the real `identifier.hpp` fetched from `v1.5-variegata` — and compiling `xml_reader_functions.cpp` against it:

```
old header (__has_include-keyed):  13 errors, all vector<Identifier> vs vector<string> bind mismatches
new header (container-derived):     0 errors
```

The general lesson, which is the same one `ToUnifiedFormat` teaches a level down: **probe the thing that actually changed, never a proxy for it.**

**4. Nothing needed** for `ExecuteWithNulls`, COPY option keys, or mutable `FlatVector` writes — webbed has none of them. The private-field/accessor migration was already handled by the existing header.

## Note for anyone copying this header

The ecosystem's shared shims are written with `if constexpr`, which **does not compile here**. webbed builds at **C++11** on Linux on purpose — see the comment on the MSVC-only `/std:c++17` block in `CMakeLists.txt`: forcing C++17 gives duckdb's static-const header members implicit inline linkage in our TUs but not in libduckdb's C++11-built ones, which is a multiple-definition link error. `CompatWithAlias` therefore uses **tag dispatch** on the trait, which has the same "only the taken branch is instantiated" property at C++11. The `void_t` member probe itself is fine at C++11 in the `decltype(void(expr))` form.

## Verification

**Pinned v1.5.4, locally:** `make release` clean, **all 100 test cases / 3828 assertions pass**. Type aliases (`XML`, `XMLFragment`), `xml_valid`, and `html_extract_links` (one of the restructured sets) all behave as before. Behaviour on the version we ship does not move — the Identifier shims are literal no-ops there (`CompatName` *is* `string`).

**DuckDB main, canary run [33832875379](https://github.com/teaguesterling/duckdb_webbed/actions/runs/33832875379):**
- **Build: success on both `linux_amd64` and `linux_arm64`** — this is what the PR is for, and it is the first time either has built.
- `linux_arm64`: **green end to end**, build and test.
- `linux_amd64`: test step red on 4 tests, discussed below.
- Format Check: green.

## Known-remaining, and why it is not this PR

The `linux_amd64` canary leg fails 4 tests **after building successfully**. These are newly *revealed*, not newly *caused* — the previous canary never compiled far enough to run any test. They are **two unrelated things**, not one.

### (a) Three failures: a new v2.0 runtime contract — `SetFallible()`. Diagnosed, tracked in #140.

```
INTERNAL Error: Scalar function "to_xml" threw an execution error, but the
function is not marked as fallible - the function must call SetFallible().
```

…in `to_xml_name_injection.test`, `github_issue_134_xpath_errors.test` and `xml_wrap_fragment_validation.test` — all three on error paths asserting that invalid input is rejected. `to_xml`, `xml_extract_text` and `xml_wrap_fragment` are none of them among the functions this PR restructured.

This is a new upstream contract, not a porting artifact. The sibling `duck_hunt` extension, on its default branch with **no compat work at all**, fails its amd64 canary with the identical message. The API is `BaseScalarFunction::SetFallible()`, no arguments (`scalar_function.hpp:249`).

Fixing it is a real follow-up — ~55 registration sites, plus a probed `CompatSetFallible` that no-ops on v1.5 — but it is a runtime-behaviour change rather than source compatibility, so it is deliberately not bundled here. See #140.

### (b) One failure: still unexplained.

`duck_block_vocabulary_conformance.test:151` is a **wrong result** on a figure/caption round-trip, not an `InternalException`. The `SetFallible` explanation in (a) does **not** cover it, and I am not claiming it does. It is genuinely open.

What can be said: it passes on `linux_arm64` against the same DuckDB main, and it passes locally against pinned v1.5.4. `html_to_duck_blocks` *is* one of the six sets this PR restructured, so that deserved checking rather than assuming — but VOLATILE stability is architecture-independent, so a defect in the restructure would have failed both legs, and the coverage was verified unchanged (the same 2 overloads marked before and after). The remaining candidates are a v2.0 behaviour difference in the round-trip itself or something genuinely platform-dependent; distinguishing them needs a v2.0 build, which is CI-only.

### On the split between the legs

All four pass on `linux_arm64` against the same DuckDB main. For (a) the likeliest reading is that the `duckdb/linux_amd64` image builds with assertions on, which turns the fallibility contract from silent into an `InternalException` — the contract is violated on both legs and only one reports it. For (b) that reasoning does not apply and the asymmetry is part of what is unexplained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoHU19qnngy1CJnXyX1csz

