### PR TITLE
chore: bump duckdb submodule to v1.5.5; CI builds against v1.5.5

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -47,15 +47,17 @@ jobs:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.4
     with:
-      # Build target is the v1.5.4 release TAG (loadable/shippable artifacts),
+      # Build target is the v1.5.5 release TAG (loadable/shippable artifacts),
       # even though the duckdb/extension-ci-tools submodule pointers track the
       # v1.5-variegata branch tip. Branch-tip (-dev) builds produce
       # non-loadable extensions; the shippable stable build stays on the tag.
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
+      # ci-tools stays on its v1.5.4 tag: extension-ci-tools has no v1.5.5 tag, and this
+      # pins the CI TOOLING, not DuckDB. duckdb_version above is what the build targets.
       ci_tools_version: v1.5.4
       extension_name: webbed
       vcpkg_commit: '68a1c387f660632f2f65cdb7e8cd093a08840e5d'
-      # windows_amd64_mingw excluded on the v1.5.4 stable job: duckdb's
+      # windows_amd64_mingw excluded on the v1.5.5 stable job: duckdb's
       # scripts/ci/run_tests.py prints a U+274C ❌ glyph on test-batch failure,
       # which Windows' default cp1252 stdout can't encode (UnicodeEncodeError),
       # masking the underlying test result. mingw-specific (see duckdb_urlpattern's
@@ -69,8 +71,10 @@ jobs:
   # Two layers (see test/wasm/):
   #   1. static symbol check (hard gate) — no duckdb-wasm runtime needed.
   #   2. live load+query in duckdb-wasm (informational / continue-on-error) —
-  #      expected-red until official duckdb-wasm ships v1.5.4 (the only public
-  #      v1.5.4 engine, haybarn, uses a newer emscripten -> lseek ABI skew).
+  #      expected-red until official duckdb-wasm ships a 1.5.x engine matching
+  #      the build target (when this was written the only public 1.5 engine,
+  #      haybarn, used a newer emscripten -> lseek ABI skew). Whether that has
+  #      changed for v1.5.5 is not known here; the step stays informational.
   wasm-load-test:
     name: WASM load test
     needs: [duckdb-stable-build]
@@ -83,20 +87,20 @@ jobs:
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: webbed-v1.5.4-extension-wasm_*
+          pattern: webbed-v1.5.5-extension-wasm_*
           path: wasm-artifacts
       - name: Static symbol check (libxml2/zlib must be linked, not unresolved)
         run: bash test/wasm/run_wasm_checks.sh wasm-artifacts
-      - name: Live load test in duckdb-wasm (informational until official v1.5.4)
+      - name: Live load test in duckdb-wasm (informational until official v1.5.5)
         continue-on-error: true
         timeout-minutes: 10
         working-directory: test/wasm
         run: |
           set -uo pipefail
           timeout 300 npm install --no-save
-          mkdir -p repo/v1.5.4/wasm_eh
-          cp "$GITHUB_WORKSPACE/wasm-artifacts/webbed-v1.5.4-extension-wasm_eh/webbed.duckdb_extension.wasm" \
-             repo/v1.5.4/wasm_eh/
+          mkdir -p repo/v1.5.5/wasm_eh
+          cp "$GITHUB_WORKSPACE/wasm-artifacts/webbed-v1.5.5-extension-wasm_eh/webbed.duckdb_extension.wasm" \
+             repo/v1.5.5/wasm_eh/
           timeout 240 node load_test.cjs --repo repo --name webbed --platform eh \
             --query "SELECT xml_valid('<a/>') AS ok" --expect '"ok":true'
 
@@ -111,7 +115,7 @@ jobs:
     name: Code Quality Check
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
     with:
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       ci_tools_version: main
       extension_name: webbed
       format_checks: 'format'

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -111,6 +111,10 @@ jobs:
   # format only, no tidy: tidy configures CMake without vcpkg, so this extension's
   # libxml2 dependency is not found and the check cannot even configure. Same reason
   # the sibling zim extension runs format only.
+  # @main, not @v1.5.4: _extension_code_quality.yml does not exist at the v1.5.4
+  # tag of extension-ci-tools (it is newer than that tag), so this job cannot be
+  # pinned the way the stable build is. It is the CI tooling ref; duckdb_version
+  # below is still the build target.
   code-quality-check:
     name: Code Quality Check
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main


### PR DESCRIPTION
`duckdb`: `b155d6f63c` (v1.5.4-154) → `2f10cfb426` (v1.5.5-146), 254 commits along `v1.5-variegata` — the branch both submodules track. **Not a jump to 2.0.** `extension-ci-tools` is already at its branch head.

## This bump is the test #139 was written for

`identifier.hpp` is **present** on the new pin — backported to `v1.5-variegata` without the signature change. That is precisely the case the old `__has_include` probe got wrong: it would have flipped `CompatName` to `Identifier` on a DuckDB whose bind signatures still take `string`. #139 replaced the probe with types derived from the containers themselves. Build clean, suite green — it held.

## CI alignment

`duckdb_version: v1.5.4 → v1.5.5` on the stable and code-quality jobs, plus the Wasm load-test artifact paths that derive from it. The **stable build** keeps its extension-ci-tools ref and `ci_tools_version` on `v1.5.4`: that repo has no `v1.5.5` tag, and they pin the CI *tooling*, not DuckDB. The **code-quality** job stays on `@main` — it has to: `_extension_code_quality.yml` does not exist at the `v1.5.4` tag. Both are now explained in comments next to the refs.

*(An earlier version of this description claimed every ci-tools ref was pinned to `v1.5.4`; review caught that the code-quality job never was.)*

One comment was reworded rather than search-and-replaced: it named haybarn as "the only public v1.5.4 engine", and renaming that to v1.5.5 would have asserted something nobody has checked.

## Verification

- Built against v1.5.5-146: 0 errors
- Suite: **3951 assertions in 102 cases** on `v1.5.5-dev154`
- `make check-vocabulary` OK; `make check-docs` 105 examples, 0 broken

The CI run on this PR is the real check of the `v1.5.5` build target across the full matrix.
