### PR TITLE
test,docs: use lambda x: syntax; single-arrow lambdas fail on DuckDB v2.0

### DIFF
--- a/docs/functions/conversion.rst
+++ b/docs/functions/conversion.rst
@@ -498,7 +498,7 @@ Convert a list of document blocks back to HTML. This is the inverse of ``html_to
    SELECT duck_blocks_to_html(
        list_filter(
            html_to_duck_blocks(html),
-           block -> block.kind = 'block' AND block.element_type IN ('heading', 'paragraph')
+           lambda block: block.kind = 'block' AND block.element_type IN ('heading', 'paragraph')
        )
    ) FROM documents;
 
@@ -572,7 +572,7 @@ When combined with the `duck_block_utils <https://github.com/teaguesterling/duck
    SELECT duck_blocks_to_markdown(
        list_filter(
            html_to_duck_blocks(html_content),
-           b -> b.kind = 'block' AND b.element_type IN ('heading', 'paragraph')
+           lambda b: b.kind = 'block' AND b.element_type IN ('heading', 'paragraph')
        )
    ) as simplified_markdown
    FROM web_pages;
@@ -591,7 +591,7 @@ When combined with the `duck_block_utils <https://github.com/teaguesterling/duck
    SELECT duck_blocks_to_html(
        list_transform(
            html_to_duck_blocks(html),
-           b -> CASE
+           lambda b: CASE
                WHEN b.kind = 'block' AND b.element_type = 'code'
                THEN {'kind': 'block', 'element_type': 'code', 'content': b.content, 'level': b.level,
                      'encoding': b.encoding, 'element_order': b.element_order,

--- a/test/sql/duck_block_vocabulary_conformance.test
+++ b/test/sql/duck_block_vocabulary_conformance.test
@@ -152,7 +152,7 @@ query I
 SELECT list_transform(html_to_duck_blocks(duck_blocks_to_html([
   {'kind':'block','element_type':'figure','content':NULL,'level':1,'encoding':'text','attributes':MAP{},'element_order':0},
   {'kind':'block','element_type':'caption','content':'Cap','level':2,'encoding':'text','attributes':MAP{},'element_order':1}
-])), x -> x.element_type);
+])), lambda x: x.element_type);
 ----
 [figure, caption]
 
@@ -201,7 +201,7 @@ plain
 query I
 SELECT list_transform(html_to_duck_blocks(duck_blocks_to_html([
   {'kind':'block','element_type':'figure','content':'Some text','level':1,'encoding':'text','attributes':MAP{},'element_order':0}
-])), x -> x.element_type);
+])), lambda x: x.element_type);
 ----
 [figure]
 


### PR DESCRIPTION
DuckDB v2.0 disables the `x -> expr` lambda form by default — it collides with the JSON extract operator, which is why 1.3 introduced `lambda x:`. DuckDB's own error for the disabled form calls `->` "the deprecated behavior". `lambda x:` has been valid since 1.3, so this is green on the pinned 1.5 build and on v2.0 alike.

## Why this matters for the v2.0 port

This is the fourth of #139's four amd64 failures against `v2.0-cyanoptera` — `duck_block_vocabulary_conformance.test:151` — and the only one that is not the SetFallible contract tracked in #140.

It was initially read as an architecture-dependent behavioural difference (arm64 green, amd64 red). It is not. **The arm64 canary leg does not run tests** — its log says `Tests are not supported for linux_arm64.` and the step reports success having run nothing. `:151` fails wherever the suite actually executes.

## Scope

Five conversions, test and docs only, no C++ — so it cannot conflict with #139:

| file | arrows |
|---|---|
| `test/sql/duck_block_vocabulary_conformance.test` | 2 |
| `docs/functions/conversion.rst` | 3 |

Verified complete by excluding comment lines rather than pattern-matching `->` in prose. An earlier count of "6 across 4 files" was wrong — four were `->` inside `#` comments. One test file with arrows is why exactly one arrow failure surfaced: the runner halts a file at its first failure.

## Verification

- Full suite on the pinned build: 3828 assertions, 100 cases
- `make check-docs`: 105 examples, 0 broken
- The converted queries run correctly under `SET lambda_syntax='DISABLE_SINGLE_ARROW'`, which is v2.0's default — not only on the pinned build

## What this does *not* claim

It does not claim #140 is the port's only remaining blocker. That is what the arithmetic suggests, but it is a number read off a runner that halts early and retries silently. The claim to trust is a canary run on `main` after this lands showing the amd64 failure count drop from four to three.