### PR TITLE
docs: v2.9.0 changelog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-Unreleased
-----------
+v2.9.0 (Current)
+----------------
 
 **Behaviour change: attribute capture is now a parameter, and** ``class`` **is opt-in.**
 
@@ -25,6 +25,18 @@ destroyed attributes the source had.
   unless requested**, because Pandoc encodes semantic structure in classes.
 - Vocabulary keys (``role``, ``heading_level``, ...) are reserved: never copied from the
   source, so ``'*'`` cannot forge them.
+
+**DuckDB 2.0 ready.** Every scalar that can throw now declares it (``SetFallible``), which
+DuckDB 2.0 enforces at runtime; the port that builds against both 1.5 and 2.0 (#139) is in; and
+the canary against DuckDB ``main`` is green on every platform, with tests passing on Linux,
+Windows and macOS. Community-extensions builds every release against 2.0, so this is what makes
+the release possible rather than a feature of it.
+
+**DuckDB submodule at v1.5.5**, up from v1.5.4; CI builds against ``v1.5.5``.
+
+**duck_block vocabulary at spec 6.5**, vendored from upstream ``cfd8e28``. ``FIELD_FILENAME``
+and ``FILENAME_IDX`` come from the header rather than local literals. The drift check learned a
+third state, AHEAD, for a copy vendored from a commit upstream has not merged yet.
 
 **``filename`` on** ``read_html_blocks`` **is now trailing, and takes core's forms.**
 


### PR DESCRIPTION
`Unreleased` → `v2.9.0 (Current)`, plus the three entries the section had not yet recorded: DuckDB 2.0 readiness, the submodule at v1.5.5, and the vocabulary at spec 6.5.

**Version is my recommendation, not a decision that has been made.** The relayed release plan called webbed a patch (v2.8.3). What's on `main` since v2.8.2 is more than that: the changelog section opens with a *behaviour change* (`class` no longer captured by default), the `filename` column moved from first to last on `read_html_blocks`, and `capture_attributes` is new API surface. A version number that disagrees with its own changelog heading is the wrong one. If v2.8.3 is what you want, say so and I'll amend before tagging — the tag is the irreversible step, this isn't.

Sphinx warnings unchanged (22); docs examples 0 broken.