### PR TITLE
DuckDB 2.0 readiness: fallible scalars (#140) + duckdb submodule v1.5.5

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -47,15 +47,17 @@ jobs:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.4
     with:
-      # Build target is the v1.5.4 release TAG (loadable/shippable artifacts),
+      # Build target is the v1.5.5 release TAG (loadable/shippable artifacts),
       # even though the duckdb/extension-ci-tools submodule pointers track the
       # v1.5-variegata branch tip. Branch-tip (-dev) builds produce
       # non-loadable extensions; the shippable stable build stays on the tag.
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
+      # ci-tools stays on its v1.5.4 tag: extension-ci-tools has no v1.5.5 tag, and this
+      # pins the CI TOOLING, not DuckDB. duckdb_version above is what the build targets.
       ci_tools_version: v1.5.4
       extension_name: webbed
       vcpkg_commit: '68a1c387f660632f2f65cdb7e8cd093a08840e5d'
-      # windows_amd64_mingw excluded on the v1.5.4 stable job: duckdb's
+      # windows_amd64_mingw excluded on the v1.5.5 stable job: duckdb's
       # scripts/ci/run_tests.py prints a U+274C ❌ glyph on test-batch failure,
       # which Windows' default cp1252 stdout can't encode (UnicodeEncodeError),
       # masking the underlying test result. mingw-specific (see duckdb_urlpattern's
@@ -69,8 +71,10 @@ jobs:
   # Two layers (see test/wasm/):
   #   1. static symbol check (hard gate) — no duckdb-wasm runtime needed.
   #   2. live load+query in duckdb-wasm (informational / continue-on-error) —
-  #      expected-red until official duckdb-wasm ships v1.5.4 (the only public
-  #      v1.5.4 engine, haybarn, uses a newer emscripten -> lseek ABI skew).
+  #      expected-red until official duckdb-wasm ships a 1.5.x engine matching
+  #      the build target (when this was written the only public 1.5 engine,
+  #      haybarn, used a newer emscripten -> lseek ABI skew). Whether that has
+  #      changed for v1.5.5 is not known here; the step stays informational.
   wasm-load-test:
     name: WASM load test
     needs: [duckdb-stable-build]
@@ -83,20 +87,20 @@ jobs:
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: webbed-v1.5.4-extension-wasm_*
+          pattern: webbed-v1.5.5-extension-wasm_*
           path: wasm-artifacts
       - name: Static symbol check (libxml2/zlib must be linked, not unresolved)
         run: bash test/wasm/run_wasm_checks.sh wasm-artifacts
-      - name: Live load test in duckdb-wasm (informational until official v1.5.4)
+      - name: Live load test in duckdb-wasm (informational until official v1.5.5)
         continue-on-error: true
         timeout-minutes: 10
         working-directory: test/wasm
         run: |
           set -uo pipefail
           timeout 300 npm install --no-save
-          mkdir -p repo/v1.5.4/wasm_eh
-          cp "$GITHUB_WORKSPACE/wasm-artifacts/webbed-v1.5.4-extension-wasm_eh/webbed.duckdb_extension.wasm" \
-             repo/v1.5.4/wasm_eh/
+          mkdir -p repo/v1.5.5/wasm_eh
+          cp "$GITHUB_WORKSPACE/wasm-artifacts/webbed-v1.5.5-extension-wasm_eh/webbed.duckdb_extension.wasm" \
+             repo/v1.5.5/wasm_eh/
           timeout 240 node load_test.cjs --repo repo --name webbed --platform eh \
             --query "SELECT xml_valid('<a/>') AS ok" --expect '"ok":true'
 
@@ -111,7 +115,7 @@ jobs:
     name: Code Quality Check
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
     with:
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       ci_tools_version: main
       extension_name: webbed
       format_checks: 'format'

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -4,11 +4,19 @@
 name: Main Extension Distribution Pipeline
 on:
   push:
+    # main only. A branch push and its pull_request run built the same commit
+    # twice, doubling queue time; the PR run is the one whose status matters.
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
+# event_name is part of the group on purpose. Without it a workflow_dispatch on a
+# branch (used to run the canary against a PR) lands in the SAME group as that
+# branch's push run -- same ref, same sha -- and cancel-in-progress kills the
+# push run, whose cancelled jobs then show on the commit as failures. That made
+# a PR read red three times while everything real about it was green.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' && github.sha || '' }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -111,6 +111,10 @@ jobs:
   # format only, no tidy: tidy configures CMake without vcpkg, so this extension's
   # libxml2 dependency is not found and the check cannot even configure. Same reason
   # the sibling zim extension runs format only.
+  # @main, not @v1.5.4: _extension_code_quality.yml does not exist at the v1.5.4
+  # tag of extension-ci-tools (it is newer than that tag), so this job cannot be
+  # pinned the way the stable build is. It is the CI tooling ref; duckdb_version
+  # below is still the build target.
   code-quality-check:
     name: Code Quality Check
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -335,6 +335,15 @@ def branched_on(root):
     return named, literal
 
 
+def pinned_sha(local_path):
+    """The commit the vendored header says it was taken from, or None."""
+    for line in open(local_path, encoding="utf-8"):
+        m = re.search(r"Vendored at upstream commit:\s*([0-9a-f]{7,40})", line)
+        if m:
+            return m.group(1)
+    return None
+
+
 def report(local, upstream, root, show_gaps=True, verified=True, strict=False):
     """Compare two constant maps. Returns (exit_code, headline)."""
     removed = sorted(set(local) - set(upstream))
@@ -561,6 +570,31 @@ def main():
     print()
 
     code, _ = report(local, upstream, root, verified=verified, strict=args.strict)
+    if code != 0 and args.upstream:
+        # A copy vendored from a commit that upstream main has not merged yet
+        # reads as DRIFT against main, and it is not: it is AHEAD. Tell the two
+        # apart by re-checking against the sha the header says it came from. If
+        # the copy matches that sha exactly, the state is correct and temporary
+        # -- it clears when upstream merges -- and a FAILED here would only
+        # train people to ignore the check. If it matches neither, that is
+        # drift, and the failure above stands.
+        pinned = pinned_sha(local_path)
+        if pinned and pinned != args.ref:
+            try:
+                pinned_text = read_upstream_git(args.upstream, pinned)
+            except SystemExit:
+                pinned_text = None
+            if pinned_text is not None:
+                pinned_code, _ = report(local, parse_constants(pinned_text), root,
+                                        show_gaps=False, verified=verified, strict=args.strict)
+                if pinned_code == 0:
+                    print()
+                    print(f"AHEAD: the copy matches its pinned upstream commit {pinned} exactly, "
+                          f"which {args.ref} does not yet contain.")
+                    print(f"       Not drift. Clears when upstream merges {pinned}; until then the "
+                          f"DRIFT above describes main being behind this copy, not this copy being "
+                          f"behind main.")
+                    return 0
     return code
 
 

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -2130,7 +2130,7 @@ unique_ptr<FunctionData> DuckBlockFunctions::ReadHTMLBlocksBind(ClientContext &c
 	// each of them expects `kind`. Leading refused to bind at all -- a loud
 	// error -- which is the only reason it never became silent misreads.
 	if (result->include_filename) {
-		names.push_back(result->filename_column);
+		names.push_back(CompatMakeName(result->filename_column)); // runtime string -> Identifier on v2.0
 		return_types.push_back(LogicalType::VARCHAR);
 	}
 

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -2410,17 +2410,19 @@ void DuckBlockFunctions::Register(ExtensionLoader &loader) {
 	// per-function PreventStructConstantFoldingAndAdd replaced the set-level call.
 	ScalarFunction html_to_duck_blocks_html({XMLTypes::HTMLType()}, DuckBlockTypes::DuckBlockListType(),
 	                                        HtmlToDuckBlocksFunction, HtmlToDuckBlocksBind);
+	html_to_duck_blocks_html.SetFallible(); // v2.0: HTML parsing can throw
 	SetScalarFunctionVarArgs(html_to_duck_blocks_html, LogicalType::ANY); // capture_attributes := ...
 	PreventStructConstantFoldingAndAdd(html_to_duck_blocks_set, html_to_duck_blocks_html);
 	ScalarFunction html_to_duck_blocks_varchar({LogicalType::VARCHAR}, DuckBlockTypes::DuckBlockListType(),
 	                                           HtmlToDuckBlocksFunction, HtmlToDuckBlocksBind);
+	html_to_duck_blocks_varchar.SetFallible(); // v2.0: HTML parsing can throw
 	SetScalarFunctionVarArgs(html_to_duck_blocks_varchar, LogicalType::ANY);
 	PreventStructConstantFoldingAndAdd(html_to_duck_blocks_set, html_to_duck_blocks_varchar);
 	loader.RegisterFunction(html_to_duck_blocks_set);
 
 	// duck_blocks_to_html(blocks LIST(duck_block)) -> HTML
-	auto duck_blocks_to_html_func = ScalarFunction("duck_blocks_to_html", {DuckBlockTypes::DuckBlockListType()},
-	                                               XMLTypes::HTMLType(), DuckBlocksToHtmlFunction);
+	auto duck_blocks_to_html_func = Fallible(ScalarFunction("duck_blocks_to_html", {DuckBlockTypes::DuckBlockListType()},
+	                                               XMLTypes::HTMLType(), DuckBlocksToHtmlFunction));
 	loader.RegisterFunction(duck_blocks_to_html_func);
 
 	// read_html_blocks table function

--- a/src/include/duck_block_types.hpp
+++ b/src/include/duck_block_types.hpp
@@ -63,12 +63,13 @@ public:
 	// registered implicit cast (see DuckBlockFunctions::Register); producers may
 	// emit it (read_html_blocks does, behind filename := true).
 	//
-	// The bare "filename" literal becomes FIELD_FILENAME once the vendored
-	// vocabulary is re-pinned to 6.4, which publishes it; the value is ruled and
-	// will not change, only the spelling of where it comes from.
+	// FIELD_FILENAME comes from the vendored vocabulary (6.4), so the name is
+	// shared with every sibling by construction; FILENAME_IDX (7) is its
+	// position, and the assert below is the trailing rule stated in code.
 	static LogicalType DuckBlockWithFilenameType() {
 		auto children = StructType::GetChildTypes(DuckBlockType());
-		children.push_back(make_pair("filename", LogicalType::VARCHAR));
+		static_assert(FILENAME_IDX == 7, "filename is the trailing eighth field (spec 6.4)");
+		children.push_back(make_pair(FIELD_FILENAME, LogicalType::VARCHAR));
 		return LogicalType::STRUCT(std::move(children));
 	}
 

--- a/src/include/duck_block_vocabulary.hpp
+++ b/src/include/duck_block_vocabulary.hpp
@@ -4,7 +4,7 @@
 // VENDORED COPY -- do not edit by hand without re-syncing from upstream.
 //
 // Source: teaguesterling/duckdb_duck_block_utils, src/include/duck_block_vocabulary.hpp
-// Vendored at upstream commit: b3b1e26 (SPEC_VERSION 6.3)
+// Vendored at upstream commit: ff5b146 (SPEC_VERSION 6.4)
 //
 // Taken from a pinned git object (`git show <sha>:<path>`) against a local
 // clone of upstream, NOT from a `raw.githubusercontent.com/.../main/...` URL.
@@ -179,9 +179,16 @@ struct DuckBlockVocabulary {
 	static constexpr uint64_t ATTRIBUTES_IDX = 5;
 	static constexpr uint64_t ELEMENT_ORDER_IDX = 6;
 
-	// Additional field indices for duck_block_ext
-	static constexpr uint64_t SOURCE_FORMAT_IDX = 7;
-	static constexpr uint64_t FILE_PATH_IDX = 8;
+	// The one OPTIONAL trailing field. A reader that emits a `filename` column makes
+	// `list(b)` an 8-field struct; consumers accept exactly that shape -- the seven
+	// canonical fields, then this -- and nothing else. Optional fields append in
+	// ADOPTION order: a later one takes index 8. Reserving slots ahead of adoption is
+	// what put `source_format` at 7 and `file_path` at 8 for a type nothing ever
+	// produced, and that reservation is why the first real optional field could not
+	// simply take the next index. Those two constants are gone; `duck_block_ext`
+	// itself stays registered, deprecated, for one release.
+	static constexpr uint64_t FILENAME_IDX = 7;
+	static constexpr const char *FIELD_FILENAME = "filename";
 
 	// Kind values
 	static constexpr const char *KIND_BLOCK = "block";
@@ -309,8 +316,35 @@ struct DuckBlockVocabulary {
 	//
 	//               Nothing renamed, nothing removed; a consumer on 6.1 is unaffected.
 	//
+	//   6.3 -> 6.4  ADDITIVE for the shape, with ONE REMOVAL and ONE DEPRECATION.
+	//               duck_block gains an optional trailing 8th field, `filename VARCHAR`,
+	//               so a reader can say which file each row came from without breaking
+	//               the `list(b)` idiom. Consumers MUST accept both the 7-field and the
+	//               8-field shape; producers MAY emit the 8th, opt-in behind
+	//               `filename := true`, DuckDB core's own convention. It is TRAILING
+	//               ONLY and the widened shape is exactly one type: a differently
+	//               named or differently placed extra field stays a binder error.
+	//               Functions that RETURN blocks return the 7-field shape: provenance
+	//               lives on the reader's rows and survives GROUP BY filename, not
+	//               duck_blocks_merge.
+	//
+	//               ROLLOUT ORDER, which is why the rule is stated: land acceptance in
+	//               every consumer BEFORE any reader emits, or every
+	//               `duck_blocks_toc(list(b))` in the field breaks with the binder
+	//               error the day the reader ships.
+	//
+	//               REMOVED: SOURCE_FORMAT_IDX (7) and FILE_PATH_IDX (8), the offsets
+	//               of a `duck_block_ext` type no function ever produced or consumed.
+	//               `filename` at 7 would otherwise contradict a published constant.
+	//               DEPRECATED: the `duck_block_ext` catalog type stays registered
+	//               for one release because a user's own `CAST(x AS duck_block_ext)`
+	//               is invisible to any grep of ours; it goes in 6.5.
+	//
+	//               A consumer on 6.3 that never referenced the two offsets is
+	//               unaffected until a reader it depends on starts emitting.
+	//
 	// The rule above is what will be followed from here.
-	static constexpr const char *SPEC_VERSION = "6.3";
+	static constexpr const char *SPEC_VERSION = "6.4";
 
 	// ========================================================================
 	// Block type names
@@ -452,7 +486,7 @@ struct DuckBlockVocabulary {
 	// Without it, a blob the author deliberately placed last is indistinguishable from
 	// metadata the FORMAT supplied with no position at all: both appended, both roleless.
 	static constexpr const char *ROLE_TAILMATTER = "tailmatter";
-	static constexpr const char *ROLE_DOCUMENT = "document";       // the blob IS the whole document
+	static constexpr const char *ROLE_DOCUMENT = "document"; // the blob IS the whole document
 
 	// ========================================================================
 	// `list_type` values -- the attribute is ATTR_LIST_TYPE

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -259,6 +259,20 @@ inline LogicalType CompatForceMaxLogicalType(const LogicalType &left, const Logi
 // shared_ptr<const T> and a set member can no longer be configured after it has been added.
 // Defined outside the #ifdef because it delegates to whichever PreventStructConstantFolding
 // overload the branch above selected (a no-op on the old API).
+// DuckDB v2.0 enforces a scalar function's declared error mode at runtime: a
+// function that throws without having called SetFallible() surfaces as
+//   INTERNAL Error: Scalar function "x" threw an execution error, but the
+//   function is not marked as fallible
+// rather than as the error it threw. Applied at CONSTRUCTION, wrapping the
+// ScalarFunction expression, so it is set before the function is added to a
+// set -- on v2.0 a set member is shared_ptr<const T> and cannot be configured
+// after AddFunction. SetFallible() exists on the pinned 1.5 too, where it only
+// informs the optimizer, so there is nothing to guard.
+inline ScalarFunction Fallible(ScalarFunction fn) {
+	fn.SetFallible();
+	return fn;
+}
+
 template <typename T>
 inline void PreventStructConstantFoldingAndAdd(FunctionSet<T> &func_set, T func) {
 	PreventStructConstantFolding(func);

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1206,16 +1206,16 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	};
 
 	// Register xml function (same as to_xml for now) - using VARCHAR for now, will enhance type system later
-	auto xml_function = ScalarFunction("xml", {LogicalType::VARCHAR}, LogicalType::VARCHAR, ValueToXMLFunction);
+	auto xml_function = Fallible(ScalarFunction("xml", {LogicalType::VARCHAR}, LogicalType::VARCHAR, ValueToXMLFunction));
 	loader.RegisterFunction(xml_function);
 
 	// Register to_xml function (single argument) - ANY type variant (unified path)
-	auto to_xml_any_function = ScalarFunction("to_xml", {LogicalType::ANY}, XMLTypes::XMLType(), ValueToXMLFunction);
+	auto to_xml_any_function = Fallible(ScalarFunction("to_xml", {LogicalType::ANY}, XMLTypes::XMLType(), ValueToXMLFunction));
 	loader.RegisterFunction(to_xml_any_function);
 
 	// Register to_xml function (two arguments: value, node_name) - ANY type variant (unified path)
 	auto to_xml_any_with_name_function =
-	    ScalarFunction("to_xml", {LogicalType::ANY, LogicalType::VARCHAR}, XMLTypes::XMLType(), ValueToXMLFunction);
+	    Fallible(ScalarFunction("to_xml", {LogicalType::ANY, LogicalType::VARCHAR}, XMLTypes::XMLType(), ValueToXMLFunction));
 	loader.RegisterFunction(to_xml_any_with_name_function);
 
 	// Register xml_libxml2_version function
@@ -1259,54 +1259,54 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	//  literal return type and trip an internal error. The named-arg case routes through the VARCHAR
 	//  overload below, with the literal xpath implicitly cast to VARCHAR.)
 	xml_extract_text_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction)));
 	// XMLFragment + VARCHAR -> LIST(VARCHAR)
 	add_ns_aware(xml_extract_text_functions,
 	             ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR},
 	                            LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction));
 	// XMLFragment + STRING_LITERAL -> LIST(VARCHAR)
 	xml_extract_text_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction)));
 	// VARCHAR + VARCHAR -> LIST(VARCHAR) (compatibility)
 	add_ns_aware(xml_extract_text_functions,
 	             ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
 	                            XMLExtractTextListFunction));
 	// VARCHAR + STRING_LITERAL -> LIST(VARCHAR) (compatibility)
 	xml_extract_text_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListFunction)));
 
 	// 3-argument variants with namespaces MAP
 	auto ns_map_type = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
 	// XML + VARCHAR + MAP -> LIST(VARCHAR)
-	xml_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type},
+	xml_extract_text_functions.AddFunction(Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type},
 	                                                      LogicalType::LIST(LogicalType::VARCHAR),
-	                                                      XMLExtractTextListWithNamespacesFunction));
+	                                                      XMLExtractTextListWithNamespacesFunction)));
 	// VARCHAR + VARCHAR + MAP -> LIST(VARCHAR)
-	xml_extract_text_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type},
+	xml_extract_text_functions.AddFunction(Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type},
 	                                                      LogicalType::LIST(LogicalType::VARCHAR),
-	                                                      XMLExtractTextListWithNamespacesFunction));
+	                                                      XMLExtractTextListWithNamespacesFunction)));
 
 	// 3-argument variants with namespace mode VARCHAR ('auto', 'strict', 'ignore')
 	// XML + VARCHAR + VARCHAR (mode) -> LIST(VARCHAR)
 	xml_extract_text_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListWithNamespacesFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListWithNamespacesFunction)));
 	// VARCHAR + VARCHAR + VARCHAR (mode) -> LIST(VARCHAR)
 	xml_extract_text_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListWithNamespacesFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::LIST(LogicalType::VARCHAR), XMLExtractTextListWithNamespacesFunction)));
 
 	loader.RegisterFunction(xml_extract_text_functions);
 
 	// Register xml_extract_all_text function - both XML and VARCHAR overloads
 	auto xml_extract_all_text_function =
-	    ScalarFunction("xml_extract_all_text", {XMLTypes::XMLType()}, LogicalType::VARCHAR, XMLExtractAllTextFunction);
+	    Fallible(ScalarFunction("xml_extract_all_text", {XMLTypes::XMLType()}, LogicalType::VARCHAR, XMLExtractAllTextFunction));
 	loader.RegisterFunction(xml_extract_all_text_function);
 	auto xml_extract_all_text_varchar_function =
-	    ScalarFunction("xml_extract_all_text", {LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractAllTextFunction);
+	    Fallible(ScalarFunction("xml_extract_all_text", {LogicalType::VARCHAR}, LogicalType::VARCHAR, XMLExtractAllTextFunction));
 	loader.RegisterFunction(xml_extract_all_text_varchar_function);
 
 	// Register xml_extract_elements function - returns LIST(XMLFragment) (PostgreSQL-compatible)
@@ -1320,50 +1320,50 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	// XML + STRING_LITERAL -> LIST(XMLFragment)
 	// (STRING_LITERAL overloads stay varargs-free; see note on xml_extract_text above.)
 	xml_extract_elements_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction)));
 	// HTML + VARCHAR -> LIST(XMLFragment)
 	add_ns_aware(xml_extract_elements_functions,
 	             ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
 	                            LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// HTML + STRING_LITERAL -> LIST(XMLFragment)
 	xml_extract_elements_functions.AddFunction(
-	    ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
+	    Fallible(ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction)));
 	// XMLFragment + VARCHAR -> LIST(XMLFragment) (for nested extraction)
 	add_ns_aware(xml_extract_elements_functions,
 	             ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType::VARCHAR},
 	                            LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// XMLFragment + STRING_LITERAL -> LIST(XMLFragment)
 	xml_extract_elements_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLFragmentType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction)));
 	// VARCHAR + VARCHAR -> LIST(XMLFragment) (compatibility)
 	add_ns_aware(xml_extract_elements_functions,
 	             ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                            LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
 	// VARCHAR + STRING_LITERAL -> LIST(XMLFragment) (compatibility)
 	xml_extract_elements_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListFunction)));
 
 	// 3-argument variants with namespaces MAP
 	// XML + VARCHAR + MAP -> LIST(XMLFragment)
-	xml_extract_elements_functions.AddFunction(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type},
+	xml_extract_elements_functions.AddFunction(Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type},
 	                                                          LogicalType::LIST(XMLTypes::XMLFragmentType()),
-	                                                          XMLExtractElementsListWithNamespacesFunction));
+	                                                          XMLExtractElementsListWithNamespacesFunction)));
 	// VARCHAR + VARCHAR + MAP -> LIST(XMLFragment)
-	xml_extract_elements_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type},
+	xml_extract_elements_functions.AddFunction(Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type},
 	                                                          LogicalType::LIST(XMLTypes::XMLFragmentType()),
-	                                                          XMLExtractElementsListWithNamespacesFunction));
+	                                                          XMLExtractElementsListWithNamespacesFunction)));
 
 	// 3-argument variants with namespace mode VARCHAR ('auto', 'strict', 'ignore')
 	xml_extract_elements_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListWithNamespacesFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListWithNamespacesFunction)));
 	xml_extract_elements_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListWithNamespacesFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::LIST(XMLTypes::XMLFragmentType()), XMLExtractElementsListWithNamespacesFunction)));
 
 	loader.RegisterFunction(xml_extract_elements_functions);
 
@@ -1377,23 +1377,23 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	                            XMLExtractElementsStringFunction));
 	// 3-argument variants with namespaces MAP
 	xml_extract_elements_string_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type}, LogicalType::VARCHAR,
-	                   XMLExtractElementsStringWithNamespacesFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type}, LogicalType::VARCHAR,
+	                   XMLExtractElementsStringWithNamespacesFunction)));
 	xml_extract_elements_string_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type}, LogicalType::VARCHAR,
-	                   XMLExtractElementsStringWithNamespacesFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type}, LogicalType::VARCHAR,
+	                   XMLExtractElementsStringWithNamespacesFunction)));
 	// 3-argument variants with namespace mode VARCHAR
 	xml_extract_elements_string_functions.AddFunction(
-	    ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	                   XMLExtractElementsStringWithNamespacesFunction));
+	    Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                   XMLExtractElementsStringWithNamespacesFunction)));
 	xml_extract_elements_string_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	                   XMLExtractElementsStringWithNamespacesFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                   XMLExtractElementsStringWithNamespacesFunction)));
 	loader.RegisterFunction(xml_extract_elements_string_functions);
 
 	// Register xml_wrap_fragment function (returns XML)
-	auto xml_wrap_fragment_function = ScalarFunction("xml_wrap_fragment", {LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                                                 XMLTypes::XMLType(), XMLWrapFragmentFunction);
+	auto xml_wrap_fragment_function = Fallible(ScalarFunction("xml_wrap_fragment", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                                 XMLTypes::XMLType(), XMLWrapFragmentFunction));
 	loader.RegisterFunction(xml_wrap_fragment_function);
 
 	// Register xml_extract_attributes function (returns LIST<STRUCT>)
@@ -1460,14 +1460,14 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	auto comment_struct_type = LogicalType::STRUCT(
 	    {make_pair("content", LogicalType::VARCHAR), make_pair("line_number", LogicalType::BIGINT)});
 	auto xml_extract_comments_function =
-	    ScalarFunction("xml_extract_comments", {XMLTypes::XMLType()}, LogicalType::LIST(comment_struct_type),
-	                   XMLExtractCommentsFunction);
+	    Fallible(ScalarFunction("xml_extract_comments", {XMLTypes::XMLType()}, LogicalType::LIST(comment_struct_type),
+	                   XMLExtractCommentsFunction));
 	PreventStructConstantFolding(xml_extract_comments_function);
 	loader.RegisterFunction(xml_extract_comments_function);
 
 	// Register xml_extract_cdata function (returns LIST<STRUCT>)
-	auto xml_extract_cdata_function = ScalarFunction("xml_extract_cdata", {XMLTypes::XMLType()},
-	                                                 LogicalType::LIST(comment_struct_type), XMLExtractCDataFunction);
+	auto xml_extract_cdata_function = Fallible(ScalarFunction("xml_extract_cdata", {XMLTypes::XMLType()},
+	                                                 LogicalType::LIST(comment_struct_type), XMLExtractCDataFunction));
 	PreventStructConstantFolding(xml_extract_cdata_function);
 	loader.RegisterFunction(xml_extract_cdata_function);
 
@@ -1502,30 +1502,30 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 
 	// Register xml_detect_prefixes function (returns LIST<VARCHAR> of namespace prefixes in XPath expression)
 	auto xml_detect_prefixes_function =
-	    ScalarFunction("xml_detect_prefixes", {LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
-	                   XMLDetectPrefixesFunction);
+	    Fallible(ScalarFunction("xml_detect_prefixes", {LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
+	                   XMLDetectPrefixesFunction));
 	loader.RegisterFunction(xml_detect_prefixes_function);
 
 	// Register xml_mock_namespaces function (returns MAP<VARCHAR, VARCHAR> with mock URIs for prefixes)
 	auto xml_mock_namespaces_function =
-	    ScalarFunction("xml_mock_namespaces", {LogicalType::LIST(LogicalType::VARCHAR)},
-	                   LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR), XMLMockNamespacesFunction);
+	    Fallible(ScalarFunction("xml_mock_namespaces", {LogicalType::LIST(LogicalType::VARCHAR)},
+	                   LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR), XMLMockNamespacesFunction));
 	PreventStructConstantFolding(xml_mock_namespaces_function);
 	loader.RegisterFunction(xml_mock_namespaces_function);
 
 	// Register xml_find_undefined_prefixes function
 	// Finds namespace prefixes used in an XPath expression that are not declared in the XML document
 	auto xml_find_undefined_prefixes_function =
-	    ScalarFunction("xml_find_undefined_prefixes", {LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(LogicalType::VARCHAR), XMLFindUndefinedPrefixesFunction);
+	    Fallible(ScalarFunction("xml_find_undefined_prefixes", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::LIST(LogicalType::VARCHAR), XMLFindUndefinedPrefixesFunction));
 	loader.RegisterFunction(xml_find_undefined_prefixes_function);
 
 	// Register xml_add_namespace_declarations function
 	// Injects xmlns declarations into an XML document's root element
 	auto xml_add_namespace_declarations_function =
-	    ScalarFunction("xml_add_namespace_declarations",
+	    Fallible(ScalarFunction("xml_add_namespace_declarations",
 	                   {LogicalType::VARCHAR, LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)},
-	                   LogicalType::VARCHAR, XMLAddNamespaceDeclarationsFunction);
+	                   LogicalType::VARCHAR, XMLAddNamespaceDeclarationsFunction));
 	loader.RegisterFunction(xml_add_namespace_declarations_function);
 
 	// Register xml_lookup_namespace function
@@ -1588,16 +1588,16 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 
 	// HTML only (no XPath) -> VARCHAR (all text concatenated, unchanged behavior)
 	html_extract_text_functions.AddFunction(
-	    ScalarFunction({XMLTypes::HTMLType()}, LogicalType::VARCHAR, HTMLExtractTextFunction));
+	    Fallible(ScalarFunction({XMLTypes::HTMLType()}, LogicalType::VARCHAR, HTMLExtractTextFunction)));
 
 	// HTML + VARCHAR XPath -> LIST(VARCHAR)
-	html_extract_text_functions.AddFunction(ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
+	html_extract_text_functions.AddFunction(Fallible(ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR},
 	                                                       LogicalType::LIST(LogicalType::VARCHAR),
-	                                                       HTMLExtractTextListFunction));
+	                                                       HTMLExtractTextListFunction)));
 	// HTML + STRING_LITERAL XPath -> LIST(VARCHAR)
 	html_extract_text_functions.AddFunction(
-	    ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(LogicalType::VARCHAR), HTMLExtractTextListFunction));
+	    Fallible(ScalarFunction({XMLTypes::HTMLType(), LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(LogicalType::VARCHAR), HTMLExtractTextListFunction)));
 	// NOTE: Namespace parameter overloads intentionally omitted for html_extract_text.
 	// HTML5 parsing (htmlReadMemory) doesn't support XML namespace declarations -
 	// prefixed elements like "svg:circle" are treated as literal names with colons.
@@ -1611,15 +1611,15 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	// the gap in doc examples. Mirrors the VARCHAR overloads xml_extract_text already has.
 	// VARCHAR only (no XPath) -> VARCHAR
 	html_extract_text_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, HTMLExtractTextFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, HTMLExtractTextFunction)));
 	// VARCHAR + VARCHAR XPath -> LIST(VARCHAR)
-	html_extract_text_functions.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
+	html_extract_text_functions.AddFunction(Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                                       LogicalType::LIST(LogicalType::VARCHAR),
-	                                                       HTMLExtractTextListFunction));
+	                                                       HTMLExtractTextListFunction)));
 	// VARCHAR + STRING_LITERAL XPath -> LIST(VARCHAR)
 	html_extract_text_functions.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
-	                   LogicalType::LIST(LogicalType::VARCHAR), HTMLExtractTextListFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType(LogicalTypeId::STRING_LITERAL)},
+	                   LogicalType::LIST(LogicalType::VARCHAR), HTMLExtractTextListFunction)));
 
 	loader.RegisterFunction(html_extract_text_functions);
 

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1191,8 +1191,12 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	// execute function then delegates to its namespace-aware sibling when a third column is present.
 	// Required for forward-compat with DuckDB main, which (unlike <=v1.5.3) no longer silently
 	// ignores argument labels on scalar functions. (GitHub Issue #78 follow-up / DuckDB main drift.)
+	// Everything routed through these helpers takes an XPath, and a malformed
+	// XPath raises (the #134 contract) -- so every member is fallible. Marked
+	// here, before AddFunction, for the same v2.0 reason the varargs are.
 	auto add_ns_aware = [](ScalarFunctionSet &set, ScalarFunction fn) {
 		SetScalarFunctionVarArgs(fn, LogicalType::ANY);
+		fn.SetFallible();
 		set.AddFunction(std::move(fn));
 	};
 	// Same, for sets whose functions return a STRUCT-containing type and therefore have to be
@@ -1202,6 +1206,7 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	auto add_ns_aware_volatile = [](ScalarFunctionSet &set, ScalarFunction fn) {
 		SetScalarFunctionVarArgs(fn, LogicalType::ANY);
 		PreventStructConstantFolding(fn);
+		fn.SetFallible();
 		set.AddFunction(std::move(fn));
 	};
 

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1507,22 +1507,22 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 
 	// Register xml_detect_prefixes function (returns LIST<VARCHAR> of namespace prefixes in XPath expression)
 	auto xml_detect_prefixes_function =
-	    Fallible(ScalarFunction("xml_detect_prefixes", {LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
-	                   XMLDetectPrefixesFunction));
+	    ScalarFunction("xml_detect_prefixes", {LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
+	                   XMLDetectPrefixesFunction);
 	loader.RegisterFunction(xml_detect_prefixes_function);
 
 	// Register xml_mock_namespaces function (returns MAP<VARCHAR, VARCHAR> with mock URIs for prefixes)
 	auto xml_mock_namespaces_function =
-	    Fallible(ScalarFunction("xml_mock_namespaces", {LogicalType::LIST(LogicalType::VARCHAR)},
-	                   LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR), XMLMockNamespacesFunction));
+	    ScalarFunction("xml_mock_namespaces", {LogicalType::LIST(LogicalType::VARCHAR)},
+	                   LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR), XMLMockNamespacesFunction);
 	PreventStructConstantFolding(xml_mock_namespaces_function);
 	loader.RegisterFunction(xml_mock_namespaces_function);
 
 	// Register xml_find_undefined_prefixes function
 	// Finds namespace prefixes used in an XPath expression that are not declared in the XML document
 	auto xml_find_undefined_prefixes_function =
-	    Fallible(ScalarFunction("xml_find_undefined_prefixes", {LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(LogicalType::VARCHAR), XMLFindUndefinedPrefixesFunction));
+	    ScalarFunction("xml_find_undefined_prefixes", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::LIST(LogicalType::VARCHAR), XMLFindUndefinedPrefixesFunction);
 	loader.RegisterFunction(xml_find_undefined_prefixes_function);
 
 	// Register xml_add_namespace_declarations function

--- a/src/xml_scalar_functions.cpp
+++ b/src/xml_scalar_functions.cpp
@@ -1419,30 +1419,30 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	                                     LogicalType::LIST(attr_struct_type), XMLExtractAttributesFunction));
 	// Add 3-argument variants with namespace map
 	PreventStructConstantFoldingAndAdd(xml_extract_attributes_functions,
-	                                   ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type},
+	                                   Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, ns_map_type},
 	                                                  LogicalType::LIST(attr_struct_type),
-	                                                  XMLExtractAttributesWithNamespacesFunction));
+	                                                  XMLExtractAttributesWithNamespacesFunction)));
 	PreventStructConstantFoldingAndAdd(xml_extract_attributes_functions,
-	                                   ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR, ns_map_type},
+	                                   Fallible(ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR, ns_map_type},
 	                                                  LogicalType::LIST(attr_struct_type),
-	                                                  XMLExtractAttributesWithNamespacesFunction));
+	                                                  XMLExtractAttributesWithNamespacesFunction)));
 	PreventStructConstantFoldingAndAdd(xml_extract_attributes_functions,
-	                                   ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type},
+	                                   Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, ns_map_type},
 	                                                  LogicalType::LIST(attr_struct_type),
-	                                                  XMLExtractAttributesWithNamespacesFunction));
+	                                                  XMLExtractAttributesWithNamespacesFunction)));
 	// Add 3-argument variants with namespace mode VARCHAR
 	PreventStructConstantFoldingAndAdd(xml_extract_attributes_functions,
-	                                   ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                   Fallible(ScalarFunction({XMLTypes::XMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                                  LogicalType::LIST(attr_struct_type),
-	                                                  XMLExtractAttributesWithNamespacesFunction));
+	                                                  XMLExtractAttributesWithNamespacesFunction)));
 	PreventStructConstantFoldingAndAdd(
 	    xml_extract_attributes_functions,
-	    ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(attr_struct_type), XMLExtractAttributesWithNamespacesFunction));
+	    Fallible(ScalarFunction({XMLTypes::HTMLType(), LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::LIST(attr_struct_type), XMLExtractAttributesWithNamespacesFunction)));
 	PreventStructConstantFoldingAndAdd(
 	    xml_extract_attributes_functions,
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::LIST(attr_struct_type), XMLExtractAttributesWithNamespacesFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::LIST(attr_struct_type), XMLExtractAttributesWithNamespacesFunction)));
 	loader.RegisterFunction(xml_extract_attributes_functions);
 
 	// Register xml_pretty_print function
@@ -1632,44 +1632,44 @@ void XMLScalarFunctions::Register(ExtensionLoader &loader) {
 	ScalarFunctionSet html_extract_links_functions("html_extract_links");
 	PreventStructConstantFoldingAndAdd(
 	    html_extract_links_functions,
-	    ScalarFunction({XMLTypes::HTMLType()}, LogicalType::LIST(html_link_struct_type), HTMLExtractLinksFunction));
+	    Fallible(ScalarFunction({XMLTypes::HTMLType()}, LogicalType::LIST(html_link_struct_type), HTMLExtractLinksFunction)));
 	PreventStructConstantFoldingAndAdd(
 	    html_extract_links_functions,
-	    ScalarFunction({LogicalType::VARCHAR}, LogicalType::LIST(html_link_struct_type), HTMLExtractLinksFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR}, LogicalType::LIST(html_link_struct_type), HTMLExtractLinksFunction)));
 	loader.RegisterFunction(html_extract_links_functions);
 
 	// Register html_extract_images function (HTML + VARCHAR compatibility overload)
 	ScalarFunctionSet html_extract_images_functions("html_extract_images");
 	PreventStructConstantFoldingAndAdd(
 	    html_extract_images_functions,
-	    ScalarFunction({XMLTypes::HTMLType()}, LogicalType::LIST(html_image_struct_type), HTMLExtractImagesFunction));
+	    Fallible(ScalarFunction({XMLTypes::HTMLType()}, LogicalType::LIST(html_image_struct_type), HTMLExtractImagesFunction)));
 	PreventStructConstantFoldingAndAdd(
 	    html_extract_images_functions,
-	    ScalarFunction({LogicalType::VARCHAR}, LogicalType::LIST(html_image_struct_type), HTMLExtractImagesFunction));
+	    Fallible(ScalarFunction({LogicalType::VARCHAR}, LogicalType::LIST(html_image_struct_type), HTMLExtractImagesFunction)));
 	loader.RegisterFunction(html_extract_images_functions);
 
 	// Register html_extract_table_rows function (HTML + VARCHAR compatibility overload)
 	ScalarFunctionSet html_extract_table_rows_functions("html_extract_table_rows");
 	PreventStructConstantFoldingAndAdd(html_extract_table_rows_functions,
-	                                   ScalarFunction({XMLTypes::HTMLType()},
+	                                   Fallible(ScalarFunction({XMLTypes::HTMLType()},
 	                                                  LogicalType::LIST(html_table_row_struct_type),
-	                                                  HTMLExtractTableRowsFunction));
+	                                                  HTMLExtractTableRowsFunction)));
 	PreventStructConstantFoldingAndAdd(html_extract_table_rows_functions,
-	                                   ScalarFunction({LogicalType::VARCHAR},
+	                                   Fallible(ScalarFunction({LogicalType::VARCHAR},
 	                                                  LogicalType::LIST(html_table_row_struct_type),
-	                                                  HTMLExtractTableRowsFunction));
+	                                                  HTMLExtractTableRowsFunction)));
 	loader.RegisterFunction(html_extract_table_rows_functions);
 
 	// Register html_extract_tables_json function (HTML + VARCHAR compatibility overload)
 	ScalarFunctionSet html_extract_tables_json_functions("html_extract_tables_json");
 	PreventStructConstantFoldingAndAdd(html_extract_tables_json_functions,
-	                                   ScalarFunction({XMLTypes::HTMLType()},
+	                                   Fallible(ScalarFunction({XMLTypes::HTMLType()},
 	                                                  LogicalType::LIST(html_table_json_struct_type),
-	                                                  HTMLExtractTablesJSONFunction));
+	                                                  HTMLExtractTablesJSONFunction)));
 	PreventStructConstantFoldingAndAdd(html_extract_tables_json_functions,
-	                                   ScalarFunction({LogicalType::VARCHAR},
+	                                   Fallible(ScalarFunction({LogicalType::VARCHAR},
 	                                                  LogicalType::LIST(html_table_json_struct_type),
-	                                                  HTMLExtractTablesJSONFunction));
+	                                                  HTMLExtractTablesJSONFunction)));
 	loader.RegisterFunction(html_extract_tables_json_functions);
 
 	// Register parse_html scalar function for parsing HTML content directly


### PR DESCRIPTION
One PR combining #145 and #146, verified as a single tree rather than as two parts. Supersedes both; they will be closed when this merges. The two touch no common files.

## From #145 — closes #140: every throwing scalar declared fallible

DuckDB v2.0 enforces a scalar's declared error mode at runtime; a function that throws without `SetFallible()` surfaces as `INTERNAL Error: ... not marked as fallible` instead of its real error. The three functions tests caught were a floor. The set came from measurement: a static throw-reachability pass, then every function it called clean probed with hostile input — and after review, three it had over-approximated (`xml_detect_prefixes`, `xml_mock_namespaces`, `xml_find_undefined_prefixes`) unmarked again, each confirmed to have no throw path and to return on NULL/empty/malformed input. **17 functions, 37 registrations** (the four function sets carry 25 overloads), applied at construction because v2.0 set members can't be configured after `AddFunction`.

Also fixes a #144 regression the canary had never seen: `names.push_back(result->filename_column)` doesn't compile on v2.0 (`vector<Identifier>`). Fixed with `CompatMakeName`, the idiom the XML readers already use.

**v2.0 canary on the final #145 head: `linux_amd64` 102 passed, 0 failed, zero "not marked as fallible" lines** — the first green run webbed has ever had against DuckDB main. Tests also ran green on `windows_amd64` and `osx_arm64`; the other legs build only.

## From #146 — duckdb submodule v1.5.4-154 → v1.5.5-146

Along `v1.5-variegata`, the branch both submodules track — not a jump to 2.0. This bump is the test #139 was written for: `identifier.hpp` is present on the new pin (backported without the signature change), the exact case the old `__has_include` probe got wrong. Build clean; it held.

CI `duckdb_version` → `v1.5.5` on the stable and code-quality jobs and the Wasm artifact paths that derive from it. The stable build's ci-tools ref stays `v1.5.4` (no `v1.5.5` tag exists); the code-quality job stays `@main` because `_extension_code_quality.yml` doesn't exist at the tag at all. Both said in comments beside the refs.

## Verification of the combined tree

- Built against v1.5.5-146: 0 errors
- **3951 assertions in 102 cases** on `v1.5.5-dev154`
- `make check-vocabulary` OK; `make check-docs` 105 examples, 0 broken

The "red" on #145 was a `push` run cancelled by the concurrency group when the PR run and a manual dispatch started in the same second — `gh pr checks` reports cancelled as failed. The PR run itself had Format Check and every build green. This PR gets a clean run of its own.

## Not in this PR

The arm64 test-skip is in `duckdb/extension-ci-tools` (`if: matrix.duckdb_arch != 'linux_arm64'`, from the cross-compile era, stale since the 2025-05 move to native `ubuntu-24.04-arm` runners). That's an upstream PR, next.