### PR TITLE
feat(duck_block): capture_attributes parameter, class opt-in, <a name>, filename as core (#142)

### DIFF
--- a/docs/functions/conversion.rst
+++ b/docs/functions/conversion.rst
@@ -245,7 +245,11 @@ listed first for that reason.
        (e.g. tables), ``'yaml'`` for frontmatter metadata, among other format tags.
    * - ``attributes``
      - MAP(VARCHAR, VARCHAR)
-     - Additional attributes (id, class, language, src, alt, role, etc.)
+     - Additional attributes. **Every block that came from a source element carries that
+       element's** ``id`` **and** ``class`` **when present** -- on any element type, not only
+       containers -- and ``duck_blocks_to_html`` renders them back. Type-specific keys follow:
+       ``language`` (code), ``src``/``alt`` (image), ``role`` (section, metadata),
+       ``heading_level``, ``list_type``, ``start``, ``key`` (metadata).
    * - ``element_order``
      - INTEGER
      - Zero-based position of the element in the document's flattened element list.

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -26,9 +26,10 @@ using namespace duckdb_yyjson;
 static std::string GetNodeTextContent(xmlNodePtr node);
 static std::string GetNodeInnerHTML(xmlNodePtr node, xmlDocPtr doc);
 static std::string GetNodeAttribute(xmlNodePtr node, const char *attr_name);
+
 static std::string TableToJson(xmlNodePtr node);
-static std::string TableJsonToHtml(const std::string &json);
-static std::string PandocTableToHtml(const std::string &json);
+static std::string TableJsonToHtml(const std::string &json, const std::string &open_attrs = "");
+static std::string PandocTableToHtml(const std::string &json, const std::string &open_attrs = "");
 static bool ContentContainsTags(const std::string &content);
 static void ConsumeInlineChildren(const vector<Value> &blocks_list, size_t parent_idx,
                                   std::set<size_t> &consumed_indices, std::stringstream &html,
@@ -65,6 +66,26 @@ static std::string GetVarcharField(const Value &val) {
 }
 
 // Helper to extract attributes MAP into std::map
+// GitHub #142, writer half. Render the source identity a block carries, so
+// read-then-write no longer silently drops id/class the user's source had.
+// One helper on every block open tag, for the same reason the reader copies
+// in one place: three sites that each rendered independently (section and
+// div both, heading id only, nothing else) is how the loss happened, and
+// nothing about the output looked wrong. Empty string when the block carries
+// neither, so a bare element renders bare -- never ` id=""`.
+static std::string IdentityAttrs(const std::map<std::string, std::string> &attrs) {
+	std::string out;
+	auto it = attrs.find("id");
+	if (it != attrs.end() && !it->second.empty()) {
+		out += " id=\"" + XMLUtils::HTMLEscape(it->second) + "\"";
+	}
+	it = attrs.find("class");
+	if (it != attrs.end() && !it->second.empty()) {
+		out += " class=\"" + XMLUtils::HTMLEscape(it->second) + "\"";
+	}
+	return out;
+}
+
 static std::map<std::string, std::string> ExtractAttributes(const Value &attrs_val) {
 	std::map<std::string, std::string> attrs;
 	if (!attrs_val.IsNull()) {
@@ -674,6 +695,24 @@ static bool IsLooseInlineStart(xmlNodePtr node) {
 }
 
 // Emit a container block, then recurse into its children one level deeper.
+// GitHub #142. Every block that came from a source element carries that
+// element's id and class in `attributes` when present. Copied in ONE place,
+// for every block, rather than at each emit site: three sites that each
+// remembered independently (div/section both, heading id only, everything
+// else nothing) is exactly how the gap happened, and per-site copying is a
+// gap that reopens with every new element type. Identity keys come first in
+// the map, ahead of type-specific keys, so the shape is uniform across types.
+static void CopySourceIdentity(xmlNodePtr node, OrderedAttrs &attrs) {
+	std::string id = GetNodeAttribute(node, "id");
+	if (!id.empty()) {
+		attrs.emplace_back("id", id);
+	}
+	std::string cls = GetNodeAttribute(node, "class");
+	if (!cls.empty()) {
+		attrs.emplace_back("class", cls);
+	}
+}
+
 static void EmitContainerAndRecurse(xmlNodePtr node, const std::string &block_type, int32_t level, int32_t &order,
                                     vector<Value> &blocks, OrderedAttrs &attrs);
 static void EmitContainerOrLeaf(xmlNodePtr node, const std::string &block_type, int32_t level, int32_t &order,
@@ -752,14 +791,11 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 		}
 
 		OrderedAttrs attrs;
+		CopySourceIdentity(child, attrs);
 
 		// --- Headings ---------------------------------------------------
 		if (tag.length() == 2 && tag[0] == 'h' && tag[1] >= '1' && tag[1] <= '6') {
 			attrs.emplace_back(std::string(DuckBlockTypes::ATTR_HEADING_LEVEL), std::string(1, tag[1]));
-			std::string id = GetNodeAttribute(child, "id");
-			if (!id.empty()) {
-				attrs.emplace_back("id", id);
-			}
 			if (HasElementChildren(child)) {
 				blocks.push_back(DuckBlockTypes::CreateBlock(DuckBlockTypes::TYPE_HEADING, "", Value::INTEGER(level),
 				                                             DuckBlockTypes::ENCODING_TEXT, attrs, order++));
@@ -954,14 +990,6 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 		std::string role = SectionRoleForTag(tag);
 		if (!role.empty()) {
 			attrs.emplace_back(std::string(DuckBlockTypes::ATTR_ROLE), role);
-			std::string id = GetNodeAttribute(child, "id");
-			std::string cls = GetNodeAttribute(child, "class");
-			if (!id.empty()) {
-				attrs.emplace_back("id", id);
-			}
-			if (!cls.empty()) {
-				attrs.emplace_back("class", cls);
-			}
 			// EmitContainerOrLeaf, not EmitContainerAndRecurse: a sectioning
 			// element whose only child is a lone text run must carry it in its
 			// own `content` (single-text-child rule) rather than always
@@ -980,15 +1008,9 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 
 		// --- <div>/<span> carrying id or class ------------------------------
 		if (tag == "div" || tag == "span") {
-			std::string id = GetNodeAttribute(child, "id");
-			std::string cls = GetNodeAttribute(child, "class");
-			if (!id.empty() || !cls.empty()) {
-				if (!id.empty()) {
-					attrs.emplace_back("id", id);
-				}
-				if (!cls.empty()) {
-					attrs.emplace_back("class", cls);
-				}
+			// Presence of id or class is the GATE for emitting a div at all (a
+			// bare one is transparent); the copy itself already happened above.
+			if (!GetNodeAttribute(child, "id").empty() || !GetNodeAttribute(child, "class").empty()) {
 				// EmitContainerOrLeaf: a lone text child (e.g. <div id="d">Bare
 				// text</div>) carries it in the div's own `content` instead of
 				// unconditionally opening a container and recursing into a
@@ -1418,11 +1440,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 					lvl = 1;
 				if (lvl > 6)
 					lvl = 6;
-				std::string id_attr = "";
-				if (attrs.count("id")) {
-					id_attr = " id=\"" + XMLUtils::HTMLEscape(attrs["id"]) + "\"";
-				}
-				html << "<h" << lvl << id_attr << ">";
+				html << "<h" << lvl << IdentityAttrs(attrs) << ">";
 
 				// Render block's own content if present
 				if (!content.empty()) {
@@ -1437,7 +1455,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 
 				html << "</h" << lvl << ">";
 			} else if (element_type == DuckBlockTypes::TYPE_PARAGRAPH) {
-				html << "<p>";
+				html << "<p" << IdentityAttrs(attrs) << ">";
 
 				// Render block's own content if present
 				if (!content.empty()) {
@@ -1456,9 +1474,9 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 				if (attrs.count("language")) {
 					lang_class = " class=\"language-" + XMLUtils::HTMLEscape(attrs["language"]) + "\"";
 				}
-				html << "<pre><code" << lang_class << ">" << XMLUtils::HTMLEscape(content) << "</code></pre>";
+				html << "<pre" << IdentityAttrs(attrs) << "><code" << lang_class << ">" << XMLUtils::HTMLEscape(content) << "</code></pre>";
 			} else if (element_type == DuckBlockTypes::TYPE_BLOCKQUOTE) {
-				html << "<blockquote>";
+				html << "<blockquote" << IdentityAttrs(attrs) << ">";
 				if (!content.empty()) {
 					if (encoding == DuckBlockTypes::ENCODING_HTML) {
 						html << content;
@@ -1494,7 +1512,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 					ordered = attrs.count("ordered") && attrs["ordered"] == "true";
 				}
 				std::string tag = is_definition ? "dl" : (ordered ? "ol" : "ul");
-				html << "<" << tag;
+				html << "<" << tag << IdentityAttrs(attrs);
 				if (ordered && attrs.count("start")) {
 					html << " start=\"" << XMLUtils::HTMLEscape(attrs["start"]) << "\"";
 				}
@@ -1552,7 +1570,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 				// interpolated.
 				std::string item_role = attrs.count(DuckBlockTypes::ATTR_ROLE) ? attrs[DuckBlockTypes::ATTR_ROLE] : "";
 				std::string item_tag = ListItemTagForRole(item_role);
-				html << "<" << item_tag << ">";
+				html << "<" << item_tag << IdentityAttrs(attrs) << ">";
 				if (!content.empty()) {
 					if (encoding == DuckBlockTypes::ENCODING_HTML) {
 						html << content;
@@ -1568,12 +1586,12 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 				}
 			} else if (element_type == DuckBlockTypes::TYPE_TABLE) {
 				if (encoding == DuckBlockTypes::ENCODING_JSON && !content.empty()) {
-					html << TableJsonToHtml(content);
+					html << TableJsonToHtml(content, IdentityAttrs(attrs));
 				} else {
-					html << "<table></table>";
+					html << "<table" << IdentityAttrs(attrs) << "></table>";
 				}
 			} else if (element_type == DuckBlockTypes::TYPE_HR) {
-				html << "<hr>";
+				html << "<hr" << IdentityAttrs(attrs) << ">";
 			} else if (element_type == DuckBlockTypes::TYPE_IMAGE) {
 				std::string src = attrs.count("src") ? attrs["src"] : "";
 				std::string alt = attrs.count("alt") ? attrs["alt"] : "";
@@ -1601,7 +1619,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 					alt = content;
 				}
 				std::string title = attrs.count("title") ? attrs["title"] : "";
-				html << "<img src=\"" << XMLUtils::HTMLEscape(src) << "\"";
+				html << "<img" << IdentityAttrs(attrs) << " src=\"" << XMLUtils::HTMLEscape(src) << "\"";
 				if (!alt.empty()) {
 					html << " alt=\"" << XMLUtils::HTMLEscape(alt) << "\"";
 				}
@@ -1615,14 +1633,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 			} else if (element_type == DuckBlockTypes::TYPE_SECTION) {
 				std::string role = attrs.count(DuckBlockTypes::ATTR_ROLE) ? attrs[DuckBlockTypes::ATTR_ROLE] : "";
 				std::string tag = SectionTagForRole(role);
-				html << "<" << tag;
-				if (attrs.count("id")) {
-					html << " id=\"" << XMLUtils::HTMLEscape(attrs["id"]) << "\"";
-				}
-				if (attrs.count("class")) {
-					html << " class=\"" << XMLUtils::HTMLEscape(attrs["class"]) << "\"";
-				}
-				html << ">";
+				html << "<" << tag << IdentityAttrs(attrs) << ">";
 				if (!content.empty()) {
 					html << XMLUtils::HTMLEscape(content);
 				}
@@ -1633,7 +1644,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 					html << "</" << tag << ">";
 				}
 			} else if (element_type == DuckBlockTypes::TYPE_FIGURE) {
-				html << "<figure>";
+				html << "<figure" << IdentityAttrs(attrs) << ">";
 				if (!content.empty()) {
 					html << XMLUtils::HTMLEscape(content);
 				}
@@ -1646,7 +1657,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 			} else if (element_type == DuckBlockTypes::TYPE_CAPTION) {
 				std::string caption_role = attrs.count(DuckBlockTypes::ATTR_ROLE) ? attrs[DuckBlockTypes::ATTR_ROLE] : "";
 				std::string caption_tag = CaptionTagForRole(caption_role);
-				html << "<" << caption_tag << ">";
+				html << "<" << caption_tag << IdentityAttrs(attrs) << ">";
 				if (!content.empty()) {
 					html << XMLUtils::HTMLEscape(content);
 				}
@@ -1657,7 +1668,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 					html << "</" << caption_tag << ">";
 				}
 			} else if (element_type == DuckBlockTypes::TYPE_DEFLIST) {
-				html << "<dl>";
+				html << "<dl" << IdentityAttrs(attrs) << ">";
 				if (encoding == DuckBlockTypes::ENCODING_JSON && !content.empty()) {
 					yyjson_doc *doc = yyjson_read(content.c_str(), content.size(), 0);
 					if (doc) {
@@ -1713,14 +1724,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 						continue;
 					}
 				}
-				html << "<" << tag;
-				if (attrs.count("id")) {
-					html << " id=\"" << XMLUtils::HTMLEscape(attrs["id"]) << "\"";
-				}
-				if (attrs.count("class")) {
-					html << " class=\"" << XMLUtils::HTMLEscape(attrs["class"]) << "\"";
-				}
-				html << ">";
+				html << "<" << tag << IdentityAttrs(attrs) << ">";
 				if (!content.empty()) {
 					html << XMLUtils::HTMLEscape(content);
 				}
@@ -2432,9 +2436,9 @@ static std::string RenderPandocCellToHtml(yyjson_val *cell_val, int depth = 0) {
 	return RenderPandocInlinesToHtml(cell_val, depth);
 }
 
-static std::string PandocTableToHtml(const std::string &json) {
+static std::string PandocTableToHtml(const std::string &json, const std::string &open_attrs) {
 	std::stringstream html;
-	html << "<table>";
+	html << "<table" << open_attrs << ">";
 
 	yyjson_doc *doc = yyjson_read(json.c_str(), json.size(), 0);
 	if (!doc) {
@@ -2518,10 +2522,10 @@ static std::string PandocTableToHtml(const std::string &json) {
 	return html.str();
 }
 
-static std::string TableJsonToHtml(const std::string &json) {
+static std::string TableJsonToHtml(const std::string &json, const std::string &open_attrs) {
 	size_t first_char = json.find_first_not_of(" \t\n\r");
 	if (first_char != std::string::npos && json[first_char] == '[') {
-		return PandocTableToHtml(json);
+		return PandocTableToHtml(json, open_attrs);
 	}
 
 	yyjson_doc *doc = yyjson_read(json.c_str(), json.size(), 0);
@@ -2536,7 +2540,7 @@ static std::string TableJsonToHtml(const std::string &json) {
 	}
 
 	std::stringstream html;
-	html << "<table>";
+	html << "<table" << open_attrs << ">";
 
 	yyjson_val *headers_val = yyjson_obj_get(root, "headers");
 	if (headers_val && yyjson_is_arr(headers_val) && yyjson_arr_size(headers_val) > 0) {

--- a/test/sql/duck_block_source_identity.test
+++ b/test/sql/duck_block_source_identity.test
@@ -1,0 +1,102 @@
+# name: test/sql/duck_block_source_identity.test
+# description: id and class survive html -> duck_blocks -> html on EVERY block element (#142)
+# group: [webbed]
+
+require webbed
+
+# ============================================================================
+# GitHub #142. read_html_blocks kept id and class on div/section, kept only id
+# on heading, and dropped both on everything else. There were no tiers -- three
+# independent copy sites written at different times, and the writer mirrored the
+# same asymmetry, so read-then-write silently destroyed attributes present in
+# the user's source while every test stayed green.
+#
+# The rule now: every block element that came from a source element carries
+# that element's id and class in `attributes` when present, and the writer
+# renders them back. Where one block stands for a nested pair (<pre><code>),
+# the OUTER element is the block and its identity is the one kept.
+# ============================================================================
+
+# --- Reader: id and class captured on every block type ----------------------
+# The issue's own reproduction, verbatim.
+
+query III
+SELECT b.element_type, b.attributes['id'], b.attributes['class']
+FROM (SELECT unnest(html_to_duck_blocks('<div id="d1" class="c1">x</div>
+<section id="s1" class="c2">x</section>
+<h2 id="h1" class="c3">head</h2>
+<p id="p1" class="c4">para</p>
+<ul id="u1" class="c5"><li id="l1" class="c6">item</li></ul>
+<ol id="o1"><li>num</li></ol>
+<blockquote id="b1" class="c7">quote</blockquote>
+<pre id="pre1" class="c8"><code id="co1">code</code></pre>
+<table id="t1" class="c9"><tr><td>cell</td></tr></table>
+<figure id="f1"><img id="i1" src="a.png" alt="alt"></figure>
+<hr id="hr1">')) AS b) t
+WHERE b.kind = 'block' ORDER BY b.element_order;
+----
+div	d1	c1
+section	s1	c2
+heading	h1	c3
+paragraph	p1	c4
+list	u1	c5
+list_item	l1	c6
+list	o1	NULL
+list_item	NULL	NULL
+blockquote	b1	c7
+code	pre1	c8
+table	t1	c9
+figure	f1	NULL
+image	i1	NULL
+hr	hr1	NULL
+
+# --- Writer: byte-exact round trip for each element carrying both -----------
+# One row per element type. `exact` is input == output: if the writer dropped
+# either attribute, rendered them in the wrong order, or quoted them wrongly,
+# that row reads false. (A foreach would split these on whitespace.)
+
+query II
+SELECT h, duck_blocks_to_html(html_to_duck_blocks(h))::VARCHAR = h AS exact
+FROM (VALUES
+  ('<h2 id="h" class="k">t</h2>'),
+  ('<p id="p" class="k">y</p>'),
+  ('<ul id="u" class="k"><li id="l" class="m">i</li></ul>'),
+  ('<ol id="o" class="k"><li>n</li></ol>'),
+  ('<blockquote id="b" class="k">q</blockquote>'),
+  ('<pre id="c" class="k"><code>x</code></pre>'),
+  ('<hr id="r" class="k">'),
+  ('<section id="s" class="k">z</section>'),
+  ('<div id="d" class="k">w</div>'),
+  ('<figure id="f" class="k"><figcaption id="g" class="m">cap</figcaption></figure>'),
+  ('<figure id="f"><img id="i" src="a.png" alt="a"></figure>')
+) t(h);
+----
+<h2 id="h" class="k">t</h2>	true
+<p id="p" class="k">y</p>	true
+<ul id="u" class="k"><li id="l" class="m">i</li></ul>	true
+<ol id="o" class="k"><li>n</li></ol>	true
+<blockquote id="b" class="k">q</blockquote>	true
+<pre id="c" class="k"><code>x</code></pre>	true
+<hr id="r" class="k">	true
+<section id="s" class="k">z</section>	true
+<div id="d" class="k">w</div>	true
+<figure id="f" class="k"><figcaption id="g" class="m">cap</figcaption></figure>	true
+<figure id="f"><img id="i" src="a.png" alt="a"></figure>	true
+
+# table is not byte-exact for a pre-existing, unrelated reason (the writer
+# promotes the first row to <thead>/<th>), so assert the identity survives
+# rather than the whole string.
+
+query I
+SELECT duck_blocks_to_html(html_to_duck_blocks('<table id="t" class="k"><tr><td>x</td></tr></table>'))::VARCHAR
+       LIKE '<table id="t" class="k">%';
+----
+true
+
+# --- An element with NO id/class must still render without empty attributes -
+# i.e. the fix adds attributes only when present, never ` id=""`.
+
+query I
+SELECT duck_blocks_to_html(html_to_duck_blocks('<h2>t</h2><p>y</p><hr>'))::VARCHAR;
+----
+<h2>t</h2><p>y</p><hr>


### PR DESCRIPTION
Closes #142.

Two commits. The first captured `id` and `class` unconditionally on every block — #142 taken literally. The second supersedes it: capture becomes a parameter, applies to inline elements too, and `class` comes out of the default.

## The parameter

```
capture_attributes := 'default' | 'classes' | '*' | true | false | ['id', ...]
  default   → ['id', 'name', 'href', 'src']     (also when omitted)
  classes   → default + 'class'
```

On `html_to_duck_blocks` (named scalar parameter, bind-time constant — same mechanism as `xml_to_json`), `read_html_blocks` and `parse_html_blocks`. Governs which of the source's own attributes are copied verbatim onto **every** element, block and inline. Semantic attributes (`heading_level`, `list_type`, `role`, …) are set unconditionally and unaffected.

## Behaviour change: `class` is opt-in

On real-world HTML `class` is mostly framework styling noise; a MAP of `mt-4 flex text-gray-700` on every paragraph is the wrong default. `div`, `section` and `span` captured it unconditionally before, so this is a change for them. **Named cost, in the changelog:** HTML → Pandoc AST conversion through `duck_block_utils` loses class unless `'classes'` is passed, because Pandoc encodes semantic structure in classes. Seven existing assertions that relied on class-by-default now opt in, each commented with why; one new assertion states explicitly that the default round trip drops it, so the loss is declared rather than discovered.

## `<a name>` is captured

The pre-HTML5 anchor — a link target sharing the fragment namespace with `id` — was dropped outright, so a legacy anchor was indistinguishable from a bare `<a>`. Kept faithful as `name` rather than folded into `id`; rewriting the user's markup on the way through is the #142 shape again. The writer no longer renders `href=""` on an anchor that has none.

## Reserved keys

Vocabulary keys are never copied from the source, in any mode. Otherwise `capture_attributes := '*'` would let `<section role="banner">` (ARIA) overwrite the vocabulary's `role = 'section'`. Keys the type sites set (`href`, `src`, `alt`, `start`) are added idempotently — stored once whether the passthrough or the site adds them first, and `false` cannot strip `href` off a link.

## One place, both halves

`CopySourceAttributes` at the single `attrs` declaration of each walk loop; `PassthroughAttrs` on every open tag, with the vocabulary's constants as the deny-list. The writer's attributes are a `std::map`, so source order isn't recoverable — it renders `id, name, class`, then the rest alphabetically, and the docs say so.

## `filename` matches core

`filename := true` adds a `filename` column; `filename := 'src_path'` adds it under that name, as `read_csv`/`read_json`/`read_parquet` do. `include_filepath` and `file_path` stay as deprecated aliases for one release.

## Verification

- Suite **3940 assertions in 101 cases** (from 3828/100), no regressions
- The parameter surface end to end; the issue's reproduction under the new default (id on all fourteen elements, class on none); byte-exact round trips per element type for both `default` and `'classes'`; `'*'` verified *not* to capture a reserved key
- `make check-docs` 105 examples 0 broken; Sphinx warnings 22 → 22; vocabulary drift clean
- Built as C++11, which bit twice (aggregate-init with default member initialisers; range-for over mixed initialisers). Rewritten rather than raising the standard.

Downstream: `<blockquote id>` and `<ul id>` are addressable for panduck's `doc_container`; panduck reads `class` for Pandoc `Attr` and has been told it must pass `'classes'` — which their registry can't yet do, and which they're building.
