### PR TITLE
duck_block: capture_attributes, trailing filename, 8-field acceptance (completes #142)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,38 @@
 Changelog
 =========
 
-v2.8.2 (Current)
-----------------
+Unreleased
+----------
+
+**Behaviour change: attribute capture is now a parameter, and** ``class`` **is opt-in.**
+
+``read_html_blocks`` kept ``id`` and ``class`` on ``div``/``section``, kept only ``id`` on
+headings, and dropped both on everything else (#142). There were no tiers -- three copy sites
+written at different times -- and the writer mirrored them, so read-then-write silently
+destroyed attributes the source had.
+
+- ``capture_attributes := 'default' | 'classes' | '*' | true | false | [...]`` on
+  ``html_to_duck_blocks``, ``read_html_blocks`` and ``parse_html_blocks`` governs which source
+  attributes are copied onto **every** element, block and inline. Default:
+  ``['id', 'name', 'href', 'src']``.
+- ``<a name="...">`` -- the pre-HTML5 anchor -- is now captured as ``name``. It was dropped
+  outright before, so a legacy anchor was indistinguishable from a bare ``<a>``.
+- ``duck_blocks_to_html`` renders captured attributes back on every element, and an anchor
+  with no ``href`` no longer renders ``href=""``.
+- **``class`` is no longer captured by default** -- it is opt-in via ``'classes'``. This
+  changes ``div``, ``section`` and ``span``, which captured it unconditionally before.
+  Downstream, **HTML → Pandoc AST conversion through** ``duck_block_utils`` **loses class
+  unless requested**, because Pandoc encodes semantic structure in classes.
+- Vocabulary keys (``role``, ``heading_level``, ...) are reserved: never copied from the
+  source, so ``'*'`` cannot forge them.
+
+**``filename`` on** ``read_html_blocks`` **now matches DuckDB core.** ``filename := true`` adds
+a ``filename`` column; ``filename := 'src_path'`` adds it under that name, as ``read_csv``,
+``read_json`` and ``read_parquet`` do. ``include_filepath`` and ``file_path`` are deprecated
+aliases, kept for one release.
+
+v2.8.2
+------
 
 A bugfix release for the ``duck_block`` reader and writer. Behavioural
 corrections against a spec that moved -- no new public surface, so the function

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,10 +26,19 @@ destroyed attributes the source had.
 - Vocabulary keys (``role``, ``heading_level``, ...) are reserved: never copied from the
   source, so ``'*'`` cannot forge them.
 
-**``filename`` on** ``read_html_blocks`` **now matches DuckDB core.** ``filename := true`` adds
-a ``filename`` column; ``filename := 'src_path'`` adds it under that name, as ``read_csv``,
-``read_json`` and ``read_parquet`` do. ``include_filepath`` and ``file_path`` are deprecated
-aliases, kept for one release.
+**``filename`` on** ``read_html_blocks`` **is now trailing, and takes core's forms.**
+
+- The column now comes **after** ``element_order``, not first. duck_block spec 6.4 keys
+  8-field acceptance on the exact type -- seven canonical fields, then ``filename VARCHAR`` --
+  so the old leading position (``STRUCT(filename, kind, ...)``) did not bind against
+  ``duck_block_utils`` at all. The emitted type string is now asserted in the suite.
+- ``filename := true`` adds a ``filename`` column. ``filename := 'src_path'`` adds it under
+  that name, as ``read_csv``/``read_json``/``read_parquet`` do -- **but a renamed column is
+  not the accepted 8-field type and will not bind as duck_blocks** (``list(b)`` into any
+  ``duck_block_utils`` function fails). This is the one place matching core diverges from
+  the vocabulary, which prefers the boolean form; use ``true`` when the rows feed
+  ``duck_block_utils``.
+- ``include_filepath`` and ``file_path`` are deprecated aliases, kept for one release.
 
 v2.8.2
 ------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,6 +40,15 @@ destroyed attributes the source had.
   ``duck_block_utils``.
 - ``include_filepath`` and ``file_path`` are deprecated aliases, kept for one release.
 
+**Consumers accept the 8-field duck_block** (spec 6.4). ``duck_blocks_to_html`` and every
+other consumer now bind the widened shape -- the canonical seven fields, then
+``filename VARCHAR`` -- so ``list(r)`` of ``read_html_blocks(..., filename := true)`` rows
+feeds a consumer directly. Acceptance is a registered implicit cast to the 7-field type
+(the same mechanism as ``duck_block_utils``); functions keep returning the 7-field shape.
+The source type is exact on purpose: a leading, renamed, ninth or wrongly-typed extra
+field is still a binder error, because every consumer reads the struct by index and a
+lenient match would have read a misplaced ``filename`` as ``kind``, silently.
+
 v2.8.2
 ------
 

--- a/docs/functions/conversion.rst
+++ b/docs/functions/conversion.rst
@@ -186,10 +186,37 @@ Convert HTML content into a list of structured document blocks. This function pa
 .. code-block:: sql
 
    html_to_duck_blocks(html)
+   html_to_duck_blocks(html, capture_attributes := ...)
 
 **Parameters:**
 
 - ``html`` (HTML/VARCHAR): The HTML content to parse
+- ``capture_attributes`` (optional, constant): which of the source's own attributes are copied
+  verbatim onto every element, block and inline, when present. One of:
+
+  .. list-table::
+     :widths: 30 70
+
+     * - ``'default'`` *(or omitted)*
+       - ``['id', 'name', 'href', 'src']`` -- identity and references
+     * - ``'classes'``
+       - the default plus ``'class'``
+     * - ``'*'`` or ``true``
+       - every source attribute
+     * - ``false``
+       - none; only the semantic attributes below
+     * - ``['id', 'class', 'data-x', ...]``
+       - an explicit list
+
+  ``class`` is not in the default on purpose: on real-world HTML it is mostly framework
+  styling noise. Pass ``'classes'`` when you want it -- notably for HTML → Pandoc conversion,
+  where Pandoc encodes semantic structure in classes, or for HTML → blocks → HTML round trips
+  that must keep their styling hooks. The same parameter is accepted by ``read_html_blocks``
+  and ``parse_html_blocks``.
+
+  Attribute keys the vocabulary gives a meaning to (``role``, ``heading_level``, ``list_type``,
+  ...) are reserved and never copied from the source in any mode, so a document cannot forge
+  them: ``<section role="banner">`` keeps the vocabulary's ``role = 'section'``.
 
 **Returns:** ``LIST(duck_block)`` - A list of document blocks
 
@@ -245,11 +272,11 @@ listed first for that reason.
        (e.g. tables), ``'yaml'`` for frontmatter metadata, among other format tags.
    * - ``attributes``
      - MAP(VARCHAR, VARCHAR)
-     - Additional attributes. **Every block that came from a source element carries that
-       element's** ``id`` **and** ``class`` **when present** -- on any element type, not only
-       containers -- and ``duck_blocks_to_html`` renders them back. Type-specific keys follow:
-       ``language`` (code), ``src``/``alt`` (image), ``role`` (section, metadata),
-       ``heading_level``, ``list_type``, ``start``, ``key`` (metadata).
+     - Two kinds of key. **Source attributes** copied from the element per
+       ``capture_attributes`` -- by default ``id``, ``name``, ``href`` and ``src``, on every
+       element type -- which ``duck_blocks_to_html`` renders back. And **semantic attributes**
+       the reader sets unconditionally: ``heading_level``, ``list_type``, ``start``, ``role``
+       (section, metadata), ``key`` (metadata), ``language`` (code), ``alt`` (image).
    * - ``element_order``
      - INTEGER
      - Zero-based position of the element in the document's flattened element list.

--- a/docs/functions/conversion.rst
+++ b/docs/functions/conversion.rst
@@ -218,6 +218,12 @@ Convert HTML content into a list of structured document blocks. This function pa
   ...) are reserved and never copied from the source in any mode, so a document cannot forge
   them: ``<section role="banner">`` keeps the vocabulary's ``role = 'section'``.
 
+- ``filename`` (``read_html_blocks`` only): ``true`` appends a ``filename`` column **after**
+  ``element_order`` -- the exact 8-field shape duck_block spec 6.4 accepts, so ``list(b)`` of
+  the rows still binds as duck_blocks. A string (``filename := 'src_path'``) names the column
+  instead, as DuckDB's core readers allow, **but that shape is not the accepted type and will
+  not bind as duck_blocks**; use ``true`` when the rows feed ``duck_block_utils``.
+
 **Returns:** ``LIST(duck_block)`` - A list of document blocks
 
 **The duck_block Type:**

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/function/cast/default_casts.hpp"
 #include "duck_block_functions.hpp"
 #include "duck_block_types.hpp"
 #include "duckdb_compat.hpp"
@@ -2379,7 +2380,28 @@ void DuckBlockFunctions::ParseHTMLBlocksFunction(ClientContext &context, TableFu
 	CompatSetOutputCardinality(output, output_idx);
 }
 
+// duck_block spec 6.4 acceptance. DuckDB's own STRUCT-to-STRUCT cast already
+// matches children BY NAME and drops the extra one, so an explicit
+// `::duck_block[]` of an 8-field list has always worked. What refused the
+// IMPLICIT cast was a single rule in the binder: a child-count mismatch costs
+// -1. The binder consults REGISTERED casts before that rule, so registering the
+// pair with a cost is the whole mechanism -- the bound cast is DuckDB's default,
+// unchanged. Same approach as duck_block_utils, so the two agree by construction.
+//
+// The source type is EXACT. Every consumer reads the struct by index; had this
+// been widened by arity, a leading `filename` would have been read as `kind`
+// by all of them, silently. Exactness is what makes that a binder error.
+static BoundCastInfo BindDefaultCast(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
+	return DefaultCasts::GetDefaultCastFunction(input, source, target);
+}
+
 void DuckBlockFunctions::Register(ExtensionLoader &loader) {
+	{
+		auto with_filename = DuckBlockTypes::DuckBlockWithFilenameType();
+		loader.RegisterCastFunction(with_filename, DuckBlockTypes::DuckBlockType(), BindDefaultCast, 10);
+		loader.RegisterCastFunction(LogicalType::LIST(with_filename), DuckBlockTypes::DuckBlockListType(),
+		                            BindDefaultCast, 10);
+	}
 	// html_to_duck_blocks(html HTML) -> LIST(duck_block)
 	ScalarFunctionSet html_to_duck_blocks_set("html_to_duck_blocks");
 	ScalarFunction html_to_duck_blocks_html({XMLTypes::HTMLType()}, DuckBlockTypes::DuckBlockListType(),

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -1,3 +1,5 @@
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 #include "duck_block_functions.hpp"
 #include "duck_block_types.hpp"
 #include "duckdb_compat.hpp"
@@ -66,26 +68,6 @@ static std::string GetVarcharField(const Value &val) {
 }
 
 // Helper to extract attributes MAP into std::map
-// GitHub #142, writer half. Render the source identity a block carries, so
-// read-then-write no longer silently drops id/class the user's source had.
-// One helper on every block open tag, for the same reason the reader copies
-// in one place: three sites that each rendered independently (section and
-// div both, heading id only, nothing else) is how the loss happened, and
-// nothing about the output looked wrong. Empty string when the block carries
-// neither, so a bare element renders bare -- never ` id=""`.
-static std::string IdentityAttrs(const std::map<std::string, std::string> &attrs) {
-	std::string out;
-	auto it = attrs.find("id");
-	if (it != attrs.end() && !it->second.empty()) {
-		out += " id=\"" + XMLUtils::HTMLEscape(it->second) + "\"";
-	}
-	it = attrs.find("class");
-	if (it != attrs.end() && !it->second.empty()) {
-		out += " class=\"" + XMLUtils::HTMLEscape(it->second) + "\"";
-	}
-	return out;
-}
-
 static std::map<std::string, std::string> ExtractAttributes(const Value &attrs_val) {
 	std::map<std::string, std::string> attrs;
 	if (!attrs_val.IsNull()) {
@@ -105,20 +87,66 @@ static std::map<std::string, std::string> ExtractAttributes(const Value &attrs_v
 }
 
 // Render inline element to HTML
+static bool IsReservedAttr(const std::string &key);
+
+// GitHub #142, writer half. Render the source attributes a block or inline
+// carries back onto its open tag, so read-then-write no longer silently drops
+// what the user's source had. Skips the vocabulary's semantic keys (never HTML
+// attributes) and any key the calling site renders itself (href on <a>, src/alt
+// on <img>, start on <ol>), so nothing is emitted twice. Canonical order --
+// id, name, class, then the rest alphabetically -- because the writer's attrs
+// are a std::map and source order is not recoverable from it. Empty when the
+// element carries nothing renderable, so a bare element renders bare.
+static std::string PassthroughAttrs(const std::map<std::string, std::string> &attrs,
+                                    std::initializer_list<const char *> exclude = {}) {
+	auto excluded = [&](const std::string &k) {
+		for (auto e : exclude) {
+			if (k == e) {
+				return true;
+			}
+		}
+		return false;
+	};
+	std::string out;
+	std::vector<std::string> done;
+	auto emit = [&](const std::string &k) {
+		auto it = attrs.find(k);
+		if (it == attrs.end() || it->second.empty() || IsReservedAttr(k) || excluded(k)) {
+			return;
+		}
+		if (std::find(done.begin(), done.end(), k) != done.end()) {
+			return;
+		}
+		out += " " + k + "=\"" + XMLUtils::HTMLEscape(it->second) + "\"";
+		done.push_back(k);
+	};
+	emit("id");
+	emit("name");
+	emit("class");
+	for (auto &kv : attrs) {
+		emit(kv.first);
+	}
+	return out;
+}
+
 static std::string RenderInlineElementToHtml(const std::string &element_type, const std::string &content,
                                              const std::map<std::string, std::string> &attrs) {
 	if (element_type == DuckBlockTypes::INLINE_TEXT) {
 		return XMLUtils::HTMLEscape(content);
 	} else if (element_type == DuckBlockTypes::INLINE_BOLD || element_type == "strong") {
-		return "<strong>" + XMLUtils::HTMLEscape(content) + "</strong>";
+		return "<strong" + PassthroughAttrs(attrs) + ">" + XMLUtils::HTMLEscape(content) + "</strong>";
 	} else if (element_type == DuckBlockTypes::INLINE_ITALIC || element_type == "em" || element_type == "emphasis") {
-		return "<em>" + XMLUtils::HTMLEscape(content) + "</em>";
+		return "<em" + PassthroughAttrs(attrs) + ">" + XMLUtils::HTMLEscape(content) + "</em>";
 	} else if (element_type == DuckBlockTypes::INLINE_CODE) {
-		return "<code>" + XMLUtils::HTMLEscape(content) + "</code>";
+		return "<code" + PassthroughAttrs(attrs) + ">" + XMLUtils::HTMLEscape(content) + "</code>";
 	} else if (element_type == DuckBlockTypes::INLINE_LINK) {
 		std::string href = attrs.count("href") ? attrs.at("href") : "";
 		std::string title = attrs.count("title") ? attrs.at("title") : "";
-		std::string result = "<a href=\"" + XMLUtils::HTMLEscape(href) + "\"";
+		std::string result = "<a" + PassthroughAttrs(attrs, {"href", "title"});
+		// An anchor (<a name=...>) has no href; rendering href="" would invent one.
+		if (!href.empty()) {
+			result += " href=\"" + XMLUtils::HTMLEscape(href) + "\"";
+		}
 		if (!title.empty()) {
 			result += " title=\"" + XMLUtils::HTMLEscape(title) + "\"";
 		}
@@ -136,7 +164,7 @@ static std::string RenderInlineElementToHtml(const std::string &element_type, co
 		// by test/sql/duck_block_writer_contract.test using distinct values.
 		std::string alt = content.empty() && attrs.count("alt") ? attrs.at("alt") : content;
 		std::string title = attrs.count("title") ? attrs.at("title") : "";
-		std::string result = "<img src=\"" + XMLUtils::HTMLEscape(src) + "\"";
+		std::string result = "<img" + PassthroughAttrs(attrs, {"src", "alt", "title"}) + " src=\"" + XMLUtils::HTMLEscape(src) + "\"";
 		if (!alt.empty()) {
 			result += " alt=\"" + XMLUtils::HTMLEscape(alt) + "\"";
 		}
@@ -152,25 +180,17 @@ static std::string RenderInlineElementToHtml(const std::string &element_type, co
 	} else if (element_type == DuckBlockTypes::INLINE_LINEBREAK || element_type == "br") {
 		return "<br>";
 	} else if (element_type == DuckBlockTypes::INLINE_STRIKETHROUGH || element_type == "del") {
-		return "<del>" + XMLUtils::HTMLEscape(content) + "</del>";
+		return "<del" + PassthroughAttrs(attrs) + ">" + XMLUtils::HTMLEscape(content) + "</del>";
 	} else if (element_type == DuckBlockTypes::INLINE_SUPERSCRIPT || element_type == "sup") {
-		return "<sup>" + XMLUtils::HTMLEscape(content) + "</sup>";
+		return "<sup" + PassthroughAttrs(attrs) + ">" + XMLUtils::HTMLEscape(content) + "</sup>";
 	} else if (element_type == DuckBlockTypes::INLINE_SUBSCRIPT || element_type == "sub") {
-		return "<sub>" + XMLUtils::HTMLEscape(content) + "</sub>";
+		return "<sub" + PassthroughAttrs(attrs) + ">" + XMLUtils::HTMLEscape(content) + "</sub>";
 	} else if (element_type == DuckBlockTypes::INLINE_UNDERLINE || element_type == "u") {
-		return "<u>" + XMLUtils::HTMLEscape(content) + "</u>";
+		return "<u" + PassthroughAttrs(attrs) + ">" + XMLUtils::HTMLEscape(content) + "</u>";
 	} else if (element_type == DuckBlockTypes::INLINE_SMALLCAPS) {
-		return "<span style=\"font-variant: small-caps\">" + XMLUtils::HTMLEscape(content) + "</span>";
+		return "<span" + PassthroughAttrs(attrs) + " style=\"font-variant: small-caps\">" + XMLUtils::HTMLEscape(content) + "</span>";
 	} else if (element_type == DuckBlockTypes::INLINE_SPAN) {
-		std::string id = attrs.count("id") ? attrs.at("id") : "";
-		std::string cls = attrs.count("class") ? attrs.at("class") : "";
-		std::string result = "<span";
-		if (!id.empty()) {
-			result += " id=\"" + XMLUtils::HTMLEscape(id) + "\"";
-		}
-		if (!cls.empty()) {
-			result += " class=\"" + XMLUtils::HTMLEscape(cls) + "\"";
-		}
+		std::string result = "<span" + PassthroughAttrs(attrs);
 		result += ">" + XMLUtils::HTMLEscape(content) + "</span>";
 		return result;
 	} else if (element_type == DuckBlockTypes::INLINE_RAW) {
@@ -226,40 +246,36 @@ static std::string RenderInlineOpenTag(const std::string &element_type,
 	if (element_type.empty()) {
 		return "";
 	} else if (element_type == DuckBlockTypes::INLINE_BOLD || element_type == "strong") {
-		return "<strong>";
+		return "<strong" + PassthroughAttrs(attrs) + ">";
 	} else if (element_type == DuckBlockTypes::INLINE_ITALIC || element_type == "em" || element_type == "emphasis") {
-		return "<em>";
+		return "<em" + PassthroughAttrs(attrs) + ">";
 	} else if (element_type == DuckBlockTypes::INLINE_CODE) {
-		return "<code>";
+		return "<code" + PassthroughAttrs(attrs) + ">";
 	} else if (element_type == DuckBlockTypes::INLINE_LINK) {
 		std::string href = attrs.count("href") ? attrs.at("href") : "";
 		std::string title = attrs.count("title") ? attrs.at("title") : "";
-		std::string result = "<a href=\"" + XMLUtils::HTMLEscape(href) + "\"";
+		std::string result = "<a" + PassthroughAttrs(attrs, {"href", "title"});
+		// An anchor (<a name=...>) has no href; rendering href="" would invent one.
+		if (!href.empty()) {
+			result += " href=\"" + XMLUtils::HTMLEscape(href) + "\"";
+		}
 		if (!title.empty()) {
 			result += " title=\"" + XMLUtils::HTMLEscape(title) + "\"";
 		}
 		result += ">";
 		return result;
 	} else if (element_type == DuckBlockTypes::INLINE_STRIKETHROUGH || element_type == "del") {
-		return "<del>";
+		return "<del" + PassthroughAttrs(attrs) + ">";
 	} else if (element_type == DuckBlockTypes::INLINE_SUPERSCRIPT || element_type == "sup") {
-		return "<sup>";
+		return "<sup" + PassthroughAttrs(attrs) + ">";
 	} else if (element_type == DuckBlockTypes::INLINE_SUBSCRIPT || element_type == "sub") {
-		return "<sub>";
+		return "<sub" + PassthroughAttrs(attrs) + ">";
 	} else if (element_type == DuckBlockTypes::INLINE_UNDERLINE || element_type == "u") {
-		return "<u>";
+		return "<u" + PassthroughAttrs(attrs) + ">";
 	} else if (element_type == DuckBlockTypes::INLINE_SMALLCAPS) {
-		return "<span style=\"font-variant: small-caps\">";
+		return "<span" + PassthroughAttrs(attrs) + " style=\"font-variant: small-caps\">";
 	} else if (element_type == DuckBlockTypes::INLINE_SPAN) {
-		std::string id = attrs.count("id") ? attrs.at("id") : "";
-		std::string cls = attrs.count("class") ? attrs.at("class") : "";
-		std::string result = "<span";
-		if (!id.empty()) {
-			result += " id=\"" + XMLUtils::HTMLEscape(id) + "\"";
-		}
-		if (!cls.empty()) {
-			result += " class=\"" + XMLUtils::HTMLEscape(cls) + "\"";
-		}
+		std::string result = "<span" + PassthroughAttrs(attrs);
 		result += ">";
 		return result;
 	} else if (element_type == DuckBlockTypes::INLINE_RAW) {
@@ -511,10 +527,139 @@ static bool HasBlockChildren(xmlNodePtr node) {
 // the insertion order below.
 using OrderedAttrs = std::vector<std::pair<std::string, std::string>>;
 
+// GitHub #142. Which SOURCE attributes are copied verbatim onto every element,
+// block and inline, when present. Governs passthrough of the source's own
+// attributes only; the semantic attributes the vocabulary defines (heading_level,
+// list_type, role, key, ...) are set by the emit sites unconditionally and are
+// not affected by this.
+struct CaptureSpec {
+	bool all = false;
+	std::vector<std::string> keys;
+
+	bool Wants(const std::string &key) const {
+		if (all) {
+			return true;
+		}
+		return std::find(keys.begin(), keys.end(), key) != keys.end();
+	}
+	// Identity (id, name) and references (href, src). class is deliberately not
+	// here: on real-world HTML it is mostly framework noise, so it is opt-in via
+	// the 'classes' preset or an explicit list.
+	// Written as assignments rather than brace-init: this file builds as C++11,
+	// where a struct with default member initialisers is not an aggregate.
+	static CaptureSpec Default() {
+		CaptureSpec s;
+		s.keys = {"id", "name", "href", "src"};
+		return s;
+	}
+	static CaptureSpec Classes() {
+		auto s = Default();
+		s.keys.push_back("class");
+		return s;
+	}
+	static CaptureSpec All() {
+		CaptureSpec s;
+		s.all = true;
+		return s;
+	}
+	static CaptureSpec None() {
+		return CaptureSpec();
+	}
+};
+
+// capture_attributes := 'default' | 'classes' | '*' | true | false | ['id', ...]
+static CaptureSpec ParseCaptureSpec(const Value &v) {
+	if (v.IsNull()) {
+		return CaptureSpec::Default();
+	}
+	switch (v.type().id()) {
+	case LogicalTypeId::BOOLEAN:
+		return v.GetValue<bool>() ? CaptureSpec::All() : CaptureSpec::None();
+	case LogicalTypeId::VARCHAR: {
+		auto s = StringValue::Get(v);
+		if (s == "*") {
+			return CaptureSpec::All();
+		}
+		if (s == "default") {
+			return CaptureSpec::Default();
+		}
+		if (s == "classes") {
+			return CaptureSpec::Classes();
+		}
+		throw BinderException("capture_attributes: unknown preset '%s'. Use 'default', 'classes', '*', true, false, "
+		                      "or a list such as ['id', 'name', 'class']",
+		                      s);
+	}
+	case LogicalTypeId::LIST: {
+		CaptureSpec spec;
+		for (auto &item : ListValue::GetChildren(v)) {
+			if (item.IsNull()) {
+				throw BinderException("capture_attributes: list may not contain NULL");
+			}
+			spec.keys.push_back(StringValue::Get(item.DefaultCastAs(LogicalType::VARCHAR)));
+		}
+		return spec;
+	}
+	default:
+		throw BinderException("capture_attributes must be a boolean, a preset name, or a list of attribute names");
+	}
+}
+
+// Attribute keys the vocabulary gives a meaning to. Never copied from the
+// source, in any capture mode: under '*' a document could otherwise forge the
+// vocabulary's own semantics -- <section role="banner"> (ARIA) overwriting
+// role=section. `language` is derived from a code block's class, not read from
+// an attribute of that name, and is reserved for the same reason.
+static bool IsReservedAttr(const std::string &key) {
+	return key == DuckBlockTypes::ATTR_ROLE || key == DuckBlockTypes::ATTR_KEY ||
+	       key == DuckBlockTypes::ATTR_HEADING_LEVEL || key == DuckBlockTypes::ATTR_LIST_TYPE ||
+	       key == DuckBlockTypes::ATTR_SOURCE_TYPE || key == DuckBlockTypes::ATTR_PANDOC_AST ||
+	       key == DuckBlockTypes::ATTR_ORDERED_LEGACY || key == "language";
+}
+
+// Replace-or-append, so a key set by the passthrough copy and again by a
+// type-specific site (href on <a>, src on <img>, start on <ol>) is stored once.
+static void PutAttr(OrderedAttrs &attrs, const std::string &key, const std::string &value) {
+	for (auto &kv : attrs) {
+		if (kv.first == key) {
+			kv.second = value;
+			return;
+		}
+	}
+	attrs.emplace_back(key, value);
+}
+
+// Copy the source element's own attributes, in document order, per the spec.
+// One call at each loop's single attrs declaration, for every element -- three
+// sites that each remembered independently is how #142 happened.
+static void CopySourceAttributes(xmlNodePtr node, OrderedAttrs &attrs, const CaptureSpec &spec) {
+	if (!spec.all && spec.keys.empty()) {
+		return;
+	}
+	for (xmlAttrPtr a = node->properties; a; a = a->next) {
+		if (!a->name) {
+			continue;
+		}
+		std::string key(reinterpret_cast<const char *>(a->name));
+		if (IsReservedAttr(key) || !spec.Wants(key)) {
+			continue;
+		}
+		xmlChar *raw = xmlNodeListGetString(node->doc, a->children, 1);
+		if (!raw) {
+			continue;
+		}
+		std::string value(reinterpret_cast<const char *>(raw));
+		xmlFree(raw);
+		if (!value.empty()) {
+			PutAttr(attrs, key, value);
+		}
+	}
+}
+
 // Forward declaration: ExtractInlineElementsRange recurses into a parent's
 // full child list (e.g. a nested formatting wrapper) via this convenience
 // form, defined just after it below.
-static std::vector<Value> ExtractInlineElements(xmlNodePtr parent_node, int32_t base_level, int32_t &element_order);
+static std::vector<Value> ExtractInlineElements(xmlNodePtr parent_node, int32_t base_level, int32_t &element_order, const CaptureSpec &spec);
 
 // Extract inline elements from an explicit sibling range [start, stop) as
 // structured kind='inline' duck_blocks. Nested formatting (e.g. <b>x
@@ -527,7 +672,7 @@ static std::vector<Value> ExtractInlineElements(xmlNodePtr parent_node, int32_t 
 // hand it a run of loose inline nodes (text plus inline elements) that sit
 // among block siblings, not gathered under a dedicated inline parent.
 static std::vector<Value> ExtractInlineElementsRange(xmlNodePtr start, xmlNodePtr stop, int32_t base_level,
-                                                      int32_t &element_order) {
+                                                      int32_t &element_order, const CaptureSpec &spec) {
 	std::vector<Value> inlines;
 
 	for (xmlNodePtr child = start; child && child != stop; child = child->next) {
@@ -552,6 +697,7 @@ static std::vector<Value> ExtractInlineElementsRange(xmlNodePtr start, xmlNodePt
 		}
 
 		OrderedAttrs attrs;
+		CopySourceAttributes(child, attrs, spec);
 
 		// Void inline elements (no children to recurse).
 		if (tag == "img") {
@@ -562,11 +708,11 @@ static std::vector<Value> ExtractInlineElementsRange(xmlNodePtr start, xmlNodePt
 			// handling in WalkBlockNode, so attribute order is a property of the
 			// reader rather than of whether the image sits at block or inline level.
 			if (!src.empty())
-				attrs.emplace_back("src", src);
+				PutAttr(attrs, "src", src);
 			if (!alt.empty())
-				attrs.emplace_back("alt", alt);
+				PutAttr(attrs, "alt", alt);
 			if (!title.empty())
-				attrs.emplace_back("title", title);
+				PutAttr(attrs, "title", title);
 			inlines.push_back(DuckBlockTypes::CreateInline(DuckBlockTypes::INLINE_IMAGE, alt,
 			                                               Value::INTEGER(base_level), DuckBlockTypes::ENCODING_TEXT,
 			                                               attrs, element_order++));
@@ -584,23 +730,17 @@ static std::vector<Value> ExtractInlineElementsRange(xmlNodePtr start, xmlNodePt
 			if (tag == "a") {
 				std::string href = GetNodeAttribute(child, "href");
 				if (!href.empty())
-					attrs.emplace_back("href", href);
+					PutAttr(attrs, "href", href);
 				std::string title = GetNodeAttribute(child, "title");
 				if (!title.empty())
-					attrs.emplace_back("title", title);
-			} else if (tag == "span") {
-				std::string id = GetNodeAttribute(child, "id");
-				std::string cls = GetNodeAttribute(child, "class");
-				if (!id.empty())
-					attrs.emplace_back("id", id);
-				if (!cls.empty())
-					attrs.emplace_back("class", cls);
+					PutAttr(attrs, "title", title);
 			}
+			// (span's id/class copy lived here; CopySourceAttributes above covers it)
 			if (HasElementChildren(child)) {
 				// Container: empty content, then recurse children one level deeper.
 				inlines.push_back(DuckBlockTypes::CreateInline(etype, "", Value::INTEGER(base_level),
 				                                               DuckBlockTypes::ENCODING_TEXT, attrs, element_order++));
-				auto nested = ExtractInlineElements(child, base_level + 1, element_order);
+				auto nested = ExtractInlineElements(child, base_level + 1, element_order, spec);
 				inlines.insert(inlines.end(), nested.begin(), nested.end());
 			} else {
 				// Leaf: carries its text content.
@@ -614,7 +754,7 @@ static std::vector<Value> ExtractInlineElementsRange(xmlNodePtr start, xmlNodePt
 		// Unknown inline element: preserve any nested formatting by recursing at
 		// the same level (the unknown wrapper is dropped); text-only becomes text.
 		if (HasElementChildren(child)) {
-			auto nested = ExtractInlineElements(child, base_level, element_order);
+			auto nested = ExtractInlineElements(child, base_level, element_order, spec);
 			inlines.insert(inlines.end(), nested.begin(), nested.end());
 		} else {
 			std::string content = GetNodeTextContent(child);
@@ -631,8 +771,8 @@ static std::vector<Value> ExtractInlineElementsRange(xmlNodePtr start, xmlNodePt
 // Convenience form of ExtractInlineElementsRange over ALL of a parent's
 // children -- the common case; WalkBlockNode is the only caller that needs
 // the explicit-range form above.
-static std::vector<Value> ExtractInlineElements(xmlNodePtr parent_node, int32_t base_level, int32_t &element_order) {
-	return ExtractInlineElementsRange(parent_node->children, nullptr, base_level, element_order);
+static std::vector<Value> ExtractInlineElements(xmlNodePtr parent_node, int32_t base_level, int32_t &element_order, const CaptureSpec &spec) {
+	return ExtractInlineElementsRange(parent_node->children, nullptr, base_level, element_order, spec);
 }
 
 // True when `node` is the start of a loose-inline run inside a container's
@@ -695,28 +835,10 @@ static bool IsLooseInlineStart(xmlNodePtr node) {
 }
 
 // Emit a container block, then recurse into its children one level deeper.
-// GitHub #142. Every block that came from a source element carries that
-// element's id and class in `attributes` when present. Copied in ONE place,
-// for every block, rather than at each emit site: three sites that each
-// remembered independently (div/section both, heading id only, everything
-// else nothing) is exactly how the gap happened, and per-site copying is a
-// gap that reopens with every new element type. Identity keys come first in
-// the map, ahead of type-specific keys, so the shape is uniform across types.
-static void CopySourceIdentity(xmlNodePtr node, OrderedAttrs &attrs) {
-	std::string id = GetNodeAttribute(node, "id");
-	if (!id.empty()) {
-		attrs.emplace_back("id", id);
-	}
-	std::string cls = GetNodeAttribute(node, "class");
-	if (!cls.empty()) {
-		attrs.emplace_back("class", cls);
-	}
-}
-
 static void EmitContainerAndRecurse(xmlNodePtr node, const std::string &block_type, int32_t level, int32_t &order,
-                                    vector<Value> &blocks, OrderedAttrs &attrs);
+                                    vector<Value> &blocks, OrderedAttrs &attrs, const CaptureSpec &spec);
 static void EmitContainerOrLeaf(xmlNodePtr node, const std::string &block_type, int32_t level, int32_t &order,
-                                vector<Value> &blocks, OrderedAttrs &attrs);
+                                vector<Value> &blocks, OrderedAttrs &attrs, const CaptureSpec &spec);
 
 // Walk `node`'s children depth-first, emitting blocks in document order.
 //
@@ -738,7 +860,7 @@ static void EmitContainerOrLeaf(xmlNodePtr node, const std::string &block_type, 
 // unchanged so it stays off for the whole unmapped subtree, not just its
 // immediate children.
 static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector<Value> &blocks,
-                          bool detect_loose_inline = true) {
+                          const CaptureSpec &spec, bool detect_loose_inline = true) {
 	for (xmlNodePtr child = node->children; child; child = child->next) {
 		// Loose inline content interleaved with block siblings -- bare text, or
 		// an inline-only element -- has nowhere else to live (no container of
@@ -768,7 +890,7 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 			} else {
 				blocks.push_back(DuckBlockTypes::CreateBlock(DuckBlockTypes::TYPE_PLAIN, "", Value::INTEGER(level),
 				                                             DuckBlockTypes::ENCODING_TEXT, OrderedAttrs(), order++));
-				auto inlines = ExtractInlineElementsRange(child, run_end, level + 1, order);
+				auto inlines = ExtractInlineElementsRange(child, run_end, level + 1, order, spec);
 				blocks.insert(blocks.end(), inlines.begin(), inlines.end());
 			}
 			if (!run_end) {
@@ -791,7 +913,7 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 		}
 
 		OrderedAttrs attrs;
-		CopySourceIdentity(child, attrs);
+		CopySourceAttributes(child, attrs, spec);
 
 		// --- Headings ---------------------------------------------------
 		if (tag.length() == 2 && tag[0] == 'h' && tag[1] >= '1' && tag[1] <= '6') {
@@ -799,7 +921,7 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 			if (HasElementChildren(child)) {
 				blocks.push_back(DuckBlockTypes::CreateBlock(DuckBlockTypes::TYPE_HEADING, "", Value::INTEGER(level),
 				                                             DuckBlockTypes::ENCODING_TEXT, attrs, order++));
-				auto inlines = ExtractInlineElements(child, level + 1, order);
+				auto inlines = ExtractInlineElements(child, level + 1, order, spec);
 				blocks.insert(blocks.end(), inlines.begin(), inlines.end());
 			} else {
 				blocks.push_back(DuckBlockTypes::CreateBlock(DuckBlockTypes::TYPE_HEADING, GetNodeTextContent(child),
@@ -814,7 +936,7 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 			if (HasElementChildren(child)) {
 				blocks.push_back(DuckBlockTypes::CreateBlock(DuckBlockTypes::TYPE_PARAGRAPH, "", Value::INTEGER(level),
 				                                             DuckBlockTypes::ENCODING_TEXT, attrs, order++));
-				auto inlines = ExtractInlineElements(child, level + 1, order);
+				auto inlines = ExtractInlineElements(child, level + 1, order, spec);
 				blocks.insert(blocks.end(), inlines.begin(), inlines.end());
 			} else {
 				blocks.push_back(DuckBlockTypes::CreateBlock(DuckBlockTypes::TYPE_PARAGRAPH, GetNodeTextContent(child),
@@ -845,7 +967,7 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 
 		// --- Blockquote: container when it holds blocks, leaf otherwise ---
 		if (tag == "blockquote") {
-			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_BLOCKQUOTE, level, order, blocks, attrs);
+			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_BLOCKQUOTE, level, order, blocks, attrs, spec);
 			continue;
 		}
 
@@ -877,10 +999,10 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 			if (is_ordered) {
 				std::string start = GetNodeAttribute(child, "start");
 				if (!start.empty()) {
-					attrs.emplace_back("start", start);
+					PutAttr(attrs, "start", start);
 				}
 			}
-			EmitContainerAndRecurse(child, DuckBlockTypes::TYPE_LIST, level, order, blocks, attrs);
+			EmitContainerAndRecurse(child, DuckBlockTypes::TYPE_LIST, level, order, blocks, attrs, spec);
 			continue;
 		}
 
@@ -890,7 +1012,7 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 		// (Pandoc's loose Para, or a nested list). Reuses EmitContainerOrLeaf
 		// rather than writing a fourth copy of that decision.
 		if (tag == "li") {
-			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_LIST_ITEM, level, order, blocks, attrs);
+			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_LIST_ITEM, level, order, blocks, attrs, spec);
 			continue;
 		}
 
@@ -904,7 +1026,7 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 		if (tag == "dl") {
 			attrs.emplace_back(std::string(DuckBlockTypes::ATTR_LIST_TYPE),
 			                   std::string(DuckBlockTypes::LIST_TYPE_DEFINITION));
-			EmitContainerAndRecurse(child, DuckBlockTypes::TYPE_LIST, level, order, blocks, attrs);
+			EmitContainerAndRecurse(child, DuckBlockTypes::TYPE_LIST, level, order, blocks, attrs, spec);
 			continue;
 		}
 
@@ -920,7 +1042,7 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 			attrs.emplace_back(std::string(DuckBlockTypes::ATTR_ROLE),
 			                   tag == "dt" ? std::string(DuckBlockTypes::ROLE_TERM)
 			                               : std::string(DuckBlockTypes::ROLE_DEFINITION));
-			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_LIST_ITEM, level, order, blocks, attrs);
+			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_LIST_ITEM, level, order, blocks, attrs, spec);
 			continue;
 		}
 
@@ -936,14 +1058,14 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 			std::string src = GetNodeAttribute(child, "src");
 			std::string alt = GetNodeAttribute(child, "alt");
 			std::string title = GetNodeAttribute(child, "title");
-			attrs.emplace_back("src", src);
+			PutAttr(attrs, "src", src);
 			std::string content;
 			if (!alt.empty()) {
-				attrs.emplace_back("alt", alt);
+				PutAttr(attrs, "alt", alt);
 				content = alt;
 			}
 			if (!title.empty()) {
-				attrs.emplace_back("title", title);
+				PutAttr(attrs, "title", title);
 			}
 			blocks.push_back(DuckBlockTypes::CreateBlock(DuckBlockTypes::TYPE_IMAGE, content, Value::INTEGER(level),
 			                                             DuckBlockTypes::ENCODING_TEXT, attrs, order++));
@@ -959,7 +1081,7 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 			// still takes the container path because img is block-level, so
 			// HasBlockChildren is true and EmitContainerOrLeaf recurses exactly
 			// as EmitContainerAndRecurse always did.
-			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_FIGURE, level, order, blocks, attrs);
+			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_FIGURE, level, order, blocks, attrs, spec);
 			continue;
 		}
 		if (tag == "figcaption") {
@@ -969,7 +1091,7 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 			if (!HasElementChildren(child) && GetNodeTextContent(child).empty()) {
 				continue;
 			}
-			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_CAPTION, level, order, blocks, attrs);
+			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_CAPTION, level, order, blocks, attrs, spec);
 			continue;
 		}
 
@@ -982,7 +1104,7 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 				continue;
 			}
 			attrs.emplace_back(std::string(DuckBlockTypes::ATTR_ROLE), "summary");
-			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_CAPTION, level, order, blocks, attrs);
+			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_CAPTION, level, order, blocks, attrs, spec);
 			continue;
 		}
 
@@ -995,14 +1117,14 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 			// own `content` (single-text-child rule) rather than always
 			// recursing into WalkBlockNode. HasBlockChildren containers still
 			// take the same recurse path EmitContainerAndRecurse always did.
-			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_SECTION, level, order, blocks, attrs);
+			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_SECTION, level, order, blocks, attrs, spec);
 			continue;
 		}
 
 		// --- <details>: semantic, but not a sectioning container -----------
 		if (tag == "details") {
 			attrs.emplace_back(std::string(DuckBlockTypes::ATTR_SOURCE_TYPE), tag);
-			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_GENERIC, level, order, blocks, attrs);
+			EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_GENERIC, level, order, blocks, attrs, spec);
 			continue;
 		}
 
@@ -1015,7 +1137,7 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 				// text</div>) carries it in the div's own `content` instead of
 				// unconditionally opening a container and recursing into a
 				// same-level `plain` sibling.
-				EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_DIV, level, order, blocks, attrs);
+				EmitContainerOrLeaf(child, DuckBlockTypes::TYPE_DIV, level, order, blocks, attrs, spec);
 				continue;
 			}
 			// A bare <div>/<span> (no id, no class) stays transparent -- no
@@ -1026,7 +1148,7 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 			// so that content surfaces as a `plain` at the parent's level
 			// (WalkBlockNode's loose-inline-run handling above) instead of
 			// being silently dropped.
-			WalkBlockNode(child, level, order, blocks, true);
+			WalkBlockNode(child, level, order, blocks, spec, true);
 			continue;
 		}
 
@@ -1037,15 +1159,15 @@ static void WalkBlockNode(xmlNodePtr node, int32_t level, int32_t &order, vector
 		// detection is OFF for this call: it exists only to find nested BLOCKS,
 		// not to harvest the wrapper's own bare text (see WalkBlockNode's
 		// detect_loose_inline doc comment).
-		WalkBlockNode(child, level, order, blocks, false);
+		WalkBlockNode(child, level, order, blocks, spec, false);
 	}
 }
 
 static void EmitContainerAndRecurse(xmlNodePtr node, const std::string &block_type, int32_t level, int32_t &order,
-                                    vector<Value> &blocks, OrderedAttrs &attrs) {
+                                    vector<Value> &blocks, OrderedAttrs &attrs, const CaptureSpec &spec) {
 	blocks.push_back(DuckBlockTypes::CreateBlock(block_type, "", Value::INTEGER(level),
 	                                             DuckBlockTypes::ENCODING_TEXT, attrs, order++));
-	WalkBlockNode(node, level + 1, order, blocks);
+	WalkBlockNode(node, level + 1, order, blocks, spec);
 }
 
 // Emit a container three ways, depending on what it actually holds:
@@ -1054,13 +1176,13 @@ static void EmitContainerAndRecurse(xmlNodePtr node, const std::string &block_ty
 //                      would transparently recurse past a <b> and emit nothing)
 //   text only       -> a leaf carrying its text
 static void EmitContainerOrLeaf(xmlNodePtr node, const std::string &block_type, int32_t level, int32_t &order,
-                                vector<Value> &blocks, OrderedAttrs &attrs) {
+                                vector<Value> &blocks, OrderedAttrs &attrs, const CaptureSpec &spec) {
 	if (HasBlockChildren(node)) {
-		EmitContainerAndRecurse(node, block_type, level, order, blocks, attrs);
+		EmitContainerAndRecurse(node, block_type, level, order, blocks, attrs, spec);
 	} else if (HasElementChildren(node)) {
 		blocks.push_back(DuckBlockTypes::CreateBlock(block_type, "", Value::INTEGER(level),
 		                                             DuckBlockTypes::ENCODING_TEXT, attrs, order++));
-		auto inlines = ExtractInlineElements(node, level + 1, order);
+		auto inlines = ExtractInlineElements(node, level + 1, order, spec);
 		blocks.insert(blocks.end(), inlines.begin(), inlines.end());
 	} else {
 		blocks.push_back(DuckBlockTypes::CreateBlock(block_type, GetNodeTextContent(node), Value::INTEGER(level),
@@ -1068,7 +1190,7 @@ static void EmitContainerOrLeaf(xmlNodePtr node, const std::string &block_type, 
 	}
 }
 
-vector<Value> DuckBlockFunctions::HtmlToDuckBlocks(const std::string &html_str) {
+vector<Value> DuckBlockFunctions::HtmlToDuckBlocks(const std::string &html_str, const CaptureSpec &spec) {
 	if (html_str.empty()) {
 		return vector<Value>();
 	}
@@ -1196,9 +1318,9 @@ vector<Value> DuckBlockFunctions::HtmlToDuckBlocks(const std::string &html_str) 
 	}
 
 	if (body) {
-		WalkBlockNode(body, 1, block_order, blocks);
+		WalkBlockNode(body, 1, block_order, blocks, spec);
 	} else if (root) {
-		WalkBlockNode(root, 1, block_order, blocks);
+		WalkBlockNode(root, 1, block_order, blocks, spec);
 	}
 
 	// Now emit the metadata, AFTER the document's blocks, continuing
@@ -1248,7 +1370,61 @@ vector<Value> DuckBlockFunctions::HtmlToDuckBlocks(const std::string &html_str) 
 	return blocks;
 }
 
+// Bind data for html_to_duck_blocks(html, capture_attributes := ...).
+struct HtmlToDuckBlocksBindData : public FunctionData {
+	CaptureSpec spec;
+
+	explicit HtmlToDuckBlocksBindData(CaptureSpec s) : spec(std::move(s)) {
+	}
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<HtmlToDuckBlocksBindData>(spec);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		auto &o = other_p.Cast<HtmlToDuckBlocksBindData>();
+		return spec.all == o.spec.all && spec.keys == o.spec.keys;
+	}
+};
+
+// Named parameters on a scalar: same mechanism as xml_to_json -- varargs ANY,
+// each extra argument must be aliased and constant.
+static unique_ptr<FunctionData> HtmlToDuckBlocksBind(DUCKDB_SCALAR_BIND_PARAMS) {
+	auto &bind_args = DUCKDB_SCALAR_BIND_ARGS;
+	auto &bind_ctx = DUCKDB_SCALAR_BIND_CONTEXT;
+	CaptureSpec spec = CaptureSpec::Default();
+	for (idx_t i = 1; i < bind_args.size(); i++) {
+		auto &arg = bind_args[i];
+		std::string name = CompatIdentifierName(arg->GetAlias());
+		if (name.empty()) {
+			throw BinderException("html_to_duck_blocks: arguments after the first must be named, e.g. "
+			                      "capture_attributes := ['id', 'class']");
+		}
+		if (arg->HasParameter()) {
+			throw ParameterNotResolvedException();
+		}
+		if (!arg->IsFoldable()) {
+			throw BinderException("Parameter '%s' must be a constant value", name);
+		}
+		Value v = ExpressionExecutor::EvaluateScalar(bind_ctx, *arg);
+		if (name == "capture_attributes") {
+			spec = ParseCaptureSpec(v);
+		} else {
+			throw BinderException("Unknown parameter '%s' for html_to_duck_blocks", name);
+		}
+	}
+	return make_uniq<HtmlToDuckBlocksBindData>(std::move(spec));
+}
+
 void DuckBlockFunctions::HtmlToDuckBlocksFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	CaptureSpec spec = CaptureSpec::Default();
+#ifdef DUCKDB_HAS_NEW_VECTOR_HEADERS
+	auto &bind_info = func_expr.BindInfo();
+#else
+	auto &bind_info = func_expr.bind_info;
+#endif
+	if (bind_info) {
+		spec = bind_info->Cast<HtmlToDuckBlocksBindData>().spec;
+	}
 	auto &html_vector = args.data[0];
 	auto count = args.size();
 
@@ -1261,7 +1437,7 @@ void DuckBlockFunctions::HtmlToDuckBlocksFunction(DataChunk &args, ExpressionSta
 		}
 
 		std::string html_str = html_value.GetValue<string>();
-		auto blocks = HtmlToDuckBlocks(html_str);
+		auto blocks = HtmlToDuckBlocks(html_str, spec);
 		result.SetValue(i, Value::LIST(DuckBlockTypes::DuckBlockType(), blocks));
 	}
 }
@@ -1440,7 +1616,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 					lvl = 1;
 				if (lvl > 6)
 					lvl = 6;
-				html << "<h" << lvl << IdentityAttrs(attrs) << ">";
+				html << "<h" << lvl << PassthroughAttrs(attrs) << ">";
 
 				// Render block's own content if present
 				if (!content.empty()) {
@@ -1455,7 +1631,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 
 				html << "</h" << lvl << ">";
 			} else if (element_type == DuckBlockTypes::TYPE_PARAGRAPH) {
-				html << "<p" << IdentityAttrs(attrs) << ">";
+				html << "<p" << PassthroughAttrs(attrs) << ">";
 
 				// Render block's own content if present
 				if (!content.empty()) {
@@ -1474,9 +1650,9 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 				if (attrs.count("language")) {
 					lang_class = " class=\"language-" + XMLUtils::HTMLEscape(attrs["language"]) + "\"";
 				}
-				html << "<pre" << IdentityAttrs(attrs) << "><code" << lang_class << ">" << XMLUtils::HTMLEscape(content) << "</code></pre>";
+				html << "<pre" << PassthroughAttrs(attrs) << "><code" << lang_class << ">" << XMLUtils::HTMLEscape(content) << "</code></pre>";
 			} else if (element_type == DuckBlockTypes::TYPE_BLOCKQUOTE) {
-				html << "<blockquote" << IdentityAttrs(attrs) << ">";
+				html << "<blockquote" << PassthroughAttrs(attrs) << ">";
 				if (!content.empty()) {
 					if (encoding == DuckBlockTypes::ENCODING_HTML) {
 						html << content;
@@ -1512,7 +1688,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 					ordered = attrs.count("ordered") && attrs["ordered"] == "true";
 				}
 				std::string tag = is_definition ? "dl" : (ordered ? "ol" : "ul");
-				html << "<" << tag << IdentityAttrs(attrs);
+				html << "<" << tag << PassthroughAttrs(attrs, {"start"});
 				if (ordered && attrs.count("start")) {
 					html << " start=\"" << XMLUtils::HTMLEscape(attrs["start"]) << "\"";
 				}
@@ -1570,7 +1746,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 				// interpolated.
 				std::string item_role = attrs.count(DuckBlockTypes::ATTR_ROLE) ? attrs[DuckBlockTypes::ATTR_ROLE] : "";
 				std::string item_tag = ListItemTagForRole(item_role);
-				html << "<" << item_tag << IdentityAttrs(attrs) << ">";
+				html << "<" << item_tag << PassthroughAttrs(attrs) << ">";
 				if (!content.empty()) {
 					if (encoding == DuckBlockTypes::ENCODING_HTML) {
 						html << content;
@@ -1586,12 +1762,12 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 				}
 			} else if (element_type == DuckBlockTypes::TYPE_TABLE) {
 				if (encoding == DuckBlockTypes::ENCODING_JSON && !content.empty()) {
-					html << TableJsonToHtml(content, IdentityAttrs(attrs));
+					html << TableJsonToHtml(content, PassthroughAttrs(attrs));
 				} else {
-					html << "<table" << IdentityAttrs(attrs) << "></table>";
+					html << "<table" << PassthroughAttrs(attrs) << "></table>";
 				}
 			} else if (element_type == DuckBlockTypes::TYPE_HR) {
-				html << "<hr" << IdentityAttrs(attrs) << ">";
+				html << "<hr" << PassthroughAttrs(attrs) << ">";
 			} else if (element_type == DuckBlockTypes::TYPE_IMAGE) {
 				std::string src = attrs.count("src") ? attrs["src"] : "";
 				std::string alt = attrs.count("alt") ? attrs["alt"] : "";
@@ -1619,7 +1795,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 					alt = content;
 				}
 				std::string title = attrs.count("title") ? attrs["title"] : "";
-				html << "<img" << IdentityAttrs(attrs) << " src=\"" << XMLUtils::HTMLEscape(src) << "\"";
+				html << "<img" << PassthroughAttrs(attrs, {"src", "alt", "title"}) << " src=\"" << XMLUtils::HTMLEscape(src) << "\"";
 				if (!alt.empty()) {
 					html << " alt=\"" << XMLUtils::HTMLEscape(alt) << "\"";
 				}
@@ -1633,7 +1809,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 			} else if (element_type == DuckBlockTypes::TYPE_SECTION) {
 				std::string role = attrs.count(DuckBlockTypes::ATTR_ROLE) ? attrs[DuckBlockTypes::ATTR_ROLE] : "";
 				std::string tag = SectionTagForRole(role);
-				html << "<" << tag << IdentityAttrs(attrs) << ">";
+				html << "<" << tag << PassthroughAttrs(attrs) << ">";
 				if (!content.empty()) {
 					html << XMLUtils::HTMLEscape(content);
 				}
@@ -1644,7 +1820,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 					html << "</" << tag << ">";
 				}
 			} else if (element_type == DuckBlockTypes::TYPE_FIGURE) {
-				html << "<figure" << IdentityAttrs(attrs) << ">";
+				html << "<figure" << PassthroughAttrs(attrs) << ">";
 				if (!content.empty()) {
 					html << XMLUtils::HTMLEscape(content);
 				}
@@ -1657,7 +1833,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 			} else if (element_type == DuckBlockTypes::TYPE_CAPTION) {
 				std::string caption_role = attrs.count(DuckBlockTypes::ATTR_ROLE) ? attrs[DuckBlockTypes::ATTR_ROLE] : "";
 				std::string caption_tag = CaptionTagForRole(caption_role);
-				html << "<" << caption_tag << IdentityAttrs(attrs) << ">";
+				html << "<" << caption_tag << PassthroughAttrs(attrs) << ">";
 				if (!content.empty()) {
 					html << XMLUtils::HTMLEscape(content);
 				}
@@ -1668,7 +1844,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 					html << "</" << caption_tag << ">";
 				}
 			} else if (element_type == DuckBlockTypes::TYPE_DEFLIST) {
-				html << "<dl" << IdentityAttrs(attrs) << ">";
+				html << "<dl" << PassthroughAttrs(attrs) << ">";
 				if (encoding == DuckBlockTypes::ENCODING_JSON && !content.empty()) {
 					yyjson_doc *doc = yyjson_read(content.c_str(), content.size(), 0);
 					if (doc) {
@@ -1724,7 +1900,7 @@ void DuckBlockFunctions::DuckBlocksToHtmlFunction(DataChunk &args, ExpressionSta
 						continue;
 					}
 				}
-				html << "<" << tag << IdentityAttrs(attrs) << ">";
+				html << "<" << tag << PassthroughAttrs(attrs) << ">";
 				if (!content.empty()) {
 					html << XMLUtils::HTMLEscape(content);
 				}
@@ -1817,6 +1993,9 @@ static void ReadFileFully(duckdb::FileHandle &handle, char *data, duckdb::idx_t 
 struct HTMLBlocksReadFunctionData : public TableFunctionData {
 	vector<string> files;
 	bool include_filename = false;
+	// filename := 'src_path' names the column, as read_csv/read_json/read_parquet do.
+	std::string filename_column = "filename";
+	CaptureSpec capture = CaptureSpec::Default();
 	bool ignore_errors = false;
 	idx_t max_file_size = 2147483648ULL; // 2GB default
 };
@@ -1900,8 +2079,21 @@ unique_ptr<FunctionData> DuckBlockFunctions::ReadHTMLBlocksBind(ClientContext &c
 	}
 
 	for (auto &kv : input.named_parameters) {
-		if (kv.first == "filename" || kv.first == "file_path" || kv.first == "include_filepath") {
+		if (kv.first == "filename") {
+			// Same contract as DuckDB core's readers: a boolean adds a column named
+			// `filename`; a string adds it under that name.
+			if (kv.second.type().id() == LogicalTypeId::VARCHAR) {
+				result->include_filename = true;
+				result->filename_column = StringValue::Get(kv.second);
+			} else {
+				result->include_filename = kv.second.DefaultCastAs(LogicalType::BOOLEAN).GetValue<bool>();
+			}
+		} else if (kv.first == "file_path" || kv.first == "include_filepath") {
+			// Deprecated spellings, kept for one release; `filename` is the name
+			// shared with core and with every sibling duck_block extension.
 			result->include_filename = kv.second.GetValue<bool>();
+		} else if (kv.first == "capture_attributes") {
+			result->capture = ParseCaptureSpec(kv.second);
 		} else if (kv.first == "ignore_errors") {
 			result->ignore_errors = kv.second.GetValue<bool>();
 		} else if (kv.first == "maximum_file_size") {
@@ -1910,7 +2102,7 @@ unique_ptr<FunctionData> DuckBlockFunctions::ReadHTMLBlocksBind(ClientContext &c
 	}
 
 	if (result->include_filename) {
-		names.push_back("filename");
+		names.push_back(result->filename_column);
 		return_types.push_back(LogicalType::VARCHAR);
 	}
 
@@ -1993,7 +2185,7 @@ void DuckBlockFunctions::ReadHTMLBlocksFunction(ClientContext &context, TableFun
 				string content;
 				content.resize(file_size);
 				ReadFileFully(*file_handle, (char *)content.data(), file_size);
-				lstate.current_blocks = HtmlToDuckBlocks(content);
+				lstate.current_blocks = HtmlToDuckBlocks(content, bind_data.capture);
 			} catch (const std::exception &e) {
 				if (!bind_data.ignore_errors) {
 					throw;
@@ -2039,6 +2231,7 @@ void DuckBlockFunctions::ReadHTMLBlocksFunction(ClientContext &context, TableFun
 struct HTMLBlocksParseFunctionData : public TableFunctionData {
 	vector<string> html_contents;
 	bool ignore_errors = false;
+	CaptureSpec capture = CaptureSpec::Default();
 };
 
 struct HTMLBlocksParseGlobalState : public GlobalTableFunctionState {
@@ -2089,7 +2282,9 @@ unique_ptr<FunctionData> DuckBlockFunctions::ParseHTMLBlocksBind(ClientContext &
 	}
 
 	for (auto &kv : input.named_parameters) {
-		if (kv.first == "ignore_errors") {
+		if (kv.first == "capture_attributes") {
+			result->capture = ParseCaptureSpec(kv.second);
+		} else if (kv.first == "ignore_errors") {
 			result->ignore_errors = kv.second.GetValue<bool>();
 		}
 	}
@@ -2147,7 +2342,7 @@ void DuckBlockFunctions::ParseHTMLBlocksFunction(ClientContext &context, TableFu
 				break;
 			}
 			lstate.have_item = true;
-			lstate.current_blocks = HtmlToDuckBlocks(gstate.html_contents[claimed]);
+			lstate.current_blocks = HtmlToDuckBlocks(gstate.html_contents[claimed], bind_data.capture);
 			lstate.current_block_index = 0;
 		}
 
@@ -2181,10 +2376,14 @@ void DuckBlockFunctions::ParseHTMLBlocksFunction(ClientContext &context, TableFu
 void DuckBlockFunctions::Register(ExtensionLoader &loader) {
 	// html_to_duck_blocks(html HTML) -> LIST(duck_block)
 	ScalarFunctionSet html_to_duck_blocks_set("html_to_duck_blocks");
-	html_to_duck_blocks_set.AddFunction(
-	    ScalarFunction({XMLTypes::HTMLType()}, DuckBlockTypes::DuckBlockListType(), HtmlToDuckBlocksFunction));
-	html_to_duck_blocks_set.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR}, DuckBlockTypes::DuckBlockListType(), HtmlToDuckBlocksFunction));
+	ScalarFunction html_to_duck_blocks_html({XMLTypes::HTMLType()}, DuckBlockTypes::DuckBlockListType(),
+	                                        HtmlToDuckBlocksFunction, HtmlToDuckBlocksBind);
+	SetScalarFunctionVarArgs(html_to_duck_blocks_html, LogicalType::ANY); // capture_attributes := ...
+	html_to_duck_blocks_set.AddFunction(html_to_duck_blocks_html);
+	ScalarFunction html_to_duck_blocks_varchar({LogicalType::VARCHAR}, DuckBlockTypes::DuckBlockListType(),
+	                                           HtmlToDuckBlocksFunction, HtmlToDuckBlocksBind);
+	SetScalarFunctionVarArgs(html_to_duck_blocks_varchar, LogicalType::ANY);
+	html_to_duck_blocks_set.AddFunction(html_to_duck_blocks_varchar);
 	PreventStructConstantFolding(html_to_duck_blocks_set);
 	loader.RegisterFunction(html_to_duck_blocks_set);
 
@@ -2200,7 +2399,8 @@ void DuckBlockFunctions::Register(ExtensionLoader &loader) {
 	                                      ReadHTMLBlocksBind, ReadHTMLBlocksInit);
 	read_html_blocks_single.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
 	read_html_blocks_single.named_parameters["maximum_file_size"] = LogicalType::BIGINT;
-	read_html_blocks_single.named_parameters["filename"] = LogicalType::BOOLEAN;
+	read_html_blocks_single.named_parameters["filename"] = LogicalType::ANY; // BOOLEAN or VARCHAR (column name)
+	read_html_blocks_single.named_parameters["capture_attributes"] = LogicalType::ANY;
 	read_html_blocks_single.named_parameters["file_path"] = LogicalType::BOOLEAN;
 	read_html_blocks_single.named_parameters["include_filepath"] = LogicalType::BOOLEAN;
 	read_html_blocks_single.init_local = ReadHTMLBlocksInitLocal;
@@ -2211,7 +2411,8 @@ void DuckBlockFunctions::Register(ExtensionLoader &loader) {
 	                                     ReadHTMLBlocksFunction, ReadHTMLBlocksBind, ReadHTMLBlocksInit);
 	read_html_blocks_array.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
 	read_html_blocks_array.named_parameters["maximum_file_size"] = LogicalType::BIGINT;
-	read_html_blocks_array.named_parameters["filename"] = LogicalType::BOOLEAN;
+	read_html_blocks_array.named_parameters["filename"] = LogicalType::ANY; // BOOLEAN or VARCHAR (column name)
+	read_html_blocks_array.named_parameters["capture_attributes"] = LogicalType::ANY;
 	read_html_blocks_array.named_parameters["file_path"] = LogicalType::BOOLEAN;
 	read_html_blocks_array.named_parameters["include_filepath"] = LogicalType::BOOLEAN;
 	read_html_blocks_array.init_local = ReadHTMLBlocksInitLocal;
@@ -2226,24 +2427,28 @@ void DuckBlockFunctions::Register(ExtensionLoader &loader) {
 	TableFunction parse_html_blocks_varchar("parse_html_blocks", {LogicalType::VARCHAR}, ParseHTMLBlocksFunction,
 	                                        ParseHTMLBlocksBind, ParseHTMLBlocksInit);
 	parse_html_blocks_varchar.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
+	parse_html_blocks_varchar.named_parameters["capture_attributes"] = LogicalType::ANY;
 	parse_html_blocks_varchar.init_local = ParseHTMLBlocksInitLocal;
 	parse_html_blocks_set.AddFunction(parse_html_blocks_varchar);
 
 	TableFunction parse_html_blocks_html("parse_html_blocks", {XMLTypes::HTMLType()}, ParseHTMLBlocksFunction,
 	                                     ParseHTMLBlocksBind, ParseHTMLBlocksInit);
 	parse_html_blocks_html.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
+	parse_html_blocks_html.named_parameters["capture_attributes"] = LogicalType::ANY;
 	parse_html_blocks_html.init_local = ParseHTMLBlocksInitLocal;
 	parse_html_blocks_set.AddFunction(parse_html_blocks_html);
 
 	TableFunction parse_html_blocks_varchar_list("parse_html_blocks", {LogicalType::LIST(LogicalType::VARCHAR)},
 	                                             ParseHTMLBlocksFunction, ParseHTMLBlocksBind, ParseHTMLBlocksInit);
 	parse_html_blocks_varchar_list.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
+	parse_html_blocks_varchar_list.named_parameters["capture_attributes"] = LogicalType::ANY;
 	parse_html_blocks_varchar_list.init_local = ParseHTMLBlocksInitLocal;
 	parse_html_blocks_set.AddFunction(parse_html_blocks_varchar_list);
 
 	TableFunction parse_html_blocks_html_list("parse_html_blocks", {LogicalType::LIST(XMLTypes::HTMLType())},
 	                                          ParseHTMLBlocksFunction, ParseHTMLBlocksBind, ParseHTMLBlocksInit);
 	parse_html_blocks_html_list.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
+	parse_html_blocks_html_list.named_parameters["capture_attributes"] = LogicalType::ANY;
 	parse_html_blocks_html_list.init_local = ParseHTMLBlocksInitLocal;
 	parse_html_blocks_set.AddFunction(parse_html_blocks_html_list);
 

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -2101,11 +2101,6 @@ unique_ptr<FunctionData> DuckBlockFunctions::ReadHTMLBlocksBind(ClientContext &c
 		}
 	}
 
-	if (result->include_filename) {
-		names.push_back(result->filename_column);
-		return_types.push_back(LogicalType::VARCHAR);
-	}
-
 	names.push_back("kind");
 	return_types.push_back(LogicalType::VARCHAR);
 
@@ -2126,6 +2121,17 @@ unique_ptr<FunctionData> DuckBlockFunctions::ReadHTMLBlocksBind(ClientContext &c
 
 	names.push_back("element_order");
 	return_types.push_back(LogicalType::INTEGER);
+
+	// TRAILING, after the seven canonical fields -- not first, where it sat
+	// before. duck_block spec 6.4 keys 8-field acceptance on the exact type
+	// (seven canonical fields, then filename VARCHAR), and every consumer reads
+	// the struct by index, so a leading column would put the file path where
+	// each of them expects `kind`. Leading refused to bind at all -- a loud
+	// error -- which is the only reason it never became silent misreads.
+	if (result->include_filename) {
+		names.push_back(result->filename_column);
+		return_types.push_back(LogicalType::VARCHAR);
+	}
 
 	return std::move(result);
 }
@@ -2201,9 +2207,6 @@ void DuckBlockFunctions::ReadHTMLBlocksFunction(ClientContext &context, TableFun
 			auto &children = StructValue::GetChildren(block);
 
 			idx_t col_idx = 0;
-			if (bind_data.include_filename) {
-				output.data[col_idx++].SetValue(output_idx, Value(lstate.current_filename));
-			}
 			output.data[col_idx++].SetValue(output_idx, children[DuckBlockTypes::KIND_IDX]);
 			output.data[col_idx++].SetValue(output_idx, children[DuckBlockTypes::ELEMENT_TYPE_IDX]);
 			output.data[col_idx++].SetValue(output_idx, children[DuckBlockTypes::CONTENT_IDX]);
@@ -2211,6 +2214,9 @@ void DuckBlockFunctions::ReadHTMLBlocksFunction(ClientContext &context, TableFun
 			output.data[col_idx++].SetValue(output_idx, children[DuckBlockTypes::ENCODING_IDX]);
 			output.data[col_idx++].SetValue(output_idx, children[DuckBlockTypes::ATTRIBUTES_IDX]);
 			output.data[col_idx++].SetValue(output_idx, children[DuckBlockTypes::ELEMENT_ORDER_IDX]);
+			if (bind_data.include_filename) {
+				output.data[col_idx++].SetValue(output_idx, Value(lstate.current_filename)); // trailing (spec 6.4)
+			}
 
 			output_idx++;
 			lstate.current_block_index++;

--- a/src/include/duck_block_functions.hpp
+++ b/src/include/duck_block_functions.hpp
@@ -4,6 +4,9 @@
 
 namespace duckdb {
 
+struct CaptureSpec; // defined in duck_block_functions.cpp; see capture_attributes
+
+
 /**
  * DuckBlockFunctions provides scalar functions for converting between HTML/XML and duck_blocks.
  *
@@ -19,7 +22,7 @@ public:
 	static void Register(ExtensionLoader &loader);
 
 	// Core parsing helper
-	static vector<Value> HtmlToDuckBlocks(const std::string &html_str);
+	static vector<Value> HtmlToDuckBlocks(const std::string &html_str, const CaptureSpec &spec);
 
 private:
 	// html_to_duck_blocks(html HTML) -> LIST(duck_block)

--- a/src/include/duck_block_types.hpp
+++ b/src/include/duck_block_types.hpp
@@ -57,6 +57,21 @@ public:
 		return DuckBlockType();
 	}
 
+	// The ONE widened shape duck_block spec 6.4 accepts: the canonical seven,
+	// then a trailing `filename VARCHAR`. Derived from DuckBlockType() rather
+	// than restated, so the two cannot drift. Consumers accept this shape via a
+	// registered implicit cast (see DuckBlockFunctions::Register); producers may
+	// emit it (read_html_blocks does, behind filename := true).
+	//
+	// The bare "filename" literal becomes FIELD_FILENAME once the vendored
+	// vocabulary is re-pinned to 6.4, which publishes it; the value is ruled and
+	// will not change, only the spelling of where it comes from.
+	static LogicalType DuckBlockWithFilenameType() {
+		auto children = StructType::GetChildTypes(DuckBlockType());
+		children.push_back(make_pair("filename", LogicalType::VARCHAR));
+		return LogicalType::STRUCT(std::move(children));
+	}
+
 	// Create a LIST(doc_element) type
 	static LogicalType DuckBlockListType() {
 		return LogicalType::LIST(DuckBlockType());

--- a/test/sql/duck_block_filename_acceptance.test
+++ b/test/sql/duck_block_filename_acceptance.test
@@ -1,0 +1,98 @@
+# name: test/sql/duck_block_filename_acceptance.test
+# description: consumers accept the 8-field duck_block (canonical seven, then filename) -- spec 6.4
+# group: [webbed]
+
+require webbed
+
+# ============================================================================
+# duck_block spec 6.4: consumers MUST accept both the 7-field duck_block and
+# the ONE widened shape -- the seven canonical fields, then `filename VARCHAR`.
+# Producers MAY emit it (read_html_blocks does, behind filename := true).
+#
+# Acceptance is a registered implicit cast from the exact 8-field type to the
+# 7-field type, bound to DuckDB's own default struct cast, which matches
+# children by name and drops the extra. Only the binder's child-count-mismatch
+# cost rule ever blocked that; a registered cast wins over the rule. Functions
+# keep returning the 7-field shape.
+#
+# The source type is EXACT on purpose. Every consumer reads the struct by
+# index, so a lenient (by-arity) acceptance would have read a leading or
+# interior `filename` as `kind`, silently. Exactness is what makes the wrong
+# shapes below binder errors instead of corrupt data.
+# ============================================================================
+
+# --- The accepted shape binds -----------------------------------------------
+# Literals type their attributes explicitly. An untyped MAP{} is
+# MAP("NULL", "NULL"), which is not the exact 8-field type and does not match
+# the registration -- the NULL-ambiguity the spec records as a caution. Real
+# producers emit MAP(VARCHAR, VARCHAR); see the read_html_blocks case below,
+# which is the junction this exists for.
+
+query I
+SELECT duck_blocks_to_html([
+  {'kind':'block','element_type':'paragraph','content':'x','level':1,'encoding':'text','attributes':MAP{}::MAP(VARCHAR, VARCHAR),'element_order':0,'filename':'a.html'}
+])::VARCHAR;
+----
+<p>x</p>
+
+# The real junction, inside webbed: rows from read_html_blocks(filename := true)
+# gathered with list(r) feed a consumer. This is the idiom that broke across
+# repos when the column was leading.
+query I
+SELECT duck_blocks_to_html(list(r ORDER BY r.element_order))::VARCHAR
+FROM read_html_blocks('test/html/simple.html', filename := true) r;
+----
+<h1>Welcome</h1><p>This is a test page.</p>
+
+# A mix of 7- and 8-field values in one expression resolves too.
+query I
+SELECT duck_blocks_to_html(list_concat(
+  html_to_duck_blocks('<h2>a</h2>'),
+  [{'kind':'block','element_type':'paragraph','content':'b','level':1,'encoding':'text','attributes':MAP{}::MAP(VARCHAR, VARCHAR),'element_order':1,'filename':'f'}]
+))::VARCHAR;
+----
+<h2>a</h2><p>b</p>
+
+# --- Everything near the accepted shape is still refused ---------------------
+# Not tolerance for "an extra column"; acceptance of one exact type.
+
+# filename LEADING (the shape webbed itself emitted before 60318d8)
+statement error
+SELECT duck_blocks_to_html([
+  {'filename':'a.html','kind':'block','element_type':'paragraph','content':'x','level':1,'encoding':'text','attributes':MAP{}::MAP(VARCHAR, VARCHAR),'element_order':0}
+]);
+----
+No function matches
+
+# a different trailing name (the rename form's output)
+statement error
+SELECT duck_blocks_to_html([
+  {'kind':'block','element_type':'paragraph','content':'x','level':1,'encoding':'text','attributes':MAP{}::MAP(VARCHAR, VARCHAR),'element_order':0,'src_path':'a.html'}
+]);
+----
+No function matches
+
+# a ninth field
+statement error
+SELECT duck_blocks_to_html([
+  {'kind':'block','element_type':'paragraph','content':'x','level':1,'encoding':'text','attributes':MAP{}::MAP(VARCHAR, VARCHAR),'element_order':0,'filename':'a','extra':'b'}
+]);
+----
+No function matches
+
+# the right name, the wrong type
+statement error
+SELECT duck_blocks_to_html([
+  {'kind':'block','element_type':'paragraph','content':'x','level':1,'encoding':'text','attributes':MAP{}::MAP(VARCHAR, VARCHAR),'element_order':0,'filename':42}
+]);
+----
+No function matches
+
+# --- The explicit cast drops filename and yields the 7-field type -------------
+
+query I
+SELECT typeof(list(r)::STRUCT(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INTEGER, encoding VARCHAR, attributes MAP(VARCHAR, VARCHAR), element_order INTEGER)[])
+       = typeof(html_to_duck_blocks('<p>x</p>'))
+FROM read_html_blocks('test/html/simple.html', filename := true) r;
+----
+true

--- a/test/sql/duck_block_html.test
+++ b/test/sql/duck_block_html.test
@@ -53,12 +53,12 @@ Some text
 
 # Test code block extraction
 query I
-SELECT (html_to_duck_blocks('<pre><code class="language-python">print("hello")</code></pre>'))[1].element_type;
+SELECT (html_to_duck_blocks('<pre><code class="language-python">print("hello")</code></pre>', capture_attributes := 'classes'))[1].element_type;
 ----
 code
 
 query I
-SELECT (html_to_duck_blocks('<pre><code class="language-python">print("hello")</code></pre>'))[1].attributes['language'];
+SELECT (html_to_duck_blocks('<pre><code class="language-python">print("hello")</code></pre>', capture_attributes := 'classes'))[1].attributes['language'];
 ----
 python
 
@@ -175,7 +175,7 @@ SELECT duck_blocks_to_html(html_to_duck_blocks('<p>Some text content</p>'));
 
 # Test duck_blocks_to_html with code block
 query I
-SELECT duck_blocks_to_html(html_to_duck_blocks('<pre><code class="language-sql">SELECT 1</code></pre>'));
+SELECT duck_blocks_to_html(html_to_duck_blocks('<pre><code class="language-sql">SELECT 1</code></pre>', capture_attributes := 'classes'));
 ----
 <pre><code class="language-sql">SELECT 1</code></pre>
 
@@ -1288,14 +1288,21 @@ underline
 
 # Extract span with class
 query I
-SELECT (html_to_duck_blocks('<p>Text <span class="highlight">highlighted</span></p>'))[3].element_type;
+SELECT (html_to_duck_blocks('<p>Text <span class="highlight">highlighted</span></p>', capture_attributes := 'classes'))[3].element_type;
 ----
 span
 
+# class is opt-in since #142; the span is still EMITTED (presence of id or class
+# on the source element is the gate), but its class is only captured on request.
 query I
-SELECT (html_to_duck_blocks('<p>Text <span class="highlight">highlighted</span></p>'))[3].attributes['class'];
+SELECT (html_to_duck_blocks('<p>Text <span class="highlight">highlighted</span></p>', capture_attributes := 'classes'))[3].attributes['class'];
 ----
 highlight
+
+query I
+SELECT (html_to_duck_blocks('<p>Text <span class="highlight">highlighted</span></p>'))[3].attributes['class'] IS NULL;
+----
+true
 
 # -----------------------------------------------------------------------------
 # Heading inline extraction

--- a/test/sql/duck_block_html_structure.test
+++ b/test/sql/duck_block_html_structure.test
@@ -135,9 +135,11 @@ inline	text	.	3
 # --- Finding 4: <section> flattened, id and class discarded ------------------
 # Attributes are asserted by key, not by the printed MAP string: MAP iteration
 # order is an internal-structure detail, not a contract.
+# capture_attributes := 'classes' because class is opt-in since #142 (framework
+# class soup made it noise by default); id is in the default set.
 query IIIIII
 SELECT b.element_type, b.content, b.level, b.attributes['role'], b.attributes['id'], b.attributes['class']
-FROM (SELECT unnest(html_to_duck_blocks('<section id="s1" class="intro"><p>x</p></section>')) AS b) x;
+FROM (SELECT unnest(html_to_duck_blocks('<section id="s1" class="intro"><p>x</p></section>', capture_attributes := 'classes')) AS b) x;
 ----
 section	NULL	1	section	s1	intro
 paragraph	x	2	NULL	NULL	NULL
@@ -152,9 +154,10 @@ heading	2	1
 
 # A <div> carrying id/class becomes a `div` block; a bare one stays transparent.
 # Attributes are asserted by key, not by the printed MAP string (see above).
+# 'classes' because class is opt-in since #142; the div is emitted either way.
 query IIIII
 SELECT b.element_type, b.content, b.level, b.attributes['id'], b.attributes['class']
-FROM (SELECT unnest(html_to_duck_blocks('<div id="w" class="row"><p>x</p></div>')) AS b) x;
+FROM (SELECT unnest(html_to_duck_blocks('<div id="w" class="row"><p>x</p></div>', capture_attributes := 'classes')) AS b) x;
 ----
 div	NULL	1	w	row
 paragraph	x	2	NULL	NULL
@@ -287,10 +290,18 @@ SELECT duck_blocks_to_html(html_to_duck_blocks('<blockquote><p>Quote.</p></block
 ----
 <blockquote><p>Quote.</p></blockquote>
 
+# Byte-exact with 'classes'. With the DEFAULT capture set the round trip drops
+# class -- asserted explicitly below, since it is the one fidelity loss the
+# opt-in default accepts, and a silent one would be the #142 shape again.
+query I
+SELECT duck_blocks_to_html(html_to_duck_blocks('<section id="s1" class="intro"><p>x</p></section>', capture_attributes := 'classes'));
+----
+<section id="s1" class="intro"><p>x</p></section>
+
 query I
 SELECT duck_blocks_to_html(html_to_duck_blocks('<section id="s1" class="intro"><p>x</p></section>'));
 ----
-<section id="s1" class="intro"><p>x</p></section>
+<section id="s1"><p>x</p></section>
 
 query I
 SELECT duck_blocks_to_html(html_to_duck_blocks('<dl><dt>Term</dt><dd>Def.</dd></dl>'));
@@ -328,7 +339,7 @@ SELECT duck_blocks_to_html(html_to_duck_blocks('<details><summary>Sum</summary><
 
 # An unmapped semantic element survives as generic rather than vanishing.
 query I
-SELECT duck_blocks_to_html(html_to_duck_blocks('<aside class="note"><p>n</p></aside>'));
+SELECT duck_blocks_to_html(html_to_duck_blocks('<aside class="note"><p>n</p></aside>', capture_attributes := 'classes'));
 ----
 <aside class="note"><p>n</p></aside>
 

--- a/test/sql/duck_block_source_identity.test
+++ b/test/sql/duck_block_source_identity.test
@@ -1,5 +1,5 @@
 # name: test/sql/duck_block_source_identity.test
-# description: id and class survive html -> duck_blocks -> html on EVERY block element (#142)
+# description: capture_attributes -- source attributes on every element, read and write (#142)
 # group: [webbed]
 
 require webbed
@@ -7,18 +7,24 @@ require webbed
 # ============================================================================
 # GitHub #142. read_html_blocks kept id and class on div/section, kept only id
 # on heading, and dropped both on everything else. There were no tiers -- three
-# independent copy sites written at different times, and the writer mirrored the
-# same asymmetry, so read-then-write silently destroyed attributes present in
-# the user's source while every test stayed green.
+# independent copy sites written at different times -- and the writer mirrored
+# the same asymmetry, so read-then-write silently destroyed attributes present
+# in the user's source while every test stayed green.
 #
-# The rule now: every block element that came from a source element carries
-# that element's id and class in `attributes` when present, and the writer
-# renders them back. Where one block stands for a nested pair (<pre><code>),
-# the OUTER element is the block and its identity is the one kept.
+# Now: capture_attributes := 'default' | 'classes' | '*' | true | false | [...]
+# governs which SOURCE attributes are copied verbatim onto EVERY element, block
+# and inline, and the writer renders them back. Default is identity and
+# references -- ['id', 'name', 'href', 'src']. class is opt-in: on real-world
+# HTML it is mostly framework noise. The semantic attributes the vocabulary
+# defines (heading_level, list_type, role, ...) are set unconditionally and are
+# not governed by this. Where one block stands for a nested pair (<pre><code>),
+# the OUTER element is the block and its attributes are the ones kept.
 # ============================================================================
 
-# --- Reader: id and class captured on every block type ----------------------
-# The issue's own reproduction, verbatim.
+# --- Default: id everywhere, class nowhere -----------------------------------
+# The issue's own reproduction, verbatim. Every source element carries an id;
+# all but ol/figure/img/hr carry a class. id is captured on all fourteen; class
+# on none, by default.
 
 query III
 SELECT b.element_type, b.attributes['id'], b.attributes['class']
@@ -35,68 +41,210 @@ FROM (SELECT unnest(html_to_duck_blocks('<div id="d1" class="c1">x</div>
 <hr id="hr1">')) AS b) t
 WHERE b.kind = 'block' ORDER BY b.element_order;
 ----
-div	d1	c1
-section	s1	c2
-heading	h1	c3
-paragraph	p1	c4
-list	u1	c5
-list_item	l1	c6
+div	d1	NULL
+section	s1	NULL
+heading	h1	NULL
+paragraph	p1	NULL
+list	u1	NULL
+list_item	l1	NULL
 list	o1	NULL
 list_item	NULL	NULL
-blockquote	b1	c7
-code	pre1	c8
-table	t1	c9
+blockquote	b1	NULL
+code	pre1	NULL
+table	t1	NULL
 figure	f1	NULL
 image	i1	NULL
 hr	hr1	NULL
 
-# --- Writer: byte-exact round trip for each element carrying both -----------
-# One row per element type. `exact` is input == output: if the writer dropped
-# either attribute, rendered them in the wrong order, or quoted them wrongly,
-# that row reads false. (A foreach would split these on whitespace.)
+# --- The presets, on one element carrying identity, class, data-* and ARIA --
+# 'default' == omitted. '*' == true. false leaves only the semantic key.
+# role="banner" is ABSENT under '*': vocabulary keys are reserved, so a source
+# attribute of that name cannot forge the vocabulary's own role.
+
+# (Named scalar parameters are bind-time constants, as with xml_to_json, so
+# each preset is its own query rather than a column fed through VALUES.)
+
+query I
+SELECT (html_to_duck_blocks('<h2 id="h" class="c" data-x="1" role="banner">T</h2>', capture_attributes := 'default'))[1].attributes;
+----
+{id=h, heading_level=2}
+
+query I
+SELECT (html_to_duck_blocks('<h2 id="h" class="c" data-x="1" role="banner">T</h2>', capture_attributes := 'classes'))[1].attributes;
+----
+{id=h, class=c, heading_level=2}
+
+query I
+SELECT (html_to_duck_blocks('<h2 id="h" class="c" data-x="1" role="banner">T</h2>', capture_attributes := '*'))[1].attributes;
+----
+{id=h, class=c, data-x=1, heading_level=2}
+
+statement error
+SELECT html_to_duck_blocks('<p>x</p>', capture_attributes := lower('DEFAULT') || random()::VARCHAR);
+----
+must be a constant value
+
+query I
+SELECT (html_to_duck_blocks('<h2 id="h" class="c" data-x="1">T</h2>'))[1].attributes;
+----
+{id=h, heading_level=2}
+
+query I
+SELECT (html_to_duck_blocks('<h2 id="h" class="c" data-x="1">T</h2>', capture_attributes := true))[1].attributes;
+----
+{id=h, class=c, data-x=1, heading_level=2}
+
+query I
+SELECT (html_to_duck_blocks('<h2 id="h" class="c" data-x="1">T</h2>', capture_attributes := false))[1].attributes;
+----
+{heading_level=2}
+
+query I
+SELECT (html_to_duck_blocks('<h2 id="h" class="c" data-x="1">T</h2>', capture_attributes := ['class', 'data-x']))[1].attributes;
+----
+{class=c, data-x=1, heading_level=2}
+
+statement error
+SELECT html_to_duck_blocks('<p>x</p>', capture_attributes := 'bogus');
+----
+Binder Error: capture_attributes: unknown preset 'bogus'
+
+# --- Inline elements are covered too, including <a name> --------------------
+# <a name="top"> is the pre-HTML5 anchor -- a link target sharing the fragment
+# namespace with id. It was dropped outright before, so a legacy anchor was
+# indistinguishable from a bare <a>. Kept faithful as `name`, not folded into
+# id: rewriting a user's markup on the way through is the #142 shape again.
+
+query III
+SELECT b.element_type, b.attributes['name'], b.attributes['href']
+FROM (SELECT unnest(html_to_duck_blocks('<p><a name="top"></a><a href="#top" name="both">up</a><strong id="s">b</strong></p>')) AS b) t
+WHERE b.kind = 'inline' AND b.element_type <> 'text' ORDER BY b.element_order;
+----
+link	top	NULL
+link	both	#top
+bold	NULL	NULL
+
+query I
+SELECT (html_to_duck_blocks('<p><strong id="s" class="k">b</strong></p>', capture_attributes := 'classes'))[2].attributes;
+----
+{id=s, class=k}
+
+# --- href and src are in the default set AND set by their type sites --------
+# Stored once, not twice, whichever path adds them first.
+
+query I
+SELECT (html_to_duck_blocks('<p><a href="/x">l</a></p>'))[2].attributes;
+----
+{href=/x}
+
+query I
+SELECT (html_to_duck_blocks('<p><a href="/x">l</a></p>', capture_attributes := false))[2].attributes;
+----
+{href=/x}
+
+query I
+SELECT (html_to_duck_blocks('<ol start="3" id="o"><li>x</li></ol>', capture_attributes := '*'))[1].attributes;
+----
+{start=3, id=o, list_type=ordered, ordered=true}
+
+# --- Writer: byte-exact round trip, default set --------------------------------
+# One row per element type. input == output means nothing was dropped and the
+# attribute was rendered in place. Table is asserted by containment below: its
+# first-row -> <thead>/<th> rewrite predates this and is unrelated.
 
 query II
 SELECT h, duck_blocks_to_html(html_to_duck_blocks(h))::VARCHAR = h AS exact
 FROM (VALUES
+  ('<h2 id="h">t</h2>'),
+  ('<p id="p">y</p>'),
+  ('<ul id="u"><li id="l">i</li></ul>'),
+  ('<ol id="o"><li>n</li></ol>'),
+  ('<blockquote id="b">q</blockquote>'),
+  ('<pre id="c"><code>x</code></pre>'),
+  ('<hr id="r">'),
+  ('<section id="s">z</section>'),
+  ('<div id="d">w</div>'),
+  ('<figure id="f"><figcaption id="g">cap</figcaption></figure>'),
+  ('<figure id="f"><img id="i" src="a.png" alt="a"></figure>'),
+  ('<p><a name="top"></a><a name="n" href="#top">up</a></p>'),
+  ('<p><strong id="s">b</strong></p>')
+) t(h);
+----
+<h2 id="h">t</h2>	true
+<p id="p">y</p>	true
+<ul id="u"><li id="l">i</li></ul>	true
+<ol id="o"><li>n</li></ol>	true
+<blockquote id="b">q</blockquote>	true
+<pre id="c"><code>x</code></pre>	true
+<hr id="r">	true
+<section id="s">z</section>	true
+<div id="d">w</div>	true
+<figure id="f"><figcaption id="g">cap</figcaption></figure>	true
+<figure id="f"><img id="i" src="a.png" alt="a"></figure>	true
+<p><a name="top"></a><a name="n" href="#top">up</a></p>	true
+<p><strong id="s">b</strong></p>	true
+
+# An anchor with no href renders without one: href="" would invent a link.
+query I
+SELECT duck_blocks_to_html(html_to_duck_blocks('<p><a name="top"></a></p>'))::VARCHAR;
+----
+<p><a name="top"></a></p>
+
+# --- Writer with 'classes': id then class, canonical order --------------------
+# The writer's attributes are a map, so source order is not recoverable; it
+# renders id, name, class, then the rest alphabetically. Inputs here use that
+# order so the row reads exact.
+
+query II
+SELECT h, duck_blocks_to_html(html_to_duck_blocks(h, capture_attributes := 'classes'))::VARCHAR = h AS exact
+FROM (VALUES
   ('<h2 id="h" class="k">t</h2>'),
   ('<p id="p" class="k">y</p>'),
   ('<ul id="u" class="k"><li id="l" class="m">i</li></ul>'),
-  ('<ol id="o" class="k"><li>n</li></ol>'),
   ('<blockquote id="b" class="k">q</blockquote>'),
-  ('<pre id="c" class="k"><code>x</code></pre>'),
   ('<hr id="r" class="k">'),
-  ('<section id="s" class="k">z</section>'),
   ('<div id="d" class="k">w</div>'),
-  ('<figure id="f" class="k"><figcaption id="g" class="m">cap</figcaption></figure>'),
-  ('<figure id="f"><img id="i" src="a.png" alt="a"></figure>')
+  ('<p><span id="s" class="k">x</span></p>')
 ) t(h);
 ----
 <h2 id="h" class="k">t</h2>	true
 <p id="p" class="k">y</p>	true
 <ul id="u" class="k"><li id="l" class="m">i</li></ul>	true
-<ol id="o" class="k"><li>n</li></ol>	true
 <blockquote id="b" class="k">q</blockquote>	true
-<pre id="c" class="k"><code>x</code></pre>	true
 <hr id="r" class="k">	true
-<section id="s" class="k">z</section>	true
 <div id="d" class="k">w</div>	true
-<figure id="f" class="k"><figcaption id="g" class="m">cap</figcaption></figure>	true
-<figure id="f"><img id="i" src="a.png" alt="a"></figure>	true
-
-# table is not byte-exact for a pre-existing, unrelated reason (the writer
-# promotes the first row to <thead>/<th>), so assert the identity survives
-# rather than the whole string.
+<p><span id="s" class="k">x</span></p>	true
 
 query I
-SELECT duck_blocks_to_html(html_to_duck_blocks('<table id="t" class="k"><tr><td>x</td></tr></table>'))::VARCHAR
+SELECT duck_blocks_to_html(html_to_duck_blocks('<table id="t" class="k"><tr><td>x</td></tr></table>', capture_attributes := 'classes'))::VARCHAR
        LIKE '<table id="t" class="k">%';
 ----
 true
 
-# --- An element with NO id/class must still render without empty attributes -
-# i.e. the fix adds attributes only when present, never ` id=""`.
+# --- The default round trip DROPS class, and says so ----------------------------
+# The one fidelity loss the opt-in default accepts. Asserted rather than left
+# implicit: a silent loss here would be #142 one layer up.
+
+query I
+SELECT duck_blocks_to_html(html_to_duck_blocks('<h2 id="h" class="k">t</h2>'))::VARCHAR;
+----
+<h2 id="h">t</h2>
+
+# --- Elements with nothing to carry render bare, never ` id=""` ---------------
 
 query I
 SELECT duck_blocks_to_html(html_to_duck_blocks('<h2>t</h2><p>y</p><hr>'))::VARCHAR;
 ----
 <h2>t</h2><p>y</p><hr>
+
+# --- The table functions take the same parameter ---------------------------
+
+query I
+SELECT attributes FROM parse_html_blocks('<h2 id="h" class="c">T</h2>', capture_attributes := 'classes');
+----
+{id=h, class=c, heading_level=2}
+
+query I
+SELECT attributes FROM parse_html_blocks('<h2 id="h" class="c">T</h2>');
+----
+{id=h, heading_level=2}

--- a/test/sql/duck_block_source_identity.test
+++ b/test/sql/duck_block_source_identity.test
@@ -248,3 +248,33 @@ query I
 SELECT attributes FROM parse_html_blocks('<h2 id="h" class="c">T</h2>');
 ----
 {id=h, heading_level=2}
+
+# --- filename is TRAILING, and the emitted type is asserted exactly ------------
+# duck_block spec 6.4 keys 8-field acceptance on the exact type: the seven
+# canonical fields, then filename VARCHAR. The column sat FIRST before this
+# (STRUCT(filename, kind, ...)), a different type that refused to bind against
+# duck_block_utils -- which, since every consumer reads the struct by index,
+# is the only reason it never put a file path where each expected `kind`.
+# The full type string is asserted, not just the column list, so a reordering
+# fails HERE, in the producer, rather than three repos away.
+
+query I
+SELECT typeof(list(r)) FROM read_html_blocks('test/html/simple.html', filename := true) r;
+----
+STRUCT(kind VARCHAR, element_type VARCHAR, "content" VARCHAR, "level" INTEGER, "encoding" VARCHAR, attributes MAP(VARCHAR, VARCHAR), element_order INTEGER, filename VARCHAR)[]
+
+# Without the flag, list(r) IS the scalar's type -- the `list(b)` idiom holds.
+query I
+SELECT (SELECT typeof(list(r)) FROM read_html_blocks('test/html/simple.html') r) = typeof(html_to_duck_blocks('<p>x</p>'));
+----
+true
+
+# filename := 'src_path' renames the column, as read_csv/read_json do. That
+# yields STRUCT(..., src_path VARCHAR), which is NOT the accepted 8-field type
+# and will not bind as duck_blocks under duck_block_utils. Documented as such;
+# a caller who wants the list(b) idiom uses the boolean form.
+query I
+SELECT typeof(list(r)) LIKE '%element_order INTEGER, src_path VARCHAR)[]'
+FROM read_html_blocks('test/html/simple.html', filename := 'src_path') r;
+----
+true


### PR DESCRIPTION
Completes #142. PR #143 merged with only its first commit — the merge happened before the redesign was pushed, and the three later commits landed on the closed PR's branch. This PR carries exactly those three. `main` today captures `class` universally by default (the approach that was rejected) and emits `filename` **leading**, which does not bind under duck_block spec 6.4.

## `a865d37` — `capture_attributes`, class opt-in, `<a name>`

```
capture_attributes := 'default' | 'classes' | '*' | true | false | ['id', ...]
  default   → ['id', 'name', 'href', 'src']     (also when omitted)
  classes   → default + 'class'
```

On `html_to_duck_blocks`, `read_html_blocks` and `parse_html_blocks`, every element block and inline. **`class` is opt-in** — a behaviour change for `div`/`section`/`span`, named in the changelog with its downstream cost (HTML → Pandoc AST loses class unless `'classes'` is passed). `<a name>` is captured as `name`; the writer no longer renders `href=""` on an anchor. Vocabulary keys are reserved so `'*'` cannot forge `role`. `filename := 'src_path'` accepted as core does, documented as a shape that does not bind as duck_blocks.

## `60318d8` — `filename` is trailing, and its type is asserted

The column was emitted **first** (`STRUCT(filename, kind, ...)`) — a defect that predates this branch but became wrong under 6.4's exact-type acceptance. panduck measured it end to end through a parquet bridge; markdown had the identical defect. Now after `element_order`, in bind and scan, with the full `typeof(list(r))` string asserted so a reordering fails in the producer.

## `d9c35dc` — consumers accept the 8-field duck_block

Two registered implicit casts (struct and list) bound to DuckDB's own default struct cast — the same mechanism as `duck_block_utils`. `read_html_blocks(filename := true)` rows → `list(r)` → `duck_blocks_to_html` binds. The source type is exact on purpose: a leading, renamed, ninth or wrongly-typed field is still a binder error, because every consumer reads by index and a lenient match would have read a misplaced `filename` as `kind`.

## Verification

- Suite **3951 assertions in 102 cases**; each test written first and watched fail
- panduck's cross-binary bridge check: webbed → parquet → panduck + duck_block_utils 6.4, `duck_blocks_toc(list(b))` binds, provenance intact — **webbed is the fleet's first conforming 8-field producer**
- `make check-docs` 0 broken; Sphinx 22 → 22; vocabulary drift clean
- Zero conflicts with current main

Still pending upstream: re-vendoring to 6.4 once duck_block_utils commits it (the bare `"filename"` literal becomes `FIELD_FILENAME`).