### PR TITLE
chore(vocabulary): re-vendor duck_block 1.2 at duck_block_utils 1c5f2a6

### DIFF
--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -132,7 +132,9 @@ UPSTREAM_API = f"https://api.github.com/repos/{UPSTREAM_REPO}/commits/main"
 # indirection exists: raw.githubusercontent.com serves BRANCH urls from a cache that
 # lags, so a branch fetch can hand back a superseded header and the check then reports
 # "in sync" against content upstream has already replaced. Observed live: the API had
-# main at 26bfe05 with SPEC_VERSION 2.0 while the branch url was still serving 1.2.
+# main at 26bfe05 with SPEC_VERSION 2.0 while the branch url was still serving 1.2
+# (both on the retired INTERNAL numbering line; the public 1.2 of 2026-09-10 is newer
+# than either).
 # Resolving main to a sha first and fetching THAT is immune -- a sha url is immutable,
 # so it is cached correctly by construction.
 UPSTREAM_RAW = "https://raw.githubusercontent.com/" + UPSTREAM_REPO + "/{ref}/" + HEADER_REL

--- a/src/include/duck_block_vocabulary.hpp
+++ b/src/include/duck_block_vocabulary.hpp
@@ -4,7 +4,7 @@
 // VENDORED COPY -- do not edit by hand without re-syncing from upstream.
 //
 // Source: teaguesterling/duckdb_duck_block_utils, src/include/duck_block_vocabulary.hpp
-// Vendored at upstream commit: cfd8e28 (SPEC_VERSION 6.5)
+// Vendored at upstream commit: 1c5f2a6 (SPEC_VERSION 1.2)
 //
 // Taken from a pinned git object (`git show <sha>:<path>`) against a local
 // clone of upstream, NOT from a `raw.githubusercontent.com/.../main/...` URL.
@@ -227,15 +227,26 @@ struct DuckBlockVocabulary {
 	// Equality goes red on every release including ones that cannot affect you,
 	// and a check that cries wolf gets muted:
 	//
-	//     major(duck_block_spec_version()) == 2   AND   minor(...) >= <what you need>
+	//     major(duck_block_spec_version()) == 1   AND   minor(...) >= <what you need>
 	//
 	// (Asked by panduck, who noticed the guidance said "compare against
 	// SPEC_VERSION" without saying compare HOW, and whose readers are untouched by
 	// 2.0 apart from lists.)
 	//
 	// HONEST HISTORY, because the numbers only mean something if they were applied
-	// consistently and one of these was not:
+	// consistently and one of these was not.
 	//
+	// TWO NUMBER LINES. Every entry below up to 6.6 is on this repo's INTERNAL line,
+	// retired on 2026-09-10 (last entry). The internal line had its own 1.1 and 1.2,
+	// which are NOT the public 1.2 that SPEC_VERSION now carries: internal 1.2 lacked
+	// explicit levels, `plain`, one shape per element_type and the native table
+	// schema; public 1.2 has all of them. A check written against internal 1.x
+	// (`major == 1 AND minor >= 2`) is satisfied by public 1.2 and is therefore not
+	// discriminating; no consumer in the fleet carries one (checked 2026-09-10:
+	// every vendored copy was on 6.5), which is why the number was reused rather
+	// than skipped. (Zim-Dev's finding, 2026-09-10.)
+	//
+	//   -- internal line --
 	//   1.1 -> 1.2  list and blockquote became structural. BREAKING -- it broke
 	//               duckdb_markdown's writer in three places. It should have been
 	//               2.0 and the minor bump was wrong. A consumer pinning "major 1"
@@ -379,8 +390,53 @@ struct DuckBlockVocabulary {
 	//               wanting text renames to the _text sibling. Failure to migrate is a
 	//               binder error, never a wrong answer.
 	//
+	//   6.5 -> 6.6  ADDITIVE for consumers; producers gain two obligations, named here.
+	//               Issue #29 (duckeye): every validation rule was a predicate on ONE
+	//               element and the one-shape rule bound only this repo, while the
+	//               divergences consumers hit are properties of a LIST and run between
+	//               repos. Four things:
+	//               * Fragments are legal input. ImplicitParentOf() below declares the
+	//                 wrapper a fragment gets (list_item -> list, caption -> figure,
+	//                 inline -> plain). duck_blocks_to_pandoc_ast used to return [] for an
+	//                 orphan inline run that duck_blocks_validate called valid.
+	//               * List-level validation (field = 'list'): element_order dense from 0,
+	//                 shallowest level 1, no level jump, required ancestors present.
+	//               * duck_blocks_repair(blocks): the deterministic fixes for those rules,
+	//                 idempotent, never touching an existing element's content, attributes
+	//                 or element_type. Composes with duck_blocks_normalize.
+	//               * ONE shape per element_type binds EVERY producer. First instance: a
+	//                 tight list item carries content (Pandoc Plain); a loose one has a
+	//                 paragraph child (Para). markdown emitted loose for both (markdown#60)
+	//                 and starts element_order at 1 (markdown#59); both are producer bugs
+	//                 under this note, not new rules.
+	//               A consumer on 6.5 is unaffected. A producer that vendored `plain` and
+	//               never emitted it has been non-conformant since 4.0; this note names it.
+	//
+	//   internal 6.6 -> public 1.2  RENUMBERED, NO SHAPE CHANGE. Teague, 2026-09-10: "I don't want to
+	//               keep numbering up into the 6.6s; this should be at most 1.2; stop
+	//               with the internal numbering." The 6.x line was this repo's internal
+	//               count of spec revisions, one per ruling, and it had climbed to a
+	//               number that says "sixth major redesign" about a vocabulary whose
+	//               public name has been duck_blocks 1.1 throughout. The public name
+	//               is now the number: 1.2 is 6.6 with a different label. Nothing
+	//               renamed, removed, or reshaped between them.
+	//
+	//               RECORDED, NOT QUIET, for the same reason the mis-numbered 1.1 -> 1.2
+	//               above is recorded: every consumer compares major equality plus a
+	//               minor floor (panduck's check implements exactly that rule), so a
+	//               major going DOWN from 6 to 1 reads as a breaking change to a rule
+	//               that is working correctly. SPEC_VERSION_SUPERSEDES below names the
+	//               last number of the retired line so a check can accept either side
+	//               of the renumbering; a consumer re-vendoring this header updates its
+	//               major-equality constant from 6 to 1 once and is done. The next
+	//               breaking change is 2.0; the next additive one is 1.3.
+	//
 	// The rule above is what will be followed from here.
-	static constexpr const char *SPEC_VERSION = "6.5";
+	static constexpr const char *SPEC_VERSION = "1.2";
+	// The last number of the internal 6.x line that 1.2 replaces. A consumer check
+	// that reads MAJOR from SPEC_VERSION treats this line's major as equivalent to
+	// the current one for the one release it takes to re-vendor. Removed at 2.0.
+	static constexpr const char *SPEC_VERSION_SUPERSEDES = "6.6";
 
 	// ========================================================================
 	// Block type names
@@ -434,6 +490,41 @@ struct DuckBlockVocabulary {
 	// rather than figure-specific: Pandoc's Table also carries a Caption, and can
 	// adopt this later without another vocabulary change.
 	static constexpr const char *TYPE_CAPTION = "caption";
+
+	// ========================================================================
+	// Implicit parents (spec: "Fragments are legal input")
+	//
+	// A fragment -- the items of one list, the inline run of one paragraph --
+	// is legal input everywhere. When an element that REQUIRES an ancestor has
+	// none, this is the wrapper it gets, declared once so duck_blocks_repair,
+	// the exporter and a sibling's vendored copy agree. Empty string = none.
+	// Constexpr and std-free so the header stays <cstdint>-only.
+	// ========================================================================
+	// Single-return recursion, not a loop: the extension compiles as C++11, where a
+	// constexpr body must be one return statement. (The standalone header probe
+	// compiles with a newer standard and cannot catch a C++14-only body.)
+	static constexpr bool SameName(const char *a, const char *b) {
+		return *a == *b && (*a == '\0' || SameName(a + 1, b + 1));
+	}
+
+	static constexpr const char *ImplicitParentOf(const char *element_type, const char *kind) {
+		return SameName(kind, KIND_INLINE)                                            ? TYPE_PLAIN
+		       : SameName(kind, KIND_BLOCK) && SameName(element_type, TYPE_LIST_ITEM) ? TYPE_LIST
+		       : SameName(kind, KIND_BLOCK) && SameName(element_type, TYPE_CAPTION)   ? TYPE_FIGURE
+		                                                                              : "";
+	}
+
+	// Does an ancestor of block type `ancestor_type` satisfy this element's
+	// requirement? Only meaningful when ImplicitParentOf() is non-empty. An inline
+	// needs any non-inline (block or value) above it, which callers check by kind.
+	static constexpr bool RequiresAncestor(const char *element_type, const char *kind, const char *ancestor_type) {
+		return SameName(kind, KIND_INLINE) ? true
+		       : SameName(element_type, TYPE_LIST_ITEM)
+		           ? (SameName(ancestor_type, TYPE_LIST) || SameName(ancestor_type, TYPE_DEFLIST))
+		       : SameName(element_type, TYPE_CAPTION)
+		           ? (SameName(ancestor_type, TYPE_FIGURE) || SameName(ancestor_type, TYPE_TABLE))
+		           : false;
+	}
 	// A structurally-valid element whose type is not in the standard vocabulary.
 	// Distinct from TYPE_RAW, which is literal content in a *named* format; this is a
 	// structured element we cannot name. Format-neutral on purpose: any reader


### PR DESCRIPTION
Re-vendors `duck_block_vocabulary.hpp` at duck_block_utils **1c5f2a6** (PR teaguesterling/duckdb_duck_block_utils#30): spec **1.2**, the renumbered internal 6.6. Same shape, no constant renamed or removed; the one addition is `SPEC_VERSION_SUPERSEDES = "6.6"`, which names the retired line so a major-equality check can distinguish this renumbering from a real break.

- Header body is byte-identical to upstream at 1c5f2a6 below webbed's provenance preamble; the "Vendored at upstream commit" line is the only preamble change.
- `scripts/check_duck_block_vocabulary.py`: comment citing an observed "SPEC_VERSION 2.0 ... serving 1.2" now says both were on the retired internal line, so the current 1.2 is not read as older than 2.0. No logic change; the checker has no version-threshold logic.
- `make check-vocabulary`: in sync, OK.

Opened by the duck_block_utils session at Teague's instruction that the whole fleet moves to 1.2; webbed had no session online. webbed's own CI is the verification that matters here; nothing in the extension's code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zwajrDwGovHyurxP53ouh
