### PR TITLE
fix: declare every throwing scalar fallible; compile filename column on v2.0 (#140)

### DIFF
--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -2130,7 +2130,7 @@ unique_ptr<FunctionData> DuckBlockFunctions::ReadHTMLBlocksBind(ClientContext &c
 	// each of them expects `kind`. Leading refused to bind at all -- a loud
 	// error -- which is the only reason it never became silent misreads.
 	if (result->include_filename) {
-		names.push_back(result->filename_column);
+		names.push_back(CompatMakeName(result->filename_column)); // runtime string -> Identifier on v2.0
 		return_types.push_back(LogicalType::VARCHAR);
 	}
 

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -2410,17 +2410,19 @@ void DuckBlockFunctions::Register(ExtensionLoader &loader) {
 	// per-function PreventStructConstantFoldingAndAdd replaced the set-level call.
 	ScalarFunction html_to_duck_blocks_html({XMLTypes::HTMLType()}, DuckBlockTypes::DuckBlockListType(),
 	                                        HtmlToDuckBlocksFunction, HtmlToDuckBlocksBind);
+	html_to_duck_blocks_html.SetFallible(); // v2.0: HTML parsing can throw
 	SetScalarFunctionVarArgs(html_to_duck_blocks_html, LogicalType::ANY); // capture_attributes := ...
 	PreventStructConstantFoldingAndAdd(html_to_duck_blocks_set, html_to_duck_blocks_html);
 	ScalarFunction html_to_duck_blocks_varchar({LogicalType::VARCHAR}, DuckBlockTypes::DuckBlockListType(),
 	                                           HtmlToDuckBlocksFunction, HtmlToDuckBlocksBind);
+	html_to_duck_blocks_varchar.SetFallible(); // v2.0: HTML parsing can throw
 	SetScalarFunctionVarArgs(html_to_duck_blocks_varchar, LogicalType::ANY);
 	PreventStructConstantFoldingAndAdd(html_to_duck_blocks_set, html_to_duck_blocks_varchar);
 	loader.RegisterFunction(html_to_duck_blocks_set);
 
 	// duck_blocks_to_html(blocks LIST(duck_block)) -> HTML
-	auto duck_blocks_to_html_func = ScalarFunction("duck_blocks_to_html", {DuckBlockTypes::DuckBlockListType()},
-	                                               XMLTypes::HTMLType(), DuckBlocksToHtmlFunction);
+	auto duck_blocks_to_html_func = Fallible(ScalarFunction("duck_blocks_to_html", {DuckBlockTypes::DuckBlockListType()},
+	                                               XMLTypes::HTMLType(), DuckBlocksToHtmlFunction));
 	loader.RegisterFunction(duck_blocks_to_html_func);
 
 	// read_html_blocks table function

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -259,6 +259,20 @@ inline LogicalType CompatForceMaxLogicalType(const LogicalType &left, const Logi
 // shared_ptr<const T> and a set member can no longer be configured after it has been added.
 // Defined outside the #ifdef because it delegates to whichever PreventStructConstantFolding
 // overload the branch above selected (a no-op on the old API).
+// DuckDB v2.0 enforces a scalar function's declared error mode at runtime: a
+// function that throws without having called SetFallible() surfaces as
+//   INTERNAL Error: Scalar function "x" threw an execution error, but the
+//   function is not marked as fallible
+// rather than as the error it threw. Applied at CONSTRUCTION, wrapping the
+// ScalarFunction expression, so it is set before the function is added to a
+// set -- on v2.0 a set member is shared_ptr<const T> and cannot be configured
+// after AddFunction. SetFallible() exists on the pinned 1.5 too, where it only
+// informs the optimizer, so there is nothing to guard.
+inline ScalarFunction Fallible(ScalarFunction fn) {
+	fn.SetFallible();
+	return fn;
+}
+
 template <typename T>
 inline void PreventStructConstantFoldingAndAdd(FunctionSet<T> &func_set, T func) {
 	PreventStructConstantFolding(func);

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1206,16 +1206,16 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	};
 
 	// Register xml function (same as to_xml for now) - using VARCHAR for now, will enhance type system later
-	auto xml_function = ScalarFunction("xml", {LogicalType::VARCHAR}, LogicalType::VARCHAR, ValueToXMLFunction);
+	auto xml_function = Fallible(ScalarFunction("xml", {LogicalType::VARCHAR}, LogicalType::VARCHAR, ValueToXMLFunction));
 	loader.RegisterFunction(xml_function);
 
 	// Register to_xml function (single argument) - ANY type variant (unified path)
-	auto to_xml_any_function = ScalarFunction("to_xml", {LogicalType::ANY}, XMLTypes::XMLType(), ValueToXMLFunction);
+	auto to_xml_any_function = Fallible(ScalarFunction("to_xml", {LogicalType::ANY}, XMLTypes::XMLType(), ValueToXMLFunction));
 	loader.RegisterFunction(to_xml_any_function);
 
 	// Register to_xml function (two arguments: value, node_name) - ANY type variant (unified path)
 	auto to_xml_any_with_name_function =
-	    ScalarFunction("to_xml", {LogicalType::ANY, LogicalType::VARCHAR}, XMLTypes::XMLType(), ValueToXMLFunction);
+	    Fallible(ScalarFunction("to_xml", {LogicalType::ANY, LogicalType::VARCHAR}, XMLTypes::XMLType(), ValueToXMLFunction));
 	loader.RegisterFunction(to_xml_any_with_name_function);
 
 	// Register xml_libxml2_version function
@@ -1259,54 +1259,54 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	//  literal return type and trip an internal error. The named-arg case routes through the VARCHAR
 	//  overload below, with the literal xpath implicitly cast to VARCHAR.)
 	xml_extract_text_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction)));
 	// XMLFragment + VARCHAR -> LIST(VARCHAR)
 	add_ns_aware(xml_extract_text_functions,
 	             ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR},
 	                            LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction));
 	// XMLFragment + STRING_LITERAL -> LIST(VARCHAR)
 	xml_extract_text_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction)));
 	// VARCHAR + VARCHAR -> LIST(VARCHAR) (compatibility)
 	add_ns_aware(xml_extract_text_functions,
 	             ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
 	                            XMLExtractTextListFunction));
 	// VARCHAR + STRING_LITERAL -> LIST(VARCHAR) (compatibility)
 	xml_extract_text_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction)));
 
 	// 3-argument variants with namespaces MAP
 	auto ns_map_type = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
 	// XML + VARCHAR + MAP -> LIST(VARCHAR)
-	xml_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type},
+	xml_extract_text_functions.AddFunction(Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type},
 	                                                      LogicalType::LIST(LogicalType::VARCHAR),
-	                                                      XMLExtractTextListWithNamespacesFunction));
+	                                                      XMLExtractTextListWithNamespacesFunction)));
 	// VARCHAR + VARCHAR + MAP -> LIST(VARCHAR)
-	xml_extract_text_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type},
+	xml_extract_text_functions.AddFunction(Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type},
 	                                                      LogicalType::LIST(LogicalType::VARCHAR),
-	                                                      XMLExtractTextListWithNamespacesFunction));
+	                                                      XMLExtractTextListWithNamespacesFunction)));
 
 	// 3-argument variants with namespace mode VARCHAR ('auto', 'strict', 'ignore')
 	// XML + VARCHAR + VARCHAR (mode) -> LIST(VARCHAR)
 	xml_extract_text_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListWithNamespacesFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListWithNamespacesFunction)));
 	// VARCHAR + VARCHAR + VARCHAR (mode) -> LIST(VARCHAR)
 	xml_extract_text_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListWithNamespacesFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListWithNamespacesFunction)));
 
 	loader.RegisterFunction(xml_extract_text_functions);
 
 	// Register xml_extract_all_text function - both XML and VARCHAR overloads
 	auto xml_extract_all_text_function =
-	    ScalarFunction("xml_extract_all_text", {XMLTypes::XMLType()}, LogicalType::VARCHAR, XMLExtractAllTextFunction);
+	    Fallible(ScalarFunction("xml_extract_all_text", {XMLTypes::XMLType()}, LogicalType::VARCHAR, XMLExtractAllTextFunction));
 	loader.RegisterFunction(xml_extract_all_text_function);
 	auto xml_extract_all_text_varchar_function =
-	    ScalarFunction("xml_extract_all_text", {LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractAllTextFunction);
+	    Fallible(ScalarFunction("xml_extract_all_text", {LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractAllTextFunction));
 	loader.RegisterFunction(xml_extract_all_text_varchar_function);
 
 	// Register xml_extract_elements function - returns LIST(XMLFragment) (PostgreSQL-compatible)
@@ -1320,50 +1320,50 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	// XML + STRING_LITERAL -> LIST(XMLFragment)
 	// (STRING_LITERAL overloads stay varargs-free; see note on xml_extract_text above.)
 	xml_extract_elements_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction)));
 	// HTML + VARCHAR -> LIST(XMLFragment)
 	add_ns_aware(xml_extract_elements_functions,
 	             ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
 	                            LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// HTML + STRING_LITERAL -> LIST(XMLFragment)
 	xml_extract_elements_functions.AddFunction(
-	    ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
+	    Fallible(ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction)));
 	// XMLFragment + VARCHAR -> LIST(XMLFragment) (for nested extraction)
 	add_ns_aware(xml_extract_elements_functions,
 	             ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR},
 	                            LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// XMLFragment + STRING_LITERAL -> LIST(XMLFragment)
 	xml_extract_elements_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction)));
 	// VARCHAR + VARCHAR -> LIST(XMLFragment) (compatibility)
 	add_ns_aware(xml_extract_elements_functions,
 	             ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                            LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// VARCHAR + STRING_LITERAL -> LIST(XMLFragment) (compatibility)
 	xml_extract_elements_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction)));
 
 	// 3-argument variants with namespaces MAP
 	// XML + VARCHAR + MAP -> LIST(XMLFragment)
-	xml_extract_elements_functions.AddFunction(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type},
+	xml_extract_elements_functions.AddFunction(Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type},
 	                                                          LogicalType::LIST(XMLTypes::XMLFragmentType()),
-	                                                          XMLExtractElementsListWithNamespacesFunction));
+	                                                          XMLExtractElementsListWithNamespacesFunction)));
 	// VARCHAR + VARCHAR + MAP -> LIST(XMLFragment)
-	xml_extract_elements_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type},
+	xml_extract_elements_functions.AddFunction(Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type},
 	                                                          LogicalType::LIST(XMLTypes::XMLFragmentType()),
-	                                                          XMLExtractElementsListWithNamespacesFunction));
+	                                                          XMLExtractElementsListWithNamespacesFunction)));
 
 	// 3-argument variants with namespace mode VARCHAR ('auto', 'strict', 'ignore')
 	xml_extract_elements_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListWithNamespacesFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListWithNamespacesFunction)));
 	xml_extract_elements_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListWithNamespacesFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListWithNamespacesFunction)));
 
 	loader.RegisterFunction(xml_extract_elements_functions);
 
@@ -1377,23 +1377,23 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	                            XMLExtractElementsStringFunction));
 	// 3-argument variants with namespaces MAP
 	xml_extract_elements_string_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type}, LogicalType::VARCHAR,
-	                   XMLExtractElementsStringWithNamespacesFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type}, LogicalType::VARCHAR,
+	                   XMLExtractElementsStringWithNamespacesFunction)));
 	xml_extract_elements_string_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type}, LogicalType::VARCHAR,
-	                   XMLExtractElementsStringWithNamespacesFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type}, LogicalType::VARCHAR,
+	                   XMLExtractElementsStringWithNamespacesFunction)));
 	// 3-argument variants with namespace mode VARCHAR
 	xml_extract_elements_string_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	                   XMLExtractElementsStringWithNamespacesFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                   XMLExtractElementsStringWithNamespacesFunction)));
 	xml_extract_elements_string_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	                   XMLExtractElementsStringWithNamespacesFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                   XMLExtractElementsStringWithNamespacesFunction)));
 	loader.RegisterFunction(xml_extract_elements_string_functions);
 
 	// Register xml_wrap_fragment function (returns XML)
-	auto xml_wrap_fragment_function = ScalarFunction("xml_wrap_fragment", {LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                                                 XMLTypes::XMLType(), XMLWrapFragmentFunction);
+	auto xml_wrap_fragment_function = Fallible(ScalarFunction("xml_wrap_fragment", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                                 XMLTypes::XMLType(), XMLWrapFragmentFunction));
 	loader.RegisterFunction(xml_wrap_fragment_function);
 
 	// Register xml_extract_attributes function (returns LIST<STRUCT>)
@@ -1460,14 +1460,14 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	auto comment_struct_type = LogicalType::STRUCT(
 	    {make_pair("content", LogicalType::VARCHAR), make_pair("line_number", LogicalType::BIGINT)});
 	auto xml_extract_comments_function =
-	    ScalarFunction("xml_extract_comments", {XMLTypes::XMLType()}, LogicalType::LIST(comment_struct_type),
-	                   XMLExtractCommentsFunction);
+	    Fallible(ScalarFunction("xml_extract_comments", {XMLTypes::XMLType()}, LogicalType::LIST(comment_struct_type),
+	                   XMLExtractCommentsFunction));
 	PreventStructConstantFolding(xml_extract_comments_function);
 	loader.RegisterFunction(xml_extract_comments_function);
 
 	// Register xml_extract_cdata function (returns LIST<STRUCT>)
-	auto xml_extract_cdata_function = ScalarFunction("xml_extract_cdata", {XMLTypes::XMLType()},
-	                                                 LogicalType::LIST(comment_struct_type), XMLExtractCDataFunction);
+	auto xml_extract_cdata_function = Fallible(ScalarFunction("xml_extract_cdata", {XMLTypes::XMLType()},
+	                                                 LogicalType::LIST(comment_struct_type), XMLExtractCDataFunction));
 	PreventStructConstantFolding(xml_extract_cdata_function);
 	loader.RegisterFunction(xml_extract_cdata_function);
 
@@ -1502,30 +1502,30 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 
 	// Register xml_detect_prefixes function (returns LIST<VARCHAR> of namespace prefixes in XPath expression)
 	auto xml_detect_prefixes_function =
-	    ScalarFunction("xml_detect_prefixes", {LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
-	                   XMLDetectPrefixesFunction);
+	    Fallible(ScalarFunction("xml_detect_prefixes", {LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
+	                   XMLDetectPrefixesFunction));
 	loader.RegisterFunction(xml_detect_prefixes_function);
 
 	// Register xml_mock_namespaces function (returns MAP<VARCHAR, VARCHAR> with mock URIs for prefixes)
 	auto xml_mock_namespaces_function =
-	    ScalarFunction("xml_mock_namespaces", {LogicalType::LIST(LogicalType::VARCHAR)},
-	                   LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR), XMLMockNamespacesFunction);
+	    Fallible(ScalarFunction("xml_mock_namespaces", {LogicalType::LIST(LogicalType::VARCHAR)},
+	                   LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR), XMLMockNamespacesFunction));
 	PreventStructConstantFolding(xml_mock_namespaces_function);
 	loader.RegisterFunction(xml_mock_namespaces_function);
 
 	// Register xml_find_undefined_prefixes function
 	// Finds namespace prefixes used in an XPath expression that are not declared in the XML document
 	auto xml_find_undefined_prefixes_function =
-	    ScalarFunction("xml_find_undefined_prefixes", {LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(LogicalType::VARCHAR), XMLFindUndefinedPrefixesFunction);
+	    Fallible(ScalarFunction("xml_find_undefined_prefixes", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::LIST(LogicalType::VARCHAR), XMLFindUndefinedPrefixesFunction));
 	loader.RegisterFunction(xml_find_undefined_prefixes_function);
 
 	// Register xml_add_namespace_declarations function
 	// Injects xmlns declarations into an XML document's root element
 	auto xml_add_namespace_declarations_function =
-	    ScalarFunction("xml_add_namespace_declarations",
+	    Fallible(ScalarFunction("xml_add_namespace_declarations",
 	                   {LogicalType::VARCHAR, LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)},
-	                   LogicalType::VARCHAR, XMLAddNamespaceDeclarationsFunction);
+	                   LogicalType::VARCHAR, XMLAddNamespaceDeclarationsFunction));
 	loader.RegisterFunction(xml_add_namespace_declarations_function);
 
 	// Register xml_lookup_namespace function
@@ -1588,16 +1588,16 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 
 	// HTML only (no XPath) -> VARCHAR (all text concatenated, unchanged behavior)
 	html_extract_text_functions.AddFunction(
-	    ScalarFunction({XMLTypes::HTMLType()}, LogicalType::VARCHAR, HTMLExtractTextFunction));
+	    Fallible(ScalarFunction({XMLTypes::HTMLType()}, LogicalType::VARCHAR, HTMLExtractTextFunction)));
 
 	// HTML + VARCHAR XPath -> LIST(VARCHAR)
-	html_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
+	html_extract_text_functions.AddFunction(Fallible(ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
 	                                                       LogicalType::LIST(LogicalType::VARCHAR),
-	                                                       HTMLExtractTextListFunction));
+	                                                       HTMLExtractTextListFunction)));
 	// HTML + STRING_LITERAL XPath -> LIST(VARCHAR)
 	html_extract_text_functions.AddFunction(
-	    ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(LogicalType::VARCHAR), HTMLExtractTextListFunction));
+	    Fallible(ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(LogicalType::VARCHAR), HTMLExtractTextListFunction)));
 	// NOTE: Namespace parameter overloads intentionally omitted for html_extract_text.
 	// HTML5 parsing (htmlReadMemory) doesn't support XML namespace declarations -
 	// prefixed elements like "svg:circle" are treated as literal names with colons.
@@ -1611,15 +1611,15 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	// the gap in doc examples. Mirrors the VARCHAR overloads xml_extract_text already has.
 	// VARCHAR only (no XPath) -> VARCHAR
 	html_extract_text_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, HTMLExtractTextFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, HTMLExtractTextFunction)));
 	// VARCHAR + VARCHAR XPath -> LIST(VARCHAR)
-	html_extract_text_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
+	html_extract_text_functions.AddFunction(Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                                       LogicalType::LIST(LogicalType::VARCHAR),
-	                                                       HTMLExtractTextListFunction));
+	                                                       HTMLExtractTextListFunction)));
 	// VARCHAR + STRING_LITERAL XPath -> LIST(VARCHAR)
 	html_extract_text_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(LogicalType::VARCHAR), HTMLExtractTextListFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(LogicalType::VARCHAR), HTMLExtractTextListFunction)));
 
 	loader.RegisterFunction(html_extract_text_functions);
 

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1191,8 +1191,12 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	// execute function then delegates to its namespace-aware sibling when a third column is present.
 	// Required for forward-compat with DuckDB main, which (unlike <=v1.5.3) no longer silently
 	// ignores argument labels on scalar functions. (GitHub Issue #78 follow-up / DuckDB main drift.)
+	// Everything routed through these helpers takes an XPath, and a malformed
+	// XPath raises (the #134 contract) -- so every member is fallible. Marked
+	// here, before AddFunction, for the same v2.0 reason the varargs are.
 	auto add_ns_aware = [](ScalarFunctionSet &set, ScalarFunction fn) {
 		SetScalarFunctionVarArgs(fn, LogicalType::ANY);
+		fn.SetFallible();
 		set.AddFunction(std::move(fn));
 	};
 	// Same, for sets whose functions return a STRUCT-containing type and therefore have to be
@@ -1202,6 +1206,7 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	auto add_ns_aware_volatile = [](ScalarFunctionSet &set, ScalarFunction fn) {
 		SetScalarFunctionVarArgs(fn, LogicalType::ANY);
 		PreventStructConstantFolding(fn);
+		fn.SetFallible();
 		set.AddFunction(std::move(fn));
 	};
 

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1507,22 +1507,22 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 
 	// Register xml_detect_prefixes function (returns LIST<VARCHAR> of namespace prefixes in XPath expression)
 	auto xml_detect_prefixes_function =
-	    Fallible(ScalarFunction("xml_detect_prefixes", {LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
-	                   XMLDetectPrefixesFunction));
+	    ScalarFunction("xml_detect_prefixes", {LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
+	                   XMLDetectPrefixesFunction);
 	loader.RegisterFunction(xml_detect_prefixes_function);
 
 	// Register xml_mock_namespaces function (returns MAP<VARCHAR, VARCHAR> with mock URIs for prefixes)
 	auto xml_mock_namespaces_function =
-	    Fallible(ScalarFunction("xml_mock_namespaces", {LogicalType::LIST(LogicalType::VARCHAR)},
-	                   LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR), XMLMockNamespacesFunction));
+	    ScalarFunction("xml_mock_namespaces", {LogicalType::LIST(LogicalType::VARCHAR)},
+	                   LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR), XMLMockNamespacesFunction);
 	PreventStructConstantFolding(xml_mock_namespaces_function);
 	loader.RegisterFunction(xml_mock_namespaces_function);
 
 	// Register xml_find_undefined_prefixes function
 	// Finds namespace prefixes used in an XPath expression that are not declared in the XML document
 	auto xml_find_undefined_prefixes_function =
-	    Fallible(ScalarFunction("xml_find_undefined_prefixes", {LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(LogicalType::VARCHAR), XMLFindUndefinedPrefixesFunction));
+	    ScalarFunction("xml_find_undefined_prefixes", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::LIST(LogicalType::VARCHAR), XMLFindUndefinedPrefixesFunction);
 	loader.RegisterFunction(xml_find_undefined_prefixes_function);
 
 	// Register xml_add_namespace_declarations function


### PR DESCRIPTION
Closes #140. **The v2.0 canary is green on this branch** — the first time webbed's suite has passed against DuckDB main: [run 33976097741](https://github.com/teaguesterling/duckdb_webbed/actions/runs/33976097741), `linux_amd64` (the leg that runs tests) **102 passed, 0 failed**, zero `not marked as fallible` lines.

## Why the three known functions were a floor

DuckDB v2.0 enforces a scalar's declared error mode at runtime. A function that throws without `SetFallible()` surfaces as `INTERNAL Error: ... not marked as fallible` rather than as the error it threw. Three `statement error` tests caught that (`xml_wrap_fragment`, `xml_extract_text`, `to_xml`) — but those are the functions tests happened to exercise. Any function that *can* throw carries the same failure into production with no test to say so. The costs are asymmetric: a missed function is an `INTERNAL Error` on user input; an over-marked one loses a folding optimisation.

So the set came from measurement, not from the failing tests: a static throw-reachability pass over every registered scalar and its helpers, then each function it declared clean probed with hostile input on the pinned build. **20 functions can throw; 14 return a value on malformed input and stay unmarked.**

## Three commits, each driven by a canary run

1. `Fallible(ScalarFunction(...))` at construction across 40 registrations — the four function sets carry 25 overloads between them, which a per-name count hides. Applied at construction because v2.0 set members are `shared_ptr<const T>` and can't be configured after `AddFunction`.
2. **A #144 regression the canary had never seen:** `names.push_back(result->filename_column)` doesn't compile on v2.0, where `names` is `vector<Identifier>` and a runtime `std::string` has no implicit conversion. #139 was certified before #144 added that line. Fixed with `CompatMakeName`, the idiom the XML readers already use.
3. The canary then went 4 failures → 1: `add_ns_aware` / `add_ns_aware_volatile` construct the namespace-aware overloads themselves and my scan didn't follow them — nine sites, including `xml_extract_attributes`, which is registered *only* through the helper and so never appeared in the static list. Probed to confirm it throws, then marked inside the helpers.

## Verification

- v2.0 canary: `linux_amd64` build + **test success**, `linux_arm64` build success (that leg runs no tests)
- Pinned 1.5: 3951 assertions in 102 cases, unchanged — `SetFallible` only informs the optimizer there

With this, webbed compiles and passes against both DuckDB 1.5 and 2.0. The next release will clear community-extensions' `build_next` gate.