### PR TITLE
fix(sax): reject malformed XML and skip invalid files atomically

### DIFF
--- a/src/include/xml_reader_functions.hpp
+++ b/src/include/xml_reader_functions.hpp
@@ -193,7 +193,8 @@ struct XMLReadLocalState : public LocalTableFunctionState {
 	xmlParserCtxtPtr sax_parser_ctx = nullptr;             // Push parser context (persists across scan calls)
 	std::unique_ptr<FileHandle> sax_file_handle;           // File handle (persists across scan calls)
 	xmlSAXHandler sax_handler;                             // SAX handler (must outlive parser context)
-	std::vector<SAXRecordAccumulator> sax_pending_records; // Records completed during current chunk
+	std::vector<SAXRecordAccumulator> sax_pending_records; // Completed records (emitted only after a successful parse when ignore_errors)
+	bool sax_parse_complete = false;                       // Push parser reached EOF without error
 
 	~XMLReadLocalState() {
 		if (sax_parser_ctx) {
@@ -216,6 +217,7 @@ struct XMLReadLocalState : public LocalTableFunctionState {
 		sax_ctx.reset();
 		sax_file_handle.reset();
 		sax_pending_records.clear();
+		sax_parse_complete = false;
 		use_sax = false;
 		file_loaded = false;
 	}

--- a/src/xml_reader_functions.cpp
+++ b/src/xml_reader_functions.cpp
@@ -952,6 +952,7 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 
 					lstate.sax_file_handle = std::move(file_handle);
 					lstate.sax_pending_records.clear();
+					lstate.sax_parse_complete = false;
 					lstate.file_loaded = true;
 				} else {
 					// DOM mode: read file content and build DOM
@@ -1009,62 +1010,55 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 				// SAX streaming: feed chunks until we have enough records or EOF
 				constexpr idx_t SAX_CHUNK_SIZE = 65536;
 				char sax_buffer[SAX_CHUNK_SIZE];
-				bool file_exhausted = false;
 
-				while (output_idx < STANDARD_VECTOR_SIZE) {
-					// First, emit any pending completed records
+				auto emit_pending_sax_rows = [&]() {
 					while (!lstate.sax_pending_records.empty() && output_idx < STANDARD_VECTOR_SIZE) {
 						auto &record = lstate.sax_pending_records.front();
-
 						auto row = SAXStreamReader::AccumulatorToRow(
 						    record, bind_data.column_names, bind_data.column_types, schema_options,
 						    bind_data.column_datetime_formats, bind_data.inferred_schema);
-
 						EmitRow(output, output_idx, row, bind_data.include_filename, filename);
-
 						output_idx++;
 						lstate.sax_pending_records.erase(lstate.sax_pending_records.begin());
 					}
+				};
 
-					// If we've filled the output, stop
-					if (output_idx >= STANDARD_VECTOR_SIZE) {
-						break;
-					}
+				if (!lstate.sax_parse_complete) {
+					while (true) {
+						// Fail-closed (ignore_errors=false): emit as records complete. A later parse
+						// error aborts the query, so prefix rows never become a result.
+						// ignore_errors: withhold until the whole file is well-formed so a truncated
+						// or trailing-garbage file matches DOM (skip the file, no prefix rows).
+						if (!bind_data.ignore_errors) {
+							emit_pending_sax_rows();
+							if (output_idx >= STANDARD_VECTOR_SIZE) {
+								break;
+							}
+						}
 
-					// Feed another chunk to the parser
-					auto bytes_read = lstate.sax_file_handle->Read(sax_buffer, SAX_CHUNK_SIZE);
-					if (bytes_read == 0) {
-						// EOF — finalize parser
-						int final_result = xmlParseChunk(lstate.sax_parser_ctx, nullptr, 0, 1);
-						if (final_result != 0) {
+						auto bytes_read = lstate.sax_file_handle->Read(sax_buffer, SAX_CHUNK_SIZE);
+						if (bytes_read == 0) {
+							int final_result = xmlParseChunk(lstate.sax_parser_ctx, nullptr, 0, 1);
+							if (final_result != 0) {
+								throw IOException("SAX parsing error in file '%s'", filename);
+							}
+							lstate.sax_parse_complete = true;
+							break;
+						}
+
+						int parse_result =
+						    xmlParseChunk(lstate.sax_parser_ctx, sax_buffer, static_cast<int>(bytes_read), 0);
+						if (parse_result != 0) {
 							throw IOException("SAX parsing error in file '%s'", filename);
 						}
-						file_exhausted = true;
-						break;
-					}
-
-					int parse_result =
-					    xmlParseChunk(lstate.sax_parser_ctx, sax_buffer, static_cast<int>(bytes_read), 0);
-					if (parse_result != 0) {
-						throw IOException("SAX parsing error in file '%s'", filename);
 					}
 				}
 
-				// Emit any remaining pending records after EOF
-				while (!lstate.sax_pending_records.empty() && output_idx < STANDARD_VECTOR_SIZE) {
-					auto &record = lstate.sax_pending_records.front();
-					auto row = SAXStreamReader::AccumulatorToRow(record, bind_data.column_names, bind_data.column_types,
-					                                             schema_options, bind_data.column_datetime_formats,
-					                                             bind_data.inferred_schema);
-
-					EmitRow(output, output_idx, row, bind_data.include_filename, filename);
-					output_idx++;
-					lstate.sax_pending_records.erase(lstate.sax_pending_records.begin());
-				}
-
-				// Check if file is done and all records emitted
-				if (file_exhausted && lstate.sax_pending_records.empty()) {
-					file_done = true;
+				if (lstate.sax_parse_complete) {
+					emit_pending_sax_rows();
+					if (lstate.sax_pending_records.empty()) {
+						file_done = true;
+					}
 				}
 			} else {
 				// DOM extraction: extract records one at a time

--- a/src/xml_reader_functions.cpp
+++ b/src/xml_reader_functions.cpp
@@ -945,8 +945,10 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 					if (!lstate.sax_parser_ctx) {
 						throw IOException("Could not create SAX push parser for '%s'", filename);
 					}
+					// Match DOM: no XML_PARSE_RECOVER. Malformed XML must error (or be skipped
+					// via ignore_errors), not silently recover into partial/corrupt rows.
 					xmlCtxtUseOptions(lstate.sax_parser_ctx,
-					                  XML_PARSE_RECOVER | XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_NONET);
+					                  XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_NONET);
 
 					lstate.sax_file_handle = std::move(file_handle);
 					lstate.sax_pending_records.clear();
@@ -1033,14 +1035,17 @@ void XMLReaderFunctions::ReadDocumentFunction(ClientContext &context, TableFunct
 					auto bytes_read = lstate.sax_file_handle->Read(sax_buffer, SAX_CHUNK_SIZE);
 					if (bytes_read == 0) {
 						// EOF — finalize parser
-						xmlParseChunk(lstate.sax_parser_ctx, nullptr, 0, 1);
+						int final_result = xmlParseChunk(lstate.sax_parser_ctx, nullptr, 0, 1);
+						if (final_result != 0) {
+							throw IOException("SAX parsing error in file '%s'", filename);
+						}
 						file_exhausted = true;
 						break;
 					}
 
 					int parse_result =
 					    xmlParseChunk(lstate.sax_parser_ctx, sax_buffer, static_cast<int>(bytes_read), 0);
-					if (parse_result != 0 && !bind_data.ignore_errors) {
+					if (parse_result != 0) {
 						throw IOException("SAX parsing error in file '%s'", filename);
 					}
 				}

--- a/src/xml_sax_reader.cpp
+++ b/src/xml_sax_reader.cpp
@@ -432,8 +432,9 @@ std::vector<SAXRecordAccumulator> SAXStreamReader::ReadRecords(FileSystem &fs, c
 		throw IOException("Could not create SAX push parser context for '%s'", filename);
 	}
 
-	// Configure parser options (thread-safe, no global state modification)
-	xmlCtxtUseOptions(parser_ctx, XML_PARSE_RECOVER | XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_NONET);
+	// Match DOM: no XML_PARSE_RECOVER. Malformed XML must error (or be skipped
+	// via ignore_errors by the caller), not silently recover into partial rows.
+	xmlCtxtUseOptions(parser_ctx, XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_NONET);
 
 	char buffer[SAX_CHUNK_SIZE];
 
@@ -444,14 +445,18 @@ std::vector<SAXRecordAccumulator> SAXStreamReader::ReadRecords(FileSystem &fs, c
 		}
 
 		int result = xmlParseChunk(parser_ctx, buffer, static_cast<int>(bytes_read), 0);
-		if (result != 0 && !options.ignore_errors) {
+		if (result != 0) {
 			xmlFreeParserCtxt(parser_ctx);
 			throw IOException("SAX parsing error in file '%s'", filename);
 		}
 	}
 
 	// Finalize parsing
-	xmlParseChunk(parser_ctx, nullptr, 0, 1 /* terminate */);
+	int final_result = xmlParseChunk(parser_ctx, nullptr, 0, 1 /* terminate */);
+	if (final_result != 0) {
+		xmlFreeParserCtxt(parser_ctx);
+		throw IOException("SAX parsing error in file '%s'", filename);
+	}
 	xmlFreeParserCtxt(parser_ctx);
 
 	return results;

--- a/test/invalid/trailing_garbage.xml
+++ b/test/invalid/trailing_garbage.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<root>
+  <item>
+    <id>1</id>
+    <name>Alice</name>
+  </item>
+  <item>
+    <id>2</id>
+    <name>Bob</name>
+  </item>
+</root>
+THIS IS NOT XML

--- a/test/invalid/truncated_records.xml
+++ b/test/invalid/truncated_records.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<root>
+  <item>
+    <id>1</id>
+    <name>Alice</name>
+  </item>
+  <item>
+    <id>2</id>
+    <name>Bob</name>
+  </item>
+  <item>
+    <id>3</id>
+    <name>Carol

--- a/test/sql/xml_table_functions.test
+++ b/test/sql/xml_table_functions.test
@@ -28,6 +28,36 @@ SELECT count(*) FROM read_xml_objects('test/invalid/invalid.xml', ignore_errors 
 ----
 0
 
+# Test malformed XML fails in streaming mode (strict parser, no recover without ignore_errors)
+statement error
+SELECT * FROM read_xml('test/invalid/invalid.xml', streaming := true, maximum_file_size := 1);
+----
+SAX parsing error
+
+# malformed XML should be skipped when ignore_errors := true in streaming mode
+query I
+SELECT count(*) FROM read_xml('test/invalid/invalid.xml', streaming := true, maximum_file_size := 1, ignore_errors := true);
+----
+0
+
+# Nested STRUCT parity: DOM and SAX must extract the same nested fields
+# (person.address.city / zip). Forces SAX via maximum_file_size := 1.
+query IIII
+SELECT id, person.name AS name, person.address.city AS city, person.address.zip AS zip
+FROM read_xml('test/xml/sax_nested_struct_parity.xml', record_element := 'item')
+ORDER BY id;
+----
+1	Alice	NYC	10001
+2	Bob	SF	94105
+
+query IIII
+SELECT id, person.name AS name, person.address.city AS city, person.address.zip AS zip
+FROM read_xml('test/xml/sax_nested_struct_parity.xml', record_element := 'item', maximum_file_size := 1)
+ORDER BY id;
+----
+1	Alice	NYC	10001
+2	Bob	SF	94105
+
 # Test read_xml_objects function for raw content access
 query II
 SELECT filename, length(xml::VARCHAR) > 0 as has_content FROM read_xml_objects('test/xml/simple.xml', filename=true);

--- a/test/sql/xml_table_functions.test
+++ b/test/sql/xml_table_functions.test
@@ -40,6 +40,45 @@ SELECT count(*) FROM read_xml('test/invalid/invalid.xml', streaming := true, max
 ----
 0
 
+# Truncated file with completed prefix records: DOM ignore_errors skips the whole file
+query I
+SELECT count(*) FROM read_xml('test/invalid/truncated_records.xml', ignore_errors := true);
+----
+0
+
+# SAX ignore_errors must match DOM (no prefix rows from records completed before the cutoff)
+statement error
+SELECT * FROM read_xml('test/invalid/truncated_records.xml', streaming := true, maximum_file_size := 1);
+----
+SAX parsing error
+
+query I
+SELECT count(*) FROM read_xml('test/invalid/truncated_records.xml', streaming := true, maximum_file_size := 1, ignore_errors := true);
+----
+0
+
+# Trailing garbage after a well-formed prefix: same whole-file skip
+query I
+SELECT count(*) FROM read_xml('test/invalid/trailing_garbage.xml', ignore_errors := true);
+----
+0
+
+statement error
+SELECT * FROM read_xml('test/invalid/trailing_garbage.xml', streaming := true, maximum_file_size := 1);
+----
+SAX parsing error
+
+query I
+SELECT count(*) FROM read_xml('test/invalid/trailing_garbage.xml', streaming := true, maximum_file_size := 1, ignore_errors := true);
+----
+0
+
+# Mixed glob: valid file kept, truncated file skipped (SAX)
+query I
+SELECT count(*) FROM read_xml(['test/xml/sax_nested_struct_parity.xml', 'test/invalid/truncated_records.xml'], record_element := 'item', streaming := true, maximum_file_size := 1, ignore_errors := true);
+----
+2
+
 # Nested STRUCT parity: DOM and SAX must extract the same nested fields
 # (person.address.city / zip). Forces SAX via maximum_file_size := 1.
 query IIII

--- a/test/xml/sax_nested_struct_parity.xml
+++ b/test/xml/sax_nested_struct_parity.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <item>
+    <id>1</id>
+    <person>
+      <name>Alice</name>
+      <address>
+        <city>NYC</city>
+        <zip>10001</zip>
+      </address>
+    </person>
+  </item>
+  <item>
+    <id>2</id>
+    <person>
+      <name>Bob</name>
+      <address>
+        <city>SF</city>
+        <zip>94105</zip>
+      </address>
+    </person>
+  </item>
+</root>


### PR DESCRIPTION
The SAX path now fails closed on malformed XML instead of recovering into partial data, matching the DOM path. With `ignore_errors=true`, an invalid file contributes no prefix rows.

The patch adds regressions for trailing garbage, truncated records, SAX/DOM parity, and nested attributes.

Validation: `xml_table_functions` (33 assertions) and `sax_nested_child_attr_parity` (9 assertions).
